### PR TITLE
feat: add auto locale switch on first visit based on browser language

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -25,6 +25,10 @@ JMAP_SERVER_URL=/api/dev-jmap
 
 APP_NAME=Bulwark Webmail (Dev)
 
+# Auto-switch locale to browser language on first visit when no saved locale exists.
+# Default is disabled; set to "true" to enable.
+# NEXT_PUBLIC_AUTO_SWITCH_LOCALE_ON_FIRST_VISIT=true
+
 # =============================================================================
 # Session & Settings Sync (optional for dev)
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@
 # App name displayed in the UI
 APP_NAME=Bulwark Webmail
 
+# Auto-switch locale to browser language on first visit when no saved locale exists.
+# Default is disabled; set to "true" to enable.
+# NEXT_PUBLIC_AUTO_SWITCH_LOCALE_ON_FIRST_VISIT=true
+
 # URL of your JMAP-compatible mail server (required unless ALLOW_CUSTOM_JMAP_ENDPOINT is set)
 JMAP_SERVER_URL=https://your-jmap-server.com
 

--- a/components/providers/intl-provider.tsx
+++ b/components/providers/intl-provider.tsx
@@ -32,6 +32,43 @@ const ALL_MESSAGES = {
   zh: zhMessages,
 };
 
+type SupportedLocale = keyof typeof ALL_MESSAGES;
+
+const AUTO_SWITCH_LOCALE_ON_FIRST_VISIT =
+  process.env.NEXT_PUBLIC_AUTO_SWITCH_LOCALE_ON_FIRST_VISIT === 'true';
+
+function normalizeLocale(locale: string | undefined | null): SupportedLocale | null {
+  if (!locale) return null;
+
+  const normalized = locale.trim().toLowerCase().replace(/_/g, '-');
+  if (normalized in ALL_MESSAGES) {
+    return normalized as SupportedLocale;
+  }
+
+  const primary = normalized.split('-')[0];
+  if (primary in ALL_MESSAGES) {
+    return primary as SupportedLocale;
+  }
+
+  return null;
+}
+
+function detectBrowserLocale(): SupportedLocale {
+  if (typeof navigator === 'undefined') return 'en';
+
+  const preferred = [
+    ...(navigator.languages ?? []),
+    navigator.language,
+  ].filter(Boolean);
+
+  for (const locale of preferred) {
+    const match = normalizeLocale(locale);
+    if (match) return match;
+  }
+
+  return 'en';
+}
+
 interface IntlProviderProps {
   locale: string;
   messages: Record<string, unknown>;
@@ -58,8 +95,23 @@ export function IntlProvider({ locale: initialLocale, children }: IntlProviderPr
 
   // Sync initial locale with store on first mount only
   useEffect(() => {
+    try {
+      const persisted = localStorage.getItem('locale-storage');
+
+      if (!persisted && AUTO_SWITCH_LOCALE_ON_FIRST_VISIT) {
+        const detected = detectBrowserLocale();
+        setLocale(detected);
+        setActiveLocale(detected);
+        return;
+      }
+    } catch {
+      // Ignore storage errors and fall back to server locale
+    }
+
     if (!currentLocale) {
-      setLocale(initialLocale);
+      const fallback = normalizeLocale(initialLocale) ?? 'en';
+      setLocale(fallback);
+      setActiveLocale(fallback);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
## Summary

This PR adds a feature to automatically switch the site language to the user's browser language on their first visit. The behavior is controlled by the `NEXT_PUBLIC_AUTO_SWITCH_LOCALE_ON_FIRST_VISIT` environment variable and is disabled by default.

## Changes

- Add automatic locale detection on first visit using the browser language
- Only trigger the auto-switch on the user's first visit
- Add `NEXT_PUBLIC_AUTO_SWITCH_LOCALE_ON_FIRST_VISIT` environment variable to control the feature
- Default behavior keeps the feature disabled unless explicitly enabled
- Ensure existing locale preference is not overridden after the first visit

## Related Issues

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

N/A

## Notes for Reviewers

- The feature is guarded by the `NEXT_PUBLIC_AUTO_SWITCH_LOCALE_ON_FIRST_VISIT` environment variable.
- Default value is **disabled**, so there is no behavior change unless the variable is enabled.
- The auto-switch only happens on the **first visit** to avoid overriding user-selected language preferences.