### PR TITLE
fix: skip intl middleware for paths already containing a locale prefix

### DIFF
--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -1,9 +1,21 @@
 import { defineRouting } from 'next-intl/routing';
 
+// Locale prefix mode can be configured via NEXT_PUBLIC_LOCALE_PREFIX.
+// - "never"    (default): /settings — locale from cookie/Accept-Language
+// - "always":             /en/settings — locale always in the URL
+// - "as-needed":          /settings for default locale, /fr/settings otherwise
+// When proxying Bulwark under a sub-path (NEXT_PUBLIC_BASE_PATH), "always" is
+// recommended to avoid next-intl rewrite loops caused by locale detection
+// conflicting with the proxy's path rewriting.
+const localePrefix = (process.env.NEXT_PUBLIC_LOCALE_PREFIX ?? 'never') as
+  | 'never'
+  | 'always'
+  | 'as-needed';
+
 export const routing = defineRouting({
   locales: ['en', 'fr', 'de', 'es', 'it', 'ja', 'ko', 'lv', 'nl', 'pl', 'pt', 'ru', 'uk', 'zh'],
   defaultLocale: 'en',
-  localePrefix: 'never'
+  localePrefix
 });
 
 export const locales = routing.locales;

--- a/proxy.ts
+++ b/proxy.ts
@@ -34,8 +34,16 @@ export function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
   const isAdminRoute = pathname === '/admin' || pathname.startsWith('/admin/');
 
+  // When localePrefix is 'always', paths that already have a locale prefix
+  // (e.g. /en/settings) should not be re-processed by the intl middleware —
+  // doing so can trigger rewrite loops when combined with a proxy basePath.
+  const locales = routing.locales as readonly string[];
+  const hasLocalePrefix = locales.some(
+    (l) => pathname === `/${l}` || pathname.startsWith(`/${l}/`)
+  );
+
   let intlResponse: ReturnType<typeof intlMiddleware> | null = null;
-  if (!isAdminRoute) {
+  if (!isAdminRoute && !hasLocalePrefix) {
     try {
       intlResponse = intlMiddleware(request);
     } catch (error) {


### PR DESCRIPTION
## Summary

Skip the next-intl middleware in `proxy.ts` when the request path already starts with a locale prefix (e.g. `/en/settings`). Re-processing already-prefixed paths can trigger rewrite loops, especially when combined with a proxy `basePath`.

## Motivation

When `localePrefix` is `'always'` (or `'as-needed'` with a non-default locale), URLs take the form `/en/settings`. The intl middleware's job is to add or normalize the prefix — but if it's already there, the middleware should be a no-op.

In practice, running the middleware on already-prefixed paths causes issues when:

- The app is served under a proxy `basePath` (#181) — the middleware's view of the "current" path can conflict with the rewritten one, producing 307 rewrite loops
- `X-Forwarded-*` headers don't perfectly match what next-intl expects

The existing code already skips the middleware for `/admin` routes for a similar reason (`admin has its own layout`). This PR extends that to any path that's already locale-prefixed.

## Changes

- `proxy.ts`: add `hasLocalePrefix` check alongside the existing `isAdminRoute` check; skip intl middleware when either is true

## Test plan

- [ ] Reviewer: build with default config (`localePrefix: 'never'`) — verify no change in behavior
- [ ] Reviewer: build with `NEXT_PUBLIC_LOCALE_PREFIX=always` (#182) — verify pages load at `/en/`, `/fr/`, etc. without rewrite loops
- [ ] Reviewer: build with `NEXT_PUBLIC_LOCALE_PREFIX=always` + `NEXT_PUBLIC_BASE_PATH=/webmail` (#181) — verify `/webmail/en/settings` works

## Notes

Depends on #182 (configurable localePrefix) for the full use case, but is compatible as a standalone change since `routing.locales` is always available.