### PR TITLE
fix: RFC 5545/6047 iMIP compliance and hide ICS attachments when invitation banner is shown

### DIFF
--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -85,7 +85,7 @@ import { UnsubscribeBanner } from "./unsubscribe-banner";
 import { CalendarInvitationBanner } from "./calendar-invitation-banner";
 import { useTour } from "@/components/tour/tour-provider";
 import { SmimePassphraseDialog } from "@/components/settings/smime-passphrase-dialog";
-import { findCalendarAttachment } from "@/lib/calendar-invitation";
+import { findCalendarAttachment, isCalendarMimeType } from "@/lib/calendar-invitation";
 import { RecipientPopover } from "./recipient-popover";
 import { isFilePreviewable } from "@/lib/file-preview";
 import { SmimeStatusBanner } from "./smime-status-banner";
@@ -2084,11 +2084,15 @@ export function EmailViewer({
       }));
     }
 
+    const hasCalInvitation = calendarInvitationParsingEnabled && !!email && !!findCalendarAttachment(email);
     const jmapAttachments = (email?.attachments ?? [])
       // Hide winmail.dat when we have successfully extracted TNEF content or attachments
       .filter(att => !(tnefHtml || tnefText || tnefAttachments.length > 0) || !isTnefAttachment(att.name, att.type))
       // Hide message/rfc822 when we have unwrapped the embedded email
       .filter(att => !embeddedEmailUnwrapped || att.type !== 'message/rfc822')
+      // Hide calendar MIME parts (text/calendar, application/ics) when the invitation
+      // banner is shown — prevents raw ICS files appearing as spurious attachments.
+      .filter(att => !hasCalInvitation || !isCalendarMimeType(att.type))
       .map((attachment, index) => ({
         id: attachment.blobId || `${attachment.name || 'attachment'}-${index}`,
         name: attachment.name || null,
@@ -2119,7 +2123,7 @@ export function EmailViewer({
       }));
 
     return [...jmapAttachments, ...tnefExtracted, ...embeddedExtracted];
-  }, [email?.attachments, smimeDecryptedAttachments, tnefHtml, tnefText, tnefAttachments, embeddedEmailUnwrapped, embeddedEmailAttachments]);
+  }, [email?.attachments, smimeDecryptedAttachments, tnefHtml, tnefText, tnefAttachments, embeddedEmailUnwrapped, embeddedEmailAttachments, calendarInvitationParsingEnabled]);
 
   // Generate email source for viewing
   const generateEmailSource = (email: Email): string => {

--- a/lib/calendar-invitation.ts
+++ b/lib/calendar-invitation.ts
@@ -67,7 +67,7 @@ function parseContentType(value?: string | null): { mimeType: string; params: Re
   };
 }
 
-function isCalendarMimeType(value?: string | null): boolean {
+export function isCalendarMimeType(value?: string | null): boolean {
   const { mimeType } = parseContentType(value);
   return mimeType === 'text/calendar' || mimeType === 'application/ics' || mimeType === 'application/icalendar';
 }

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -274,6 +274,25 @@ function computeHasMore(position: number, emailCount: number, total: number, lim
   return emailCount === limit;
 }
 
+/**
+ * Fold a single iCalendar content line per RFC 5545 §3.1.
+ * Lines longer than 75 octets MUST be split with CRLF + a single linear white space character.
+ * We fold at 74 characters to leave room for the leading space on continuation lines.
+ * @see https://www.rfc-editor.org/rfc/rfc5545#section-3.1
+ */
+function foldIcsLine(line: string): string {
+  const MAX = 74;
+  if (line.length <= MAX) return line;
+  const chunks: string[] = [];
+  chunks.push(line.slice(0, MAX));
+  let pos = MAX;
+  while (pos < line.length) {
+    chunks.push(' ' + line.slice(pos, pos + MAX - 1));
+    pos += MAX - 1;
+  }
+  return chunks.join('\r\n');
+}
+
 export class JMAPClient implements IJMAPClient {
   private static readonly RATE_LIMIT_TOAST_THROTTLE_MS = 10_000;
 
@@ -2017,7 +2036,7 @@ export class JMAPClient implements IJMAPClient {
     lines.push(`ATTENDEE;PARTSTAT=${opts.status}${attCn}:mailto:${opts.attendeeEmail}`);
     lines.push('END:VEVENT');
     lines.push('END:VCALENDAR');
-    const icsContent = lines.join('\r\n') + '\r\n';
+    const icsContent = lines.map(foldIcsLine).join('\r\n') + '\r\n';
 
     debug.log('calendar', '[iMIP] Generated ICS:\n' + icsContent);
 
@@ -2039,10 +2058,16 @@ export class JMAPClient implements IJMAPClient {
       keywords: { "$seen": true, "$draft": true },
       mailboxIds: { [draftsMailbox.id]: true },
       bodyStructure: {
-        type: 'multipart/alternative',
+        // RFC 6047 §3 requires multipart/mixed when a text/calendar part is present.
+        // Using multipart/alternative causes most clients to ignore the iTIP method.
+        // @see https://www.rfc-editor.org/rfc/rfc6047#section-3
+        // @see https://devguide.calconnect.org/iMIP/iMIPBest-Practices/
+        // Note: Gmail-to-Gmail events use Google's internal scheduling API, not iMIP.
+        // This fix targets non-Gmail organizers and external CalDAV servers.
+        type: 'multipart/mixed',
         subParts: [
           { partId: 'text', type: 'text/plain' },
-          { partId: 'cal', type: 'text/calendar; method=REPLY' },
+          { partId: 'cal', type: 'text/calendar; method=REPLY; charset=UTF-8', disposition: 'inline', name: 'reply.ics' },
         ],
       },
       bodyValues: {
@@ -2195,7 +2220,7 @@ export class JMAPClient implements IJMAPClient {
 
     lines.push('END:VEVENT');
     lines.push('END:VCALENDAR');
-    const icsContent = lines.join('\r\n') + '\r\n';
+    const icsContent = lines.map(foldIcsLine).join('\r\n') + '\r\n';
 
     const subject = `Invitation: ${event.title || 'Event'}`;
     const toAddresses = attendees
@@ -2212,10 +2237,11 @@ export class JMAPClient implements IJMAPClient {
       keywords: { "$seen": true, "$draft": true },
       mailboxIds: { [draftsMailbox.id]: true },
       bodyStructure: {
-        type: 'multipart/alternative',
+        // See RFC 6047 §3: https://www.rfc-editor.org/rfc/rfc6047#section-3
+        type: 'multipart/mixed',
         subParts: [
           { partId: 'text', type: 'text/plain' },
-          { partId: 'cal', type: 'text/calendar; method=REQUEST' },
+          { partId: 'cal', type: 'text/calendar; method=REQUEST; charset=UTF-8', disposition: 'inline', name: 'invite.ics' },
         ],
       },
       bodyValues: {
@@ -2342,7 +2368,7 @@ export class JMAPClient implements IJMAPClient {
 
     lines.push('END:VEVENT');
     lines.push('END:VCALENDAR');
-    const icsContent = lines.join('\r\n') + '\r\n';
+    const icsContent = lines.map(foldIcsLine).join('\r\n') + '\r\n';
 
     const subject = `Cancelled: ${event.title || 'Event'}`;
     const toAddresses = attendees
@@ -2359,10 +2385,11 @@ export class JMAPClient implements IJMAPClient {
       keywords: { "$seen": true, "$draft": true },
       mailboxIds: { [draftsMailbox.id]: true },
       bodyStructure: {
-        type: 'multipart/alternative',
+        // See RFC 6047 §3: https://www.rfc-editor.org/rfc/rfc6047#section-3
+        type: 'multipart/mixed',
         subParts: [
           { partId: 'text', type: 'text/plain' },
-          { partId: 'cal', type: 'text/calendar; method=CANCEL' },
+          { partId: 'cal', type: 'text/calendar; method=CANCEL; charset=UTF-8', disposition: 'inline', name: 'cancel.ics' },
         ],
       },
       bodyValues: {

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -189,6 +189,7 @@ const CALENDAR_TASK_PROPERTIES = [
   'useDefaultAlerts',
   'alerts',
   'relatedTo',
+  'percentComplete',  // Task-only per RFC 8984 §5.2.4 — used in detection heuristic
 ] as const;
 
 /**
@@ -3974,9 +3975,13 @@ export class JMAPClient implements IJMAPClient {
       const isExplicitTask = typeof type === 'string' && type.toLowerCase() === 'task';
       // CalDAV-created tasks (e.g. Thunderbird) may lack @type or have @type
       // set to something other than 'Event'. Detect them by the presence of
-      // task-specific fields: progress, due, or percentComplete.
-      const hasTaskFields = ('progress' in obj && typeof obj.progress === 'string')
-        || ('due' in obj && obj.due != null)
+      // task-specific keys (due, progress, percentComplete), which RFC 8984 §5.2
+      // defines as Task-only — a VEVENT will never include them in the response.
+      // We check for key presence (even if null) because Stalwart may return null
+      // instead of the RFC defaults (e.g. progress default is "needs-action").
+      // @see https://www.rfc-editor.org/rfc/rfc8984#section-5.2
+      const hasTaskFields = ('due' in obj)
+        || ('progress' in obj)
         || ('percentComplete' in obj);
       const isCalDavTask = type !== 'Event' && hasTaskFields;
 

--- a/stores/calendar-store.ts
+++ b/stores/calendar-store.ts
@@ -288,6 +288,13 @@ export const useCalendarStore = create<CalendarStore>()(
           }
 
           set((state) => ({ events: [...state.events, mappedCreated] }));
+          if (sendSchedulingMessages && created.participants) {
+            try {
+              await client.sendImipInvitation(created);
+            } catch (e) {
+              debug.error('Failed to send invitation emails:', e);
+            }
+          }
           return mappedCreated;
         } catch (error) {
           debug.error('Failed to create event:', error);
@@ -342,6 +349,22 @@ export const useCalendarStore = create<CalendarStore>()(
               return merged;
             }),
           }));
+          if (sendSchedulingMessages) {
+            const mergedParticipants = cleanUpdates.participants ?? storeEvent?.participants;
+            if (mergedParticipants) {
+              const eventForInvitation = {
+                ...(storeEvent ?? {}),
+                ...cleanUpdates,
+                id: realId,
+                participants: mergedParticipants,
+              } as import('@/lib/jmap/types').CalendarEvent;
+              try {
+                await client.sendImipInvitation(eventForInvitation);
+              } catch (e) {
+                debug.error('Failed to send invitation emails:', e);
+              }
+            }
+          }
         } catch (error) {
           debug.error('Failed to update event:', error);
           set({ error: 'Failed to update event' });


### PR DESCRIPTION
## Summary

- Fix RFC 5545 / RFC 6047 compliance issues in outgoing iMIP calendar emails (REPLY, REQUEST, CANCEL)
- Hide raw `.ics` attachments from the email attachment list when the calendar invitation banner is already shown
- Fix calendar invitation emails not being sent to participants when creating or updating an event
- Fix CalDAV-created tasks (Thunderbird) not appearing in the task view

## Related Issues

- Closes #16 (partially — see Notes for Reviewers)
- Closes #84
- Closes #189
- Closes #192

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Key Changes

- **`lib/jmap/client.ts`** — Added `foldIcsLine()` helper that wraps iCalendar content lines at 74 characters as required by RFC 5545 §3.1. Previously, long lines (e.g. `ATTENDEE` with a full `CN` and `mailto:` URI) could exceed the 75-octet limit and cause strict parsers to silently discard the ICS. Applied to `sendImipReply`, `sendImipInvitation` and `sendImipCancellation`.

- **`lib/jmap/client.ts`** — Changed the MIME wrapper for all three iMIP methods from `multipart/alternative` to `multipart/mixed`. The [CalConnect iMIP Best Practices guide](https://devguide.calconnect.org/iMIP/iMIPBest-Practices/) recommends `multipart/mixed` for better client interoperability; a number of clients skip iTIP processing when they encounter `multipart/alternative`. Also added `charset=UTF-8`, `disposition: inline` and a descriptive filename to each outgoing calendar MIME part, as recommended by RFC 6047.

- **`lib/jmap/client.ts`** — Improved the CalDAV task detection heuristic in `getCalendarTasksFallback()`. The previous check required `due != null` and `typeof progress === 'string'`, which caused tasks without a due date or explicit status (the default in Thunderbird) to be silently skipped. RFC 8984 §5.2 defines `due`, `progress` and `percentComplete` as Task-only properties — their presence in the JMAP response (even as `null`) is sufficient to identify an object as a task. Also added `percentComplete` to `CALENDAR_TASK_PROPERTIES` so it is actually requested from the server.

- **`lib/calendar-invitation.ts`** — Exported `isCalendarMimeType` so it can be reused outside the module.

- **`components/email/email-viewer.tsx`** — Raw `.ics` / `text/calendar` MIME parts are now filtered out of the email attachment list when the calendar invitation banner is active. Previously they appeared as unnamed or `invite.ics` attachments alongside the banner, which was confusing.

- **`stores/calendar-store.ts`** — `sendImipInvitation()` is now called after a successful `createEvent` and `updateEvent` when the "send invitation" checkbox is checked. Previously, `sendImipInvitation()` was fully implemented but never called on create/update — only `sendImipCancellation()` was wired up (in `deleteEvent`). This meant participants were saved correctly on the server but invitation emails were never dispatched. The fix follows the same best-effort pattern already used by `deleteEvent`: errors are logged but do not block the calendar operation.

## Notes for Reviewers

This PR **should** improve RSVP delivery to Outlook, Thunderbird, Fastmail and standard CalDAV servers. However, for **Gmail-to-Gmail** events specifically, Google Calendar handles attendee responses through its own internal scheduling API rather than processing incoming iMIP emails — so external RSVP emails cannot update those events regardless of MIME structure. If the organizer is on Gmail and the original invitation was created inside Google Calendar, the "unanswered" status in Gmail is expected and cannot be fixed from the email side.

For the task detection fix (#84): if tasks still do not appear after this change, the next diagnostic step is to enable debug logging in Advanced Settings and check the browser console for `[DEBUG:tasks] CalendarTask/fallback scan` entries, which log the exact `@type`, `due` and `progress` values that Stalwart returns for each object. This would confirm whether Stalwart is returning the objects at all and which fields it includes.
