### PR TITLE
Update elliptic dependency from git to version 6.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9854,7 +9854,7 @@
         "asn1js": "^3.0.5",
         "core-js": "^3.35.1",
         "des.js": "^1.1.0",
-        "elliptic": "git+https://github.com/mahrud/elliptic.git",
+        "elliptic": "^6.6.1",
         "pvtsutils": "^1.3.5",
         "tslib": "^2.6.2",
         "webcrypto-core": "^1.7.8"


### PR DESCRIPTION
Kept getting  TypeError: Invalid comparator: with the git+URL.

## Summary
Simply use a version number instead of git+URL for dependency version resolution.

## Changes

One change to one line. Remove git+URL and add ^6.6.1

- 

## Related Issues

Closes #89 


## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ x ] Chore / dependency update / CI change

## Checklist

- [ x ] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [ x ] My code follows the project's code style and conventions
- [ ] I have run `npm run typecheck && npm run lint` and there are no errors
- [ x ] The build passes (`npm run build`)
- [ x ] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

N/A

## Notes for Reviewers


