### PR TITLE
fix: use heap limit pressure in health checks to avoid false unhealthy state

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,6 +1,8 @@
+import v8 from 'node:v8';
 import { NextResponse } from 'next/server';
 import { NextRequest } from 'next/server';
 import { logger } from '@/lib/logger';
+import { calculateHeapUsagePercent } from '@/lib/health-memory';
 
 // Health check thresholds
 const MEMORY_WARNING_THRESHOLD = 0.85; // 85% heap usage
@@ -14,6 +16,7 @@ interface HealthStatus {
   memory?: {
     heapUsed: number;
     heapTotal: number;
+    heapSizeLimit: number;
     rss: number;
     external: number;
     heapUsagePercent: number;
@@ -43,7 +46,8 @@ export async function GET(request: NextRequest) {
   try {
     const timestamp = new Date().toISOString();
     const memUsage = process.memoryUsage();
-    const heapUsagePercent = (memUsage.heapUsed / memUsage.heapTotal) * 100;
+    const heapSizeLimit = process.constrainedMemory() || v8.getHeapStatistics().heap_size_limit;
+    const heapUsagePercent = calculateHeapUsagePercent(memUsage.heapUsed, memUsage.heapTotal, heapSizeLimit);
 
     // Determine health status based on memory usage
     let status: 'healthy' | 'degraded' | 'unhealthy' = 'healthy';
@@ -75,6 +79,7 @@ export async function GET(request: NextRequest) {
       response.memory = {
         heapUsed: memUsage.heapUsed,
         heapTotal: memUsage.heapTotal,
+        heapSizeLimit,
         rss: memUsage.rss,
         external: memUsage.external,
         heapUsagePercent: Number(heapUsagePercent.toFixed(2)),
@@ -117,7 +122,8 @@ export async function GET(request: NextRequest) {
 export async function HEAD() {
   try {
     const memUsage = process.memoryUsage();
-    const heapUsagePercent = (memUsage.heapUsed / memUsage.heapTotal) * 100;
+    const heapSizeLimit = process.constrainedMemory() || v8.getHeapStatistics().heap_size_limit;
+    const heapUsagePercent = calculateHeapUsagePercent(memUsage.heapUsed, memUsage.heapTotal, heapSizeLimit);
 
     if (heapUsagePercent >= MEMORY_CRITICAL_THRESHOLD * 100) {
       return new Response(null, { status: 503 });

--- a/lib/__tests__/health-memory.test.ts
+++ b/lib/__tests__/health-memory.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { calculateHeapUsagePercent } from '@/lib/health-memory';
+
+describe('calculateHeapUsagePercent', () => {
+  it('uses heap size limit when available', () => {
+    const percent = calculateHeapUsagePercent(45, 50, 200);
+    expect(percent).toBeCloseTo(22.5, 5);
+  });
+
+  it('falls back to heap total when heap size limit is unavailable', () => {
+    const percent = calculateHeapUsagePercent(45, 50, 0);
+    expect(percent).toBeCloseTo(90, 5);
+  });
+
+  it('returns 0 when denominator is invalid', () => {
+    expect(calculateHeapUsagePercent(45, 0, 0)).toBe(0);
+  });
+});

--- a/lib/health-memory.ts
+++ b/lib/health-memory.ts
@@ -1,0 +1,12 @@
+export function calculateHeapUsagePercent(
+  heapUsed: number,
+  heapTotal: number,
+  heapSizeLimit: number,
+): number {
+  const denominator = heapSizeLimit > 0 ? heapSizeLimit : heapTotal;
+  if (denominator <= 0) {
+    return 0;
+  }
+
+  return (heapUsed / denominator) * 100;
+}


### PR DESCRIPTION
## Bug
Fixes https://github.com/bulwarkmail/webmail/issues/53 — health checks were using `heapUsed / heapTotal`, which can spike to >95% even when process memory pressure is normal, causing false unhealthy responses.

## Fix
- Switched memory pressure calculation to use heap size limit (`process.constrainedMemory()` or V8 `heap_size_limit`) when available.
- Kept a safe fallback to `heapTotal` if no limit is available.
- Wired the same calculation into both GET and HEAD health checks.
- Included `heapSizeLimit` in detailed health output for better diagnostics.
- Added focused unit tests for the memory-pressure calculation helper.

## Testing
- `npx vitest run lib/__tests__/health-memory.test.ts`
- `npm run typecheck`

Happy to address any feedback.

Greetings, saschabuehrle
