### PR TITLE
feat: configurable OAuth scopes and cookie security via env vars

### DIFF
--- a/lib/oauth/cookie-config.ts
+++ b/lib/oauth/cookie-config.ts
@@ -1,9 +1,12 @@
 const COOKIE_SAME_SITE = (process.env.COOKIE_SAME_SITE || 'lax') as 'lax' | 'none' | 'strict';
+const COOKIE_SECURE = process.env.COOKIE_SECURE !== undefined
+  ? process.env.COOKIE_SECURE === 'true'
+  : (COOKIE_SAME_SITE === 'none' || process.env.NODE_ENV === 'production');
 
 export function getCookieOptions() {
   return {
     httpOnly: true,
-    secure: COOKIE_SAME_SITE === 'none' || process.env.NODE_ENV === 'production',
+    secure: COOKIE_SECURE,
     sameSite: COOKIE_SAME_SITE,
     path: '/',
     maxAge: 30 * 24 * 60 * 60,

--- a/lib/oauth/tokens.ts
+++ b/lib/oauth/tokens.ts
@@ -1,4 +1,6 @@
-export const OAUTH_SCOPES = 'openid email profile';
+const DEFAULT_SCOPES = 'openid email profile';
+const EXTRA_SCOPES = process.env.OAUTH_EXTRA_SCOPES || '';
+export const OAUTH_SCOPES = process.env.OAUTH_SCOPES || (EXTRA_SCOPES ? `${DEFAULT_SCOPES} ${EXTRA_SCOPES}`.trim() : DEFAULT_SCOPES);
 export const REFRESH_TOKEN_COOKIE = 'jmap_rt';
 
 /** Get the cookie name for a given account slot (0-4). Slot 0 uses the legacy name. */


### PR DESCRIPTION
## Summary

Add three environment variables for deployments with external identity providers (Keycloak, Authentik, Ory Hydra, etc.). Without these, deploying Bulwark with an external OIDC provider that requires `offline_access` for refresh tokens is impossible — sessions die on every page refresh because no refresh token is issued.

All three are backwards-compatible: unset = identical to current behavior.

## Changes

- OAUTH_EXTRA_SCOPES: append additional scopes to the default "openid email profile" (e.g. "offline_access" for refresh tokens)
- OAUTH_SCOPES: full override of the requested OAuth scopes
- COOKIE_SECURE: override the Secure flag on auth cookies (useful for reverse proxy setups where the internal hop is HTTP)

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Notes for Reviewers

I am running this patch in production with Ory Hydra & Ory Kratos.
