### PR TITLE
feat: configurable localePrefix via NEXT_PUBLIC_LOCALE_PREFIX

### DIFF
--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -1,9 +1,21 @@
 import { defineRouting } from 'next-intl/routing';
 
+// Locale prefix mode can be configured via NEXT_PUBLIC_LOCALE_PREFIX.
+// - "never"    (default): /settings — locale from cookie/Accept-Language
+// - "always":             /en/settings — locale always in the URL
+// - "as-needed":          /settings for default locale, /fr/settings otherwise
+// When proxying Bulwark under a sub-path (NEXT_PUBLIC_BASE_PATH), "always" is
+// recommended to avoid next-intl rewrite loops caused by locale detection
+// conflicting with the proxy's path rewriting.
+const localePrefix = (process.env.NEXT_PUBLIC_LOCALE_PREFIX ?? 'never') as
+  | 'never'
+  | 'always'
+  | 'as-needed';
+
 export const routing = defineRouting({
   locales: ['en', 'fr', 'de', 'es', 'it', 'ja', 'ko', 'lv', 'nl', 'pl', 'pt', 'ru', 'uk', 'zh'],
   defaultLocale: 'en',
-  localePrefix: 'never'
+  localePrefix
 });
 
 export const locales = routing.locales;


### PR DESCRIPTION
## Summary

Allow the next-intl `localePrefix` mode to be configured via the `NEXT_PUBLIC_LOCALE_PREFIX` env var at build time. Default behavior (`'never'`) is unchanged.

## Motivation

Two use cases where the hardcoded `'never'` mode is problematic:

1. **Proxied under a sub-path.** When Bulwark is reverse-proxied under a path prefix (e.g. `/webmail`), `localePrefix: 'never'` can trigger next-intl rewrite loops because locale detection conflicts with the proxy's path handling. Switching to `'always'` resolves this by making the locale explicit in URLs.

2. **Operator preference.** Some deployments prefer URL-embedded locales (`/en/settings`) over cookie-driven detection (`/settings`) for link shareability, analytics, and caching.

## Changes

- `i18n/routing.ts`: read `localePrefix` from `process.env.NEXT_PUBLIC_LOCALE_PREFIX` with `'never'` as default; accept the three standard next-intl values (`'never' | 'always' | 'as-needed'`)

## Usage

```bash
NEXT_PUBLIC_LOCALE_PREFIX=always npm run build
```

When unset, the existing behavior (`'never'`) is preserved — no breaking change for existing deployments.

## Test plan

- [ ] Reviewer: build with `NEXT_PUBLIC_LOCALE_PREFIX=never` (default) — verify URLs like `/settings` work
- [ ] Reviewer: build with `NEXT_PUBLIC_LOCALE_PREFIX=always` — verify URLs like `/en/settings` work and locale switcher generates prefixed URLs

## Notes

This pairs with #181 (configurable basePath) for deployments proxying under a sub-path.