### PR TITLE
feat: improved Stalwart 0.16 support

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -493,7 +493,10 @@ export default function Home() {
   // Load mailboxes and emails when authenticated (only if not already loaded)
   useEffect(() => {
     if (isAuthenticated && client && mailboxes.length === 0) {
-      const loadData = async () => {
+      let retryTimer: ReturnType<typeof setTimeout> | null = null;
+      let cancelled = false;
+
+      const loadData = async (attempt = 1) => {
         try {
           // First fetch mailboxes and quota (inbox will be auto-selected in fetchMailboxes)
           await Promise.all([
@@ -504,6 +507,15 @@ export default function Home() {
           // Get the selected mailbox (should be inbox by default)
           const state = useEmailStore.getState();
           const selectedMailboxId = state.selectedMailbox;
+
+          // On first login the server may still be provisioning mailboxes.
+          // Retry a few times with back-off before giving up.
+          if (state.mailboxes.length === 0 && attempt <= 5 && !cancelled) {
+            const delay = Math.min(1000 * attempt, 5000);
+            debug.log('jmap', `[Mailbox] No mailboxes returned (attempt ${attempt}), retrying in ${delay}ms`);
+            retryTimer = setTimeout(() => loadData(attempt + 1), delay);
+            return;
+          }
 
           // Fetch emails for the selected mailbox
           if (selectedMailboxId) {
@@ -538,6 +550,12 @@ export default function Home() {
         }
       };
       loadData();
+
+      return () => {
+        cancelled = true;
+        if (retryTimer) clearTimeout(retryTimer);
+        client.closePushNotifications();
+      };
     }
 
     // Cleanup push notifications on unmount

--- a/components/settings/account-security-settings.tsx
+++ b/components/settings/account-security-settings.tsx
@@ -14,6 +14,7 @@ import { cn } from '@/lib/utils';
 function PasswordChangeSection() {
   const t = useTranslations('settings.security');
   const { changePassword, isSaving } = useAccountSecurityStore();
+  const { client } = useAuthStore();
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -35,7 +36,7 @@ function PasswordChangeSection() {
     }
 
     try {
-      await changePassword(currentPassword, newPassword);
+      await changePassword(client, currentPassword, newPassword);
       setCurrentPassword('');
       setNewPassword('');
       setConfirmPassword('');
@@ -125,6 +126,7 @@ function PasswordChangeSection() {
 function DisplayNameSection() {
   const t = useTranslations('settings.security');
   const { displayName, updateDisplayName, isSaving, isLoadingPrincipal } = useAccountSecurityStore();
+  const { client } = useAuthStore();
   const [name, setName] = useState(displayName);
   const [saved, setSaved] = useState(false);
 
@@ -134,7 +136,7 @@ function DisplayNameSection() {
 
   const handleSave = async () => {
     try {
-      await updateDisplayName(name);
+      await updateDisplayName(client, name);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
       toast.success(t('display_name.success'));
@@ -175,17 +177,18 @@ function DisplayNameSection() {
 function TotpSection() {
   const t = useTranslations('settings.security');
   const { otpEnabled, enableTotp, disableTotp, isSaving, isLoadingAuth } = useAccountSecurityStore();
+  const { client } = useAuthStore();
   const [totpUrl, setTotpUrl] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
   const handleToggle = async (enable: boolean) => {
     try {
       if (enable) {
-        const url = await enableTotp();
+        const url = await enableTotp(client);
         setTotpUrl(url);
         toast.success(t('totp.enabled'));
       } else {
-        await disableTotp();
+        await disableTotp(client);
         setTotpUrl(null);
         toast.success(t('totp.disabled'));
       }
@@ -253,10 +256,15 @@ function TotpSection() {
 function AppPasswordsSection() {
   const t = useTranslations('settings.security');
   const { appPasswords, addAppPassword, removeAppPassword, isSaving, isLoadingAuth } = useAccountSecurityStore();
+  const { client } = useAuthStore();
   const [showAdd, setShowAdd] = useState(false);
   const [newName, setNewName] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const [generatedSecret, setGeneratedSecret] = useState<string | null>(null);
+  const [copiedSecret, setCopiedSecret] = useState(false);
+
+  const isJmap = !!client?.supportsStalwartManagement();
 
   const generatePassword = useCallback(() => {
     const chars = 'abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789';
@@ -277,10 +285,15 @@ function AppPasswordsSection() {
     const password = newPassword || generatePassword();
 
     try {
-      await addAppPassword(newName.trim(), password);
+      const serverSecret = await addAppPassword(client, newName.trim(), password);
+      if (serverSecret) {
+        setGeneratedSecret(serverSecret);
+        setCopiedSecret(false);
+      } else {
+        setShowAdd(false);
+      }
       setNewName('');
       setNewPassword('');
-      setShowAdd(false);
       toast.success(t('app_passwords.added'));
     } catch (err) {
       toast.error(t('app_passwords.add_error'), err instanceof Error ? err.message : undefined);
@@ -289,7 +302,7 @@ function AppPasswordsSection() {
 
   const handleRemove = async (name: string) => {
     try {
-      await removeAppPassword(name);
+      await removeAppPassword(client, name);
       toast.success(t('app_passwords.removed'));
     } catch (err) {
       toast.error(t('app_passwords.remove_error'), err instanceof Error ? err.message : undefined);
@@ -322,7 +335,28 @@ function AppPasswordsSection() {
       </div>
       <p className="text-xs text-muted-foreground">{t('app_passwords.description')}</p>
 
-      {showAdd && (
+      {generatedSecret && (
+        <div className="p-3 bg-muted rounded-md space-y-2">
+          <p className="text-xs text-muted-foreground">{t('app_passwords.secret_instructions')}</p>
+          <div className="flex items-center gap-2">
+            <code className="text-xs bg-background px-2 py-1 rounded border border-border flex-1 truncate">
+              {generatedSecret}
+            </code>
+            <Button variant="outline" size="sm" onClick={() => {
+              navigator.clipboard.writeText(generatedSecret);
+              setCopiedSecret(true);
+              setTimeout(() => setCopiedSecret(false), 2000);
+            }}>
+              {copiedSecret ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+            </Button>
+          </div>
+          <Button variant="ghost" size="sm" onClick={() => { setGeneratedSecret(null); setShowAdd(false); }}>
+            {t('app_passwords.done')}
+          </Button>
+        </div>
+      )}
+
+      {showAdd && !generatedSecret && (
         <form onSubmit={handleAdd} className="p-3 bg-muted rounded-md space-y-2">
           <div>
             <label className="text-xs text-muted-foreground mb-1 block">{t('app_passwords.name_label')}</label>
@@ -333,30 +367,32 @@ function AppPasswordsSection() {
               required
             />
           </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">{t('app_passwords.password_label')}</label>
-            <div className="flex gap-2">
-              <div className="relative flex-1">
-                <Input
-                  type={showPassword ? 'text' : 'password'}
-                  value={newPassword}
-                  onChange={(e) => setNewPassword(e.target.value)}
-                  placeholder={t('app_passwords.password_placeholder')}
-                  className="pr-10"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                >
-                  {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                </button>
+          {!isJmap && (
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">{t('app_passwords.password_label')}</label>
+              <div className="flex gap-2">
+                <div className="relative flex-1">
+                  <Input
+                    type={showPassword ? 'text' : 'password'}
+                    value={newPassword}
+                    onChange={(e) => setNewPassword(e.target.value)}
+                    placeholder={t('app_passwords.password_placeholder')}
+                    className="pr-10"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  >
+                    {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                  </button>
+                </div>
+                <Button type="button" variant="outline" size="sm" onClick={() => setNewPassword(generatePassword())}>
+                  {t('app_passwords.generate')}
+                </Button>
               </div>
-              <Button type="button" variant="outline" size="sm" onClick={() => setNewPassword(generatePassword())}>
-                {t('app_passwords.generate')}
-              </Button>
             </div>
-          </div>
+          )}
           <div className="flex gap-2">
             <Button type="submit" size="sm" disabled={isSaving || !newName.trim()}>
               {isSaving ? <Loader2 className="w-4 h-4 mr-1 animate-spin" /> : null}
@@ -396,14 +432,15 @@ function AppPasswordsSection() {
 function EncryptionSection() {
   const t = useTranslations('settings.security');
   const { encryptionType, updateEncryption, isSaving, isLoadingCrypto } = useAccountSecurityStore();
+  const { client } = useAuthStore();
 
   const handleToggle = async (enabled: boolean) => {
     try {
       if (enabled) {
-        await updateEncryption({ type: 'pgp', algo: 'Aes256' });
+        await updateEncryption(client, { type: 'pgp', algo: 'Aes256' });
         toast.success(t('encryption.enabled'));
       } else {
-        await updateEncryption({ type: 'disabled' });
+        await updateEncryption(client, { type: 'disabled' });
         toast.success(t('encryption.disabled_success'));
       }
     } catch (err) {
@@ -493,22 +530,22 @@ function EmailClientSection() {
 export function AccountSecuritySettings() {
   const t = useTranslations('settings.security');
   const { isStalwart, isProbing, probe, fetchAll, fetchAuthInfo } = useAccountSecurityStore();
-  const { isAuthenticated, authMode } = useAuthStore();
+  const { isAuthenticated, authMode, client } = useAuthStore();
   const isOAuth = authMode === 'oauth';
 
   useEffect(() => {
-    if (isAuthenticated && isStalwart === null) {
-      probe().then((detected) => {
+    if (isAuthenticated && client && isStalwart === null) {
+      probe(client).then((detected) => {
         if (detected) {
           if (isOAuth) {
-            fetchAuthInfo();
+            fetchAuthInfo(client);
           } else {
-            fetchAll();
+            fetchAll(client);
           }
         }
       });
     }
-  }, [isAuthenticated, isStalwart, probe, fetchAll, fetchAuthInfo, isOAuth]);
+  }, [isAuthenticated, isStalwart, probe, fetchAll, fetchAuthInfo, isOAuth, client]);
 
   if (isProbing) {
     return (

--- a/lib/demo/demo-client.ts
+++ b/lib/demo/demo-client.ts
@@ -1,4 +1,4 @@
-import type { IJMAPClient } from '@/lib/jmap/client-interface';
+import type { IJMAPClient, StalwartAppPassword, StalwartAccountPassword, StalwartAccountInfo } from '@/lib/jmap/client-interface';
 import type { Email, Mailbox, StateChange, AccountStates, Thread, Identity, EmailAddress, ContactCard, AddressBook, VacationResponse, Calendar, CalendarEvent, CalendarEventFilter, CalendarTask, FileNode } from '@/lib/jmap/types';
 import type { SieveScript, SieveCapabilities } from '@/lib/jmap/sieve-types';
 import { getDemoData, type DemoData } from './demo-data';
@@ -74,6 +74,20 @@ export class DemoJMAPClient implements IJMAPClient {
   supportsCalendars(): boolean { return true; }
   supportsSieve(): boolean { return true; }
   supportsFiles(): boolean { return true; }
+  supportsStalwartManagement(): boolean { return false; }
+
+  // ── Stalwart management stubs (not available in demo) ────────
+  async stalwartGetAppPasswords(): Promise<StalwartAppPassword[]> { return []; }
+  async stalwartCreateAppPassword(): Promise<StalwartAppPassword> { throw new Error('Not available in demo'); }
+  async stalwartDestroyAppPassword(): Promise<void> { throw new Error('Not available in demo'); }
+  async stalwartGetAccountPassword(): Promise<StalwartAccountPassword> { return {}; }
+  async stalwartEnableTotp(): Promise<string> { throw new Error('Not available in demo'); }
+  async stalwartDisableTotp(): Promise<void> { throw new Error('Not available in demo'); }
+  async stalwartGetAccountInfo(): Promise<StalwartAccountInfo> { return {}; }
+  async stalwartUpdateDisplayName(): Promise<void> { throw new Error('Not available in demo'); }
+  async stalwartChangePassword(): Promise<void> { throw new Error('Not available in demo'); }
+  async stalwartGetEncryption(): Promise<string> { return 'disabled'; }
+  async stalwartUpdateEncryption(): Promise<void> { throw new Error('Not available in demo'); }
 
   // ── Push / state ──────────────────────────────────────────────
 

--- a/lib/jmap/client-interface.ts
+++ b/lib/jmap/client-interface.ts
@@ -242,4 +242,39 @@ export interface IJMAPClient {
   importRawEmail(blob: Blob, mailboxIds: Record<string, boolean>, keywords?: Record<string, boolean>): Promise<string>;
   submitEmail(emailId: string, identityId: string): Promise<void>;
   sendRawEmail(blob: Blob, identityId: string, sentMailboxId: string, draftMailboxId?: string): Promise<void>;
+
+  // ── Stalwart management (JMAP, requires urn:stalwart:jmap) ───
+  supportsStalwartManagement(): boolean;
+  stalwartGetAppPasswords(): Promise<StalwartAppPassword[]>;
+  stalwartCreateAppPassword(description: string): Promise<StalwartAppPassword>;
+  stalwartDestroyAppPassword(id: string): Promise<void>;
+  stalwartGetAccountPassword(): Promise<StalwartAccountPassword>;
+  stalwartEnableTotp(): Promise<string>;
+  stalwartDisableTotp(): Promise<void>;
+  stalwartGetAccountInfo(): Promise<StalwartAccountInfo>;
+  stalwartUpdateDisplayName(displayName: string): Promise<void>;
+  stalwartChangePassword(currentPassword: string, newPassword: string): Promise<void>;
+  stalwartGetEncryption(): Promise<string>;
+  stalwartUpdateEncryption(settings: { type: string; algo?: string; certs?: string }): Promise<void>;
+}
+
+// ── Stalwart management types ─────────────────────────────────
+
+export interface StalwartAppPassword {
+  id: string;
+  description: string;
+  secret?: string;
+  createdAt?: string;
+}
+
+export interface StalwartAccountPassword {
+  otpAuth?: { otpUrl?: string } | null;
+}
+
+export interface StalwartAccountInfo {
+  name?: string;
+  description?: string;
+  emails?: string[];
+  quota?: number;
+  roles?: string[];
 }

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -1,6 +1,6 @@
 import type { Email, Mailbox, StateChange, AccountStates, Thread, Identity, EmailAddress, ContactCard, AddressBook, VacationResponse, Calendar, CalendarEvent, CalendarEventFilter, CalendarTask, FileNode, FileNodeFilter } from "./types";
 import type { SieveScript, SieveCapabilities } from "./sieve-types";
-import type { IJMAPClient } from "./client-interface";
+import type { IJMAPClient, StalwartAppPassword, StalwartAccountPassword, StalwartAccountInfo } from "./client-interface";
 import { toWildcardQuery } from "./search-utils";
 import { debug } from "@/lib/debug";
 import { normalizeCalendarEventLike } from "@/lib/calendar-event-normalization";
@@ -2613,6 +2613,13 @@ export class JMAPClient implements IJMAPClient {
     return this.hasCapability("urn:ietf:params:jmap:sieve");
   }
 
+  supportsStalwartManagement(): boolean {
+    // urn:stalwart:jmap is advertised per-account in accountCapabilities, not at session root
+    if (this.hasCapability("urn:stalwart:jmap")) return true;
+    const account = this.accounts[this.accountId];
+    return !!account?.accountCapabilities?.["urn:stalwart:jmap"];
+  }
+
   getSieveAccountId(): string {
     const sieveAccount = this.session?.primaryAccounts?.["urn:ietf:params:jmap:sieve"];
     return sieveAccount || this.accountId;
@@ -4976,6 +4983,199 @@ export class JMAPClient implements IJMAPClient {
         const firstErr = Object.values(r.notCreated)[0];
         throw new Error(firstErr?.description || firstErr?.type || 'Failed to send raw email');
       }
+    }
+  }
+
+  // ─── Stalwart management via JMAP (urn:stalwart:jmap) ─────────
+
+  private stalwartUsing(): string[] {
+    return ["urn:ietf:params:jmap:core", "urn:stalwart:jmap"];
+  }
+
+  private stalwartAccountId(): string {
+    return this.session?.primaryAccounts?.["urn:stalwart:jmap"] || this.accountId;
+  }
+
+  private throwOnStalwartError(response: JMAPResponse): void {
+    for (const [methodName, result] of response.methodResponses ?? []) {
+      if (methodName === 'error' || methodName.endsWith('/error')) {
+        const err = result as { type?: string; description?: string };
+        throw new Error(err.description || err.type || 'JMAP error');
+      }
+    }
+  }
+
+  async stalwartGetAppPasswords(): Promise<StalwartAppPassword[]> {
+    const accountId = this.stalwartAccountId();
+    const response = await this.request([
+      ["x:AppPassword/get", { accountId }, "0"],
+    ], this.stalwartUsing());
+    this.throwOnStalwartError(response);
+    const result = response.methodResponses?.[0]?.[1] as { list?: StalwartAppPassword[] } | undefined;
+    return (result?.list ?? []).map(ap => ({
+      id: ap.id,
+      description: ap.description,
+      secret: ap.secret,
+      createdAt: ap.createdAt,
+    }));
+  }
+
+  async stalwartCreateAppPassword(description: string): Promise<StalwartAppPassword> {
+    const accountId = this.stalwartAccountId();
+    const response = await this.request([
+      ["x:AppPassword/set", {
+        accountId,
+        create: { "new": { description, permissions: { "@type": "Inherit" } } },
+      }, "0"],
+    ], this.stalwartUsing());
+    this.throwOnStalwartError(response);
+    const result = response.methodResponses?.[0]?.[1] as {
+      created?: Record<string, StalwartAppPassword>;
+      notCreated?: Record<string, { type?: string; description?: string }>;
+    } | undefined;
+    if (result?.notCreated) {
+      const firstErr = Object.values(result.notCreated)[0];
+      throw new Error(firstErr?.description || firstErr?.type || 'Failed to create app password');
+    }
+    const created = result?.created?.["new"] || (result?.created && Object.values(result.created)[0]);
+    if (!created) {
+      throw new Error('No app password returned from server');
+    }
+    return created;
+  }
+
+  async stalwartDestroyAppPassword(id: string): Promise<void> {
+    const accountId = this.stalwartAccountId();
+    const response = await this.request([
+      ["x:AppPassword/set", { accountId, destroy: [id] }, "0"],
+    ], this.stalwartUsing());
+    this.throwOnStalwartError(response);
+    const result = response.methodResponses?.[0]?.[1] as {
+      notDestroyed?: Record<string, { type?: string; description?: string }>;
+    } | undefined;
+    if (result?.notDestroyed?.[id]) {
+      const err = result.notDestroyed[id];
+      throw new Error(err.description || err.type || 'Failed to remove app password');
+    }
+  }
+
+  async stalwartGetAccountPassword(): Promise<StalwartAccountPassword> {
+    const accountId = this.stalwartAccountId();
+    const response = await this.request([
+      ["x:AccountPassword/get", { accountId, ids: ["singleton"] }, "0"],
+    ], this.stalwartUsing());
+    this.throwOnStalwartError(response);
+    const result = response.methodResponses?.[0]?.[1] as { list?: StalwartAccountPassword[] } | undefined;
+    return result?.list?.[0] ?? {};
+  }
+
+  async stalwartEnableTotp(): Promise<string> {
+    const accountId = this.stalwartAccountId();
+    const response = await this.request([
+      ["x:AccountPassword/set", {
+        accountId,
+        update: { singleton: { otpAuth: { otpUrl: "" } } },
+      }, "0"],
+    ], this.stalwartUsing());
+    this.throwOnStalwartError(response);
+    const result = response.methodResponses?.[0]?.[1] as {
+      updated?: Record<string, { otpAuth?: { otpUrl?: string } } | null>;
+      notUpdated?: Record<string, { type?: string; description?: string }>;
+    } | undefined;
+    if (result?.notUpdated?.singleton) {
+      throw new Error(result.notUpdated.singleton.description || 'Failed to enable TOTP');
+    }
+    return result?.updated?.singleton?.otpAuth?.otpUrl || '';
+  }
+
+  async stalwartDisableTotp(): Promise<void> {
+    const accountId = this.stalwartAccountId();
+    const response = await this.request([
+      ["x:AccountPassword/set", {
+        accountId,
+        update: { singleton: { otpAuth: null } },
+      }, "0"],
+    ], this.stalwartUsing());
+    this.throwOnStalwartError(response);
+    const result = response.methodResponses?.[0]?.[1] as {
+      notUpdated?: Record<string, { type?: string; description?: string }>;
+    } | undefined;
+    if (result?.notUpdated?.singleton) {
+      throw new Error(result.notUpdated.singleton.description || 'Failed to disable TOTP');
+    }
+  }
+
+  async stalwartGetAccountInfo(): Promise<StalwartAccountInfo> {
+    const accountId = this.stalwartAccountId();
+    const response = await this.request([
+      ["x:Account/get", { accountId, ids: [accountId] }, "0"],
+    ], this.stalwartUsing());
+    this.throwOnStalwartError(response);
+    const result = response.methodResponses?.[0]?.[1] as { list?: StalwartAccountInfo[] } | undefined;
+    return result?.list?.[0] ?? {};
+  }
+
+  async stalwartUpdateDisplayName(displayName: string): Promise<void> {
+    const accountId = this.stalwartAccountId();
+    const response = await this.request([
+      ["x:Account/set", {
+        accountId,
+        update: { [accountId]: { description: displayName } },
+      }, "0"],
+    ], this.stalwartUsing());
+    this.throwOnStalwartError(response);
+    const result = response.methodResponses?.[0]?.[1] as {
+      notUpdated?: Record<string, { type?: string; description?: string }>;
+    } | undefined;
+    if (result?.notUpdated?.[accountId]) {
+      const err = result.notUpdated[accountId];
+      throw new Error(err.description || err.type || 'Failed to update display name');
+    }
+  }
+
+  async stalwartChangePassword(currentPassword: string, newPassword: string): Promise<void> {
+    const accountId = this.stalwartAccountId();
+    const response = await this.request([
+      ["x:AccountPassword/set", {
+        accountId,
+        update: { singleton: { currentPassword, newPassword } },
+      }, "0"],
+    ], this.stalwartUsing());
+    this.throwOnStalwartError(response);
+    const result = response.methodResponses?.[0]?.[1] as {
+      notUpdated?: Record<string, { type?: string; description?: string }>;
+    } | undefined;
+    if (result?.notUpdated?.singleton) {
+      throw new Error(result.notUpdated.singleton.description || 'Failed to change password');
+    }
+  }
+
+  async stalwartGetEncryption(): Promise<string> {
+    const accountId = this.stalwartAccountId();
+    const response = await this.request([
+      ["x:AccountPassword/get", { accountId, ids: ["singleton"] }, "0"],
+    ], this.stalwartUsing());
+    this.throwOnStalwartError(response);
+    const result = response.methodResponses?.[0]?.[1] as {
+      list?: Array<{ encryption?: { type?: string } }>;
+    } | undefined;
+    return result?.list?.[0]?.encryption?.type ?? 'disabled';
+  }
+
+  async stalwartUpdateEncryption(settings: { type: string; algo?: string; certs?: string }): Promise<void> {
+    const accountId = this.stalwartAccountId();
+    const response = await this.request([
+      ["x:AccountPassword/set", {
+        accountId,
+        update: { singleton: { encryption: settings } },
+      }, "0"],
+    ], this.stalwartUsing());
+    this.throwOnStalwartError(response);
+    const result = response.methodResponses?.[0]?.[1] as {
+      notUpdated?: Record<string, { type?: string; description?: string }>;
+    } | undefined;
+    if (result?.notUpdated?.singleton) {
+      throw new Error(result.notUpdated.singleton.description || 'Failed to update encryption');
     }
   }
 }

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -1092,7 +1092,9 @@
         "removed": "App-Passwort entfernt",
         "add_error": "App-Passwort konnte nicht erstellt werden",
         "remove_error": "App-Passwort konnte nicht entfernt werden",
-        "none": "Keine App-Passwörter konfiguriert"
+        "none": "Keine App-Passwörter konfiguriert",
+        "secret_instructions": "Copy this password now — it will not be shown again.",
+        "done": "Done"
       },
       "encryption": {
         "section_title": "Verschlüsselung im Ruhezustand",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1097,7 +1097,9 @@
         "removed": "App password removed",
         "add_error": "Failed to create app password",
         "remove_error": "Failed to remove app password",
-        "none": "No app passwords configured"
+        "none": "No app passwords configured",
+        "secret_instructions": "Copy this password now — it will not be shown again.",
+        "done": "Done"
       },
       "encryption": {
         "section_title": "Encryption at Rest",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -1092,7 +1092,9 @@
         "removed": "Contraseña de aplicación eliminada",
         "add_error": "No se pudo crear la contraseña de aplicación",
         "remove_error": "No se pudo eliminar la contraseña de aplicación",
-        "none": "No hay contraseñas de aplicación configuradas"
+        "none": "No hay contraseñas de aplicación configuradas",
+        "secret_instructions": "Copy this password now — it will not be shown again.",
+        "done": "Done"
       },
       "encryption": {
         "section_title": "Cifrado en reposo",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -1092,7 +1092,9 @@
         "removed": "Mot de passe d'application supprimé",
         "add_error": "Impossible de créer le mot de passe d'application",
         "remove_error": "Impossible de supprimer le mot de passe d'application",
-        "none": "Aucun mot de passe d'application configuré"
+        "none": "Aucun mot de passe d'application configuré",
+        "secret_instructions": "Copy this password now — it will not be shown again.",
+        "done": "Done"
       },
       "encryption": {
         "section_title": "Chiffrement au repos",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -1092,7 +1092,9 @@
         "removed": "Password per l'app rimossa",
         "add_error": "Impossibile creare la password per l'app",
         "remove_error": "Impossibile rimuovere la password per l'app",
-        "none": "Nessuna password per le app configurata"
+        "none": "Nessuna password per le app configurata",
+        "secret_instructions": "Copy this password now — it will not be shown again.",
+        "done": "Done"
       },
       "encryption": {
         "section_title": "Crittografia a riposo",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -1092,7 +1092,9 @@
         "removed": "アプリパスワードが削除されました",
         "add_error": "アプリパスワードを作成できませんでした",
         "remove_error": "アプリパスワードを削除できませんでした",
-        "none": "アプリパスワードは設定されていません"
+        "none": "アプリパスワードは設定されていません",
+        "secret_instructions": "Copy this password now — it will not be shown again.",
+        "done": "Done"
       },
       "encryption": {
         "section_title": "保存時の暗号化",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -1092,7 +1092,9 @@
         "removed": "앱 비밀번호가 삭제되었어요",
         "add_error": "앱 비밀번호를 만들지 못했어요",
         "remove_error": "앱 비밀번호를 삭제하지 못했어요",
-        "none": "설정된 앱 비밀번호가 없어요"
+        "none": "설정된 앱 비밀번호가 없어요",
+        "secret_instructions": "Copy this password now — it will not be shown again.",
+        "done": "Done"
       },
       "encryption": {
         "section_title": "저장 데이터 암호화",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -1092,7 +1092,9 @@
         "removed": "Lietotnes parole izdzēsta",
         "add_error": "Neizdevās izveidot lietotnes paroli",
         "remove_error": "Neizdevās izdzēst lietotnes paroli",
-        "none": "Lietotņu paroles nav iestatītas"
+        "none": "Lietotņu paroles nav iestatītas",
+        "secret_instructions": "Copy this password now — it will not be shown again.",
+        "done": "Done"
       },
       "encryption": {
         "section_title": "Krātuves šifrēšana",

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -1092,7 +1092,9 @@
         "removed": "App-wachtwoord verwijderd",
         "add_error": "Kan app-wachtwoord niet aanmaken",
         "remove_error": "Kan app-wachtwoord niet verwijderen",
-        "none": "Geen app-wachtwoorden geconfigureerd"
+        "none": "Geen app-wachtwoorden geconfigureerd",
+        "secret_instructions": "Copy this password now — it will not be shown again.",
+        "done": "Done"
       },
       "encryption": {
         "section_title": "Versleuteling in rust",

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -1092,7 +1092,9 @@
         "removed": "Hasło aplikacji zostało usunięte",
         "add_error": "Nie udało się utworzyć hasła aplikacji",
         "remove_error": "Nie udało się usunąć hasła aplikacji",
-        "none": "Brak skonfigurowanych haseł aplikacji"
+        "none": "Brak skonfigurowanych haseł aplikacji",
+        "secret_instructions": "Copy this password now — it will not be shown again.",
+        "done": "Done"
       },
       "encryption": {
         "section_title": "Szyfrowanie danych w spoczynku",

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -1092,7 +1092,9 @@
         "removed": "Senha de aplicativo removida",
         "add_error": "Não foi possível criar a senha de aplicativo",
         "remove_error": "Não foi possível remover a senha de aplicativo",
-        "none": "Nenhuma senha de aplicativo configurada"
+        "none": "Nenhuma senha de aplicativo configurada",
+        "secret_instructions": "Copy this password now — it will not be shown again.",
+        "done": "Done"
       },
       "encryption": {
         "section_title": "Criptografia em repouso",

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -1092,7 +1092,9 @@
         "removed": "Пароль приложения удалён",
         "add_error": "Не удалось создать пароль приложения",
         "remove_error": "Не удалось удалить пароль приложения",
-        "none": "Пароли приложений не настроены"
+        "none": "Пароли приложений не настроены",
+        "secret_instructions": "Copy this password now — it will not be shown again.",
+        "done": "Done"
       },
       "encryption": {
         "section_title": "Шифрование хранилища",

--- a/locales/uk/common.json
+++ b/locales/uk/common.json
@@ -1092,7 +1092,9 @@
         "removed": "Пароль програми видалено",
         "add_error": "Не вдалося створити пароль програми",
         "remove_error": "Не вдалося видалити пароль програми",
-        "none": "Паролі програм не налаштовано"
+        "none": "Паролі програм не налаштовано",
+        "secret_instructions": "Copy this password now — it will not be shown again.",
+        "done": "Done"
       },
       "encryption": {
         "section_title": "Шифрування в спокої",

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -1092,7 +1092,9 @@
         "removed": "应用密码已删除",
         "add_error": "创建应用密码失败",
         "remove_error": "无法删除应用密码",
-        "none": "未配置应用密码"
+        "none": "未配置应用密码",
+        "secret_instructions": "Copy this password now — it will not be shown again.",
+        "done": "Done"
       },
       "encryption": {
         "section_title": "静态加密",

--- a/stores/__tests__/account-security-store.test.ts
+++ b/stores/__tests__/account-security-store.test.ts
@@ -25,6 +25,9 @@ const defaultState = {
   error: null,
 };
 
+// All tests pass null as client to exercise the legacy REST fallback path.
+const NO_CLIENT = null;
+
 describe('AccountSecurityStore', () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
@@ -41,7 +44,7 @@ describe('AccountSecurityStore', () => {
     it('sets isStalwart to true when probe succeeds', async () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, { isStalwart: true }));
 
-      const result = await useAccountSecurityStore.getState().probe();
+      const result = await useAccountSecurityStore.getState().probe(NO_CLIENT);
 
       expect(result).toBe(true);
       expect(useAccountSecurityStore.getState().isStalwart).toBe(true);
@@ -51,7 +54,7 @@ describe('AccountSecurityStore', () => {
     it('sets isStalwart to false when probe returns false', async () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, { isStalwart: false }));
 
-      const result = await useAccountSecurityStore.getState().probe();
+      const result = await useAccountSecurityStore.getState().probe(NO_CLIENT);
 
       expect(result).toBe(false);
       expect(useAccountSecurityStore.getState().isStalwart).toBe(false);
@@ -60,7 +63,7 @@ describe('AccountSecurityStore', () => {
     it('sets isStalwart to false on network error', async () => {
       fetchSpy.mockRejectedValueOnce(new TypeError('Network error'));
 
-      const result = await useAccountSecurityStore.getState().probe();
+      const result = await useAccountSecurityStore.getState().probe(NO_CLIENT);
 
       expect(result).toBe(false);
       expect(useAccountSecurityStore.getState().isStalwart).toBe(false);
@@ -74,7 +77,7 @@ describe('AccountSecurityStore', () => {
         mockFetchResponse(200, { data: { otpEnabled: true, appPasswords: ['app1', 'app2'] } })
       );
 
-      await useAccountSecurityStore.getState().fetchAuthInfo();
+      await useAccountSecurityStore.getState().fetchAuthInfo(NO_CLIENT);
 
       const state = useAccountSecurityStore.getState();
       expect(state.otpEnabled).toBe(true);
@@ -86,7 +89,7 @@ describe('AccountSecurityStore', () => {
     it('sets defaults when data fields are missing', async () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, { data: {} }));
 
-      await useAccountSecurityStore.getState().fetchAuthInfo();
+      await useAccountSecurityStore.getState().fetchAuthInfo(NO_CLIENT);
 
       const state = useAccountSecurityStore.getState();
       expect(state.otpEnabled).toBe(false);
@@ -96,7 +99,7 @@ describe('AccountSecurityStore', () => {
     it('sets error on HTTP failure', async () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(500));
 
-      await useAccountSecurityStore.getState().fetchAuthInfo();
+      await useAccountSecurityStore.getState().fetchAuthInfo(NO_CLIENT);
 
       const state = useAccountSecurityStore.getState();
       expect(state.isLoadingAuth).toBe(false);
@@ -106,7 +109,7 @@ describe('AccountSecurityStore', () => {
     it('sets error on network failure', async () => {
       fetchSpy.mockRejectedValueOnce(new Error('Connection refused'));
 
-      await useAccountSecurityStore.getState().fetchAuthInfo();
+      await useAccountSecurityStore.getState().fetchAuthInfo(NO_CLIENT);
 
       const state = useAccountSecurityStore.getState();
       expect(state.isLoadingAuth).toBe(false);
@@ -120,7 +123,7 @@ describe('AccountSecurityStore', () => {
         mockFetchResponse(200, { data: { type: 'pgp' } })
       );
 
-      await useAccountSecurityStore.getState().fetchCryptoInfo();
+      await useAccountSecurityStore.getState().fetchCryptoInfo(NO_CLIENT);
 
       const state = useAccountSecurityStore.getState();
       expect(state.encryptionType).toBe('pgp');
@@ -130,7 +133,7 @@ describe('AccountSecurityStore', () => {
     it('defaults to disabled when type is missing', async () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, { data: {} }));
 
-      await useAccountSecurityStore.getState().fetchCryptoInfo();
+      await useAccountSecurityStore.getState().fetchCryptoInfo(NO_CLIENT);
 
       expect(useAccountSecurityStore.getState().encryptionType).toBe('disabled');
     });
@@ -138,7 +141,7 @@ describe('AccountSecurityStore', () => {
     it('sets error on failure', async () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(403));
 
-      await useAccountSecurityStore.getState().fetchCryptoInfo();
+      await useAccountSecurityStore.getState().fetchCryptoInfo(NO_CLIENT);
 
       expect(useAccountSecurityStore.getState().error).toBe('HTTP 403');
     });
@@ -157,7 +160,7 @@ describe('AccountSecurityStore', () => {
         })
       );
 
-      await useAccountSecurityStore.getState().fetchPrincipal();
+      await useAccountSecurityStore.getState().fetchPrincipal(NO_CLIENT);
 
       const state = useAccountSecurityStore.getState();
       expect(state.displayName).toBe('John Doe');
@@ -174,7 +177,7 @@ describe('AccountSecurityStore', () => {
         })
       );
 
-      await useAccountSecurityStore.getState().fetchPrincipal();
+      await useAccountSecurityStore.getState().fetchPrincipal(NO_CLIENT);
 
       expect(useAccountSecurityStore.getState().emails).toEqual(['single@example.com']);
     });
@@ -184,7 +187,7 @@ describe('AccountSecurityStore', () => {
         mockFetchResponse(200, { data: { description: 'User' } })
       );
 
-      await useAccountSecurityStore.getState().fetchPrincipal();
+      await useAccountSecurityStore.getState().fetchPrincipal(NO_CLIENT);
 
       expect(useAccountSecurityStore.getState().emails).toEqual([]);
     });
@@ -192,7 +195,7 @@ describe('AccountSecurityStore', () => {
     it('sets defaults when fields are missing', async () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, { data: {} }));
 
-      await useAccountSecurityStore.getState().fetchPrincipal();
+      await useAccountSecurityStore.getState().fetchPrincipal(NO_CLIENT);
 
       const state = useAccountSecurityStore.getState();
       expect(state.displayName).toBe('');
@@ -209,7 +212,7 @@ describe('AccountSecurityStore', () => {
         .mockResolvedValueOnce(mockFetchResponse(200, { data: { type: 'smime' } }))
         .mockResolvedValueOnce(mockFetchResponse(200, { data: { description: 'Test', emails: [], quota: 0, roles: [] } }));
 
-      await useAccountSecurityStore.getState().fetchAll();
+      await useAccountSecurityStore.getState().fetchAll(NO_CLIENT);
 
       const state = useAccountSecurityStore.getState();
       expect(state.encryptionType).toBe('smime');
@@ -225,7 +228,7 @@ describe('AccountSecurityStore', () => {
         .mockResolvedValueOnce(mockFetchResponse(200, { data: { type: 'pgp' } }))
         .mockResolvedValueOnce(mockFetchResponse(200, { data: { description: 'OK', emails: [], quota: 0, roles: [] } }));
 
-      await useAccountSecurityStore.getState().fetchAll();
+      await useAccountSecurityStore.getState().fetchAll(NO_CLIENT);
 
       const state = useAccountSecurityStore.getState();
       expect(state.encryptionType).toBe('pgp');
@@ -237,7 +240,7 @@ describe('AccountSecurityStore', () => {
     it('sends POST with currentPassword and newPassword', async () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, { ok: true }));
 
-      await useAccountSecurityStore.getState().changePassword('oldpass', 'newpass123');
+      await useAccountSecurityStore.getState().changePassword(NO_CLIENT, 'oldpass', 'newpass123');
 
       expect(fetchSpy).toHaveBeenCalledWith('/api/account/stalwart/password', expect.objectContaining({
         method: 'POST',
@@ -250,7 +253,7 @@ describe('AccountSecurityStore', () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(403, { error: 'Current password is incorrect' }));
 
       await expect(
-        useAccountSecurityStore.getState().changePassword('wrong', 'newpass123')
+        useAccountSecurityStore.getState().changePassword(NO_CLIENT, 'wrong', 'newpass123')
       ).rejects.toThrow('Current password is incorrect');
 
       expect(useAccountSecurityStore.getState().isSaving).toBe(false);
@@ -262,7 +265,7 @@ describe('AccountSecurityStore', () => {
     it('sends PATCH and updates local state on success', async () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, { data: null }));
 
-      await useAccountSecurityStore.getState().updateDisplayName('New Name');
+      await useAccountSecurityStore.getState().updateDisplayName(NO_CLIENT, 'New Name');
 
       const state = useAccountSecurityStore.getState();
       expect(state.displayName).toBe('New Name');
@@ -276,7 +279,7 @@ describe('AccountSecurityStore', () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(500, { error: 'Server error' }));
 
       await expect(
-        useAccountSecurityStore.getState().updateDisplayName('Name')
+        useAccountSecurityStore.getState().updateDisplayName(NO_CLIENT, 'Name')
       ).rejects.toThrow('Server error');
 
       expect(useAccountSecurityStore.getState().isSaving).toBe(false);
@@ -288,7 +291,7 @@ describe('AccountSecurityStore', () => {
       const totpUrl = 'otpauth://totp/user@example.com?secret=ABC';
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, { data: totpUrl }));
 
-      const result = await useAccountSecurityStore.getState().enableTotp();
+      const result = await useAccountSecurityStore.getState().enableTotp(NO_CLIENT);
 
       expect(result).toBe(totpUrl);
       expect(useAccountSecurityStore.getState().otpEnabled).toBe(true);
@@ -302,7 +305,7 @@ describe('AccountSecurityStore', () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(400, { error: 'TOTP error' }));
 
       await expect(
-        useAccountSecurityStore.getState().enableTotp()
+        useAccountSecurityStore.getState().enableTotp(NO_CLIENT)
       ).rejects.toThrow('TOTP error');
 
       expect(useAccountSecurityStore.getState().otpEnabled).toBe(false);
@@ -314,7 +317,7 @@ describe('AccountSecurityStore', () => {
       useAccountSecurityStore.setState({ otpEnabled: true });
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, { data: null }));
 
-      await useAccountSecurityStore.getState().disableTotp();
+      await useAccountSecurityStore.getState().disableTotp(NO_CLIENT);
 
       expect(useAccountSecurityStore.getState().otpEnabled).toBe(false);
       expect(useAccountSecurityStore.getState().isSaving).toBe(false);
@@ -330,7 +333,7 @@ describe('AccountSecurityStore', () => {
         mockFetchResponse(200, { data: { otpEnabled: false, appPasswords: ['Thunderbird'] } })
       );
 
-      await useAccountSecurityStore.getState().addAppPassword('Thunderbird', 'secret');
+      await useAccountSecurityStore.getState().addAppPassword(NO_CLIENT, 'Thunderbird', 'secret');
 
       const state = useAccountSecurityStore.getState();
       expect(state.appPasswords).toEqual(['Thunderbird']);
@@ -344,7 +347,7 @@ describe('AccountSecurityStore', () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(500, { error: 'Server down' }));
 
       await expect(
-        useAccountSecurityStore.getState().addAppPassword('App', 'pass')
+        useAccountSecurityStore.getState().addAppPassword(NO_CLIENT, 'App', 'pass')
       ).rejects.toThrow('Server down');
     });
   });
@@ -360,7 +363,7 @@ describe('AccountSecurityStore', () => {
         mockFetchResponse(200, { data: { otpEnabled: false, appPasswords: ['iPhone'] } })
       );
 
-      await useAccountSecurityStore.getState().removeAppPassword('Thunderbird');
+      await useAccountSecurityStore.getState().removeAppPassword(NO_CLIENT, 'Thunderbird');
 
       expect(useAccountSecurityStore.getState().appPasswords).toEqual(['iPhone']);
 
@@ -373,7 +376,7 @@ describe('AccountSecurityStore', () => {
     it('sends crypto settings and updates local encryptionType', async () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, { data: null }));
 
-      await useAccountSecurityStore.getState().updateEncryption({ type: 'pgp' });
+      await useAccountSecurityStore.getState().updateEncryption(NO_CLIENT, { type: 'pgp' });
 
       expect(useAccountSecurityStore.getState().encryptionType).toBe('pgp');
       expect(useAccountSecurityStore.getState().isSaving).toBe(false);
@@ -384,7 +387,7 @@ describe('AccountSecurityStore', () => {
       fetchSpy.mockResolvedValueOnce(mockFetchResponse(500, { error: 'Encryption error' }));
 
       await expect(
-        useAccountSecurityStore.getState().updateEncryption({ type: 'pgp' })
+        useAccountSecurityStore.getState().updateEncryption(NO_CLIENT, { type: 'pgp' })
       ).rejects.toThrow('Encryption error');
 
       expect(useAccountSecurityStore.getState().encryptionType).toBe('disabled');

--- a/stores/account-security-store.ts
+++ b/stores/account-security-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { debug } from '@/lib/debug';
 import { getActiveAccountSlotHeaders } from '@/lib/auth/active-account-slot';
 import { apiFetch } from '@/lib/browser-navigation';
+import type { IJMAPClient } from '@/lib/jmap/client-interface';
 
 interface AccountSecurityState {
   // Detection
@@ -28,25 +29,174 @@ interface AccountSecurityState {
   isSaving: boolean;
   error: string | null;
 
-  // Actions
-  probe: () => Promise<boolean>;
-  fetchAuthInfo: () => Promise<void>;
-  fetchCryptoInfo: () => Promise<void>;
-  fetchPrincipal: () => Promise<void>;
-  fetchAll: () => Promise<void>;
-  changePassword: (currentPassword: string, newPassword: string) => Promise<void>;
-  updateDisplayName: (displayName: string) => Promise<void>;
-  enableTotp: () => Promise<string>;
-  disableTotp: () => Promise<void>;
-  addAppPassword: (name: string, password: string) => Promise<void>;
-  removeAppPassword: (name: string) => Promise<void>;
-  updateEncryption: (settings: { type: string; algo?: string; certs?: string }) => Promise<void>;
+  // Actions — client param enables JMAP path when non-null, falls back to REST otherwise
+  probe: (client: IJMAPClient | null) => Promise<boolean>;
+  fetchAuthInfo: (client: IJMAPClient | null) => Promise<void>;
+  fetchCryptoInfo: (client: IJMAPClient | null) => Promise<void>;
+  fetchPrincipal: (client: IJMAPClient | null) => Promise<void>;
+  fetchAll: (client: IJMAPClient | null) => Promise<void>;
+  changePassword: (client: IJMAPClient | null, currentPassword: string, newPassword: string) => Promise<void>;
+  updateDisplayName: (client: IJMAPClient | null, displayName: string) => Promise<void>;
+  enableTotp: (client: IJMAPClient | null) => Promise<string>;
+  disableTotp: (client: IJMAPClient | null) => Promise<void>;
+  addAppPassword: (client: IJMAPClient | null, name: string, password: string) => Promise<string | undefined>;
+  removeAppPassword: (client: IJMAPClient | null, name: string) => Promise<void>;
+  updateEncryption: (client: IJMAPClient | null, settings: { type: string; algo?: string; certs?: string }) => Promise<void>;
   clearState: () => void;
 }
 
 function getApiHeaders(): Record<string, string> {
   return getActiveAccountSlotHeaders();
 }
+
+/** Return the client only if it supports Stalwart JMAP management. */
+function jmap(client: IJMAPClient | null): IJMAPClient | null {
+  return client?.supportsStalwartManagement() ? client : null;
+}
+
+// ── BEGIN LEGACY REST FALLBACK ──────────────────────────────────
+// The functions below proxy through Next.js API routes to Stalwart's
+// REST API (pre-0.16). They can be removed once Stalwart <0.16
+// support is dropped.
+
+async function legacyProbe(): Promise<boolean> {
+  const response = await apiFetch('/api/account/stalwart/probe', {
+    headers: getApiHeaders(),
+  });
+  const data = await response.json();
+  return data.isStalwart === true;
+}
+
+async function legacyFetchAuthInfo(): Promise<{ otpEnabled: boolean; appPasswords: string[] }> {
+  const response = await apiFetch('/api/account/stalwart/auth', {
+    headers: getApiHeaders(),
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const data = await response.json();
+  return {
+    otpEnabled: data.data?.otpEnabled ?? false,
+    appPasswords: data.data?.appPasswords ?? [],
+  };
+}
+
+async function legacyFetchCryptoInfo(): Promise<string> {
+  const response = await apiFetch('/api/account/stalwart/crypto', {
+    headers: getApiHeaders(),
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const data = await response.json();
+  return data.data?.type ?? 'disabled';
+}
+
+async function legacyFetchPrincipal(): Promise<{ description: string; emails: string[]; quota: number; roles: string[] }> {
+  const response = await apiFetch('/api/account/stalwart/principal', {
+    headers: getApiHeaders(),
+  });
+  if (!response.ok) {
+    if (response.status === 403) {
+      return { description: '', emails: [], quota: 0, roles: [] };
+    }
+    throw new Error(`HTTP ${response.status}`);
+  }
+  const data = await response.json();
+  const principal = data.data;
+  return {
+    description: principal?.description ?? '',
+    emails: Array.isArray(principal?.emails) ? principal.emails : principal?.emails ? [principal.emails] : [],
+    quota: principal?.quota ?? 0,
+    roles: principal?.roles ?? [],
+  };
+}
+
+async function legacyChangePassword(currentPassword: string, newPassword: string): Promise<void> {
+  const response = await apiFetch('/api/account/stalwart/password', {
+    method: 'POST',
+    headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ currentPassword, newPassword }),
+  });
+  if (!response.ok) {
+    const data = await response.json();
+    throw new Error(data.error || `HTTP ${response.status}`);
+  }
+}
+
+async function legacyUpdateDisplayName(displayName: string): Promise<void> {
+  const response = await apiFetch('/api/account/stalwart/principal', {
+    method: 'PATCH',
+    headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify([
+      { action: 'set', field: 'description', value: displayName },
+    ]),
+  });
+  if (!response.ok) {
+    const data = await response.json();
+    throw new Error(data.error || `HTTP ${response.status}`);
+  }
+}
+
+async function legacyEnableTotp(): Promise<string> {
+  const response = await apiFetch('/api/account/stalwart/auth', {
+    method: 'POST',
+    headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify([{ type: 'enableOtpAuth' }]),
+  });
+  if (!response.ok) {
+    const data = await response.json();
+    throw new Error(data.error || data.details || `HTTP ${response.status}`);
+  }
+  const data = await response.json();
+  return data.data;
+}
+
+async function legacyDisableTotp(): Promise<void> {
+  const response = await apiFetch('/api/account/stalwart/auth', {
+    method: 'POST',
+    headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify([{ type: 'disableOtpAuth' }]),
+  });
+  if (!response.ok) {
+    const data = await response.json();
+    throw new Error(data.error || data.details || `HTTP ${response.status}`);
+  }
+}
+
+async function legacyAddAppPassword(name: string, password: string): Promise<void> {
+  const response = await apiFetch('/api/account/stalwart/auth', {
+    method: 'POST',
+    headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify([{ type: 'addAppPassword', name, password }]),
+  });
+  if (!response.ok) {
+    const data = await response.json();
+    throw new Error(data.error || data.details || `HTTP ${response.status}`);
+  }
+}
+
+async function legacyRemoveAppPassword(name: string): Promise<void> {
+  const response = await apiFetch('/api/account/stalwart/auth', {
+    method: 'POST',
+    headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify([{ type: 'removeAppPassword', name }]),
+  });
+  if (!response.ok) {
+    const data = await response.json();
+    throw new Error(data.error || data.details || `HTTP ${response.status}`);
+  }
+}
+
+async function legacyUpdateEncryption(settings: { type: string; algo?: string; certs?: string }): Promise<void> {
+  const response = await apiFetch('/api/account/stalwart/crypto', {
+    method: 'POST',
+    headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify(settings),
+  });
+  if (!response.ok) {
+    const data = await response.json();
+    throw new Error(data.error || data.details || `HTTP ${response.status}`);
+  }
+}
+
+// ── END LEGACY REST FALLBACK ────────────────────────────────────
 
 export const useAccountSecurityStore = create<AccountSecurityState>()((set, get) => ({
   isStalwart: null,
@@ -64,14 +214,14 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
   isSaving: false,
   error: null,
 
-  probe: async () => {
+  probe: async (client) => {
     set({ isProbing: true });
     try {
-      const response = await apiFetch('/api/account/stalwart/probe', {
-        headers: getApiHeaders(),
-      });
-      const data = await response.json();
-      const isStalwart = data.isStalwart === true;
+      if (jmap(client)) {
+        set({ isStalwart: true, isProbing: false });
+        return true;
+      }
+      const isStalwart = await legacyProbe();
       set({ isStalwart, isProbing: false });
       return isStalwart;
     } catch (error) {
@@ -81,19 +231,28 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     }
   },
 
-  fetchAuthInfo: async () => {
+  fetchAuthInfo: async (client) => {
     set({ isLoadingAuth: true, error: null });
     try {
-      const response = await apiFetch('/api/account/stalwart/auth', {
-        headers: getApiHeaders(),
-      });
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      const data = await response.json();
-      set({
-        otpEnabled: data.data?.otpEnabled ?? false,
-        appPasswords: data.data?.appPasswords ?? [],
-        isLoadingAuth: false,
-      });
+      const j = jmap(client);
+      if (j) {
+        const [appPasswords, accountPassword] = await Promise.all([
+          j.stalwartGetAppPasswords(),
+          j.stalwartGetAccountPassword(),
+        ]);
+        set({
+          otpEnabled: !!accountPassword.otpAuth?.otpUrl,
+          appPasswords: appPasswords.map(ap => ap.description),
+          isLoadingAuth: false,
+        });
+      } else {
+        const info = await legacyFetchAuthInfo();
+        set({
+          otpEnabled: info.otpEnabled,
+          appPasswords: info.appPasswords,
+          isLoadingAuth: false,
+        });
+      }
     } catch (error) {
       debug.error('Failed to fetch auth info:', error);
       set({
@@ -103,18 +262,17 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     }
   },
 
-  fetchCryptoInfo: async () => {
+  fetchCryptoInfo: async (client) => {
     set({ isLoadingCrypto: true, error: null });
     try {
-      const response = await apiFetch('/api/account/stalwart/crypto', {
-        headers: getApiHeaders(),
-      });
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      const data = await response.json();
-      set({
-        encryptionType: data.data?.type ?? 'disabled',
-        isLoadingCrypto: false,
-      });
+      const j = jmap(client);
+      if (j) {
+        const encryptionType = await j.stalwartGetEncryption();
+        set({ encryptionType, isLoadingCrypto: false });
+      } else {
+        const encryptionType = await legacyFetchCryptoInfo();
+        set({ encryptionType, isLoadingCrypto: false });
+      }
     } catch (error) {
       debug.error('Failed to fetch crypto info:', error);
       set({
@@ -124,35 +282,29 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     }
   },
 
-  fetchPrincipal: async () => {
+  fetchPrincipal: async (client) => {
     set({ isLoadingPrincipal: true, error: null });
     try {
-      const response = await apiFetch('/api/account/stalwart/principal', {
-        headers: getApiHeaders(),
-      });
-      if (!response.ok) {
-        if (response.status === 403) {
-          // User lacks permission to read principal (e.g. non-admin); treat as empty
-          set({
-            displayName: '',
-            emails: [],
-            quota: 0,
-            roles: [],
-            isLoadingPrincipal: false,
-          });
-          return;
-        }
-        throw new Error(`HTTP ${response.status}`);
+      const j = jmap(client);
+      if (j) {
+        const info = await j.stalwartGetAccountInfo();
+        set({
+          displayName: info.description ?? info.name ?? '',
+          emails: info.emails ?? [],
+          quota: info.quota ?? 0,
+          roles: info.roles ?? [],
+          isLoadingPrincipal: false,
+        });
+      } else {
+        const principal = await legacyFetchPrincipal();
+        set({
+          displayName: principal.description,
+          emails: principal.emails,
+          quota: principal.quota,
+          roles: principal.roles,
+          isLoadingPrincipal: false,
+        });
       }
-      const data = await response.json();
-      const principal = data.data;
-      set({
-        displayName: principal?.description ?? '',
-        emails: Array.isArray(principal?.emails) ? principal.emails : principal?.emails ? [principal.emails] : [],
-        quota: principal?.quota ?? 0,
-        roles: principal?.roles ?? [],
-        isLoadingPrincipal: false,
-      });
     } catch (error) {
       debug.error('Failed to fetch principal:', error);
       set({
@@ -162,25 +314,20 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     }
   },
 
-  fetchAll: async () => {
+  fetchAll: async (client) => {
     const { fetchAuthInfo, fetchCryptoInfo, fetchPrincipal } = get();
-    await Promise.allSettled([fetchAuthInfo(), fetchCryptoInfo(), fetchPrincipal()]);
+    await Promise.allSettled([fetchAuthInfo(client), fetchCryptoInfo(client), fetchPrincipal(client)]);
   },
 
-  changePassword: async (currentPassword, newPassword) => {
+  changePassword: async (client, currentPassword, newPassword) => {
     set({ isSaving: true, error: null });
     try {
-      const response = await apiFetch('/api/account/stalwart/password', {
-        method: 'POST',
-        headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
-        body: JSON.stringify({ currentPassword, newPassword }),
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || `HTTP ${response.status}`);
+      const j = jmap(client);
+      if (j) {
+        await j.stalwartChangePassword(currentPassword, newPassword);
+      } else {
+        await legacyChangePassword(currentPassword, newPassword);
       }
-
       set({ isSaving: false });
     } catch (error) {
       set({
@@ -191,22 +338,15 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     }
   },
 
-  updateDisplayName: async (displayName) => {
+  updateDisplayName: async (client, displayName) => {
     set({ isSaving: true, error: null });
     try {
-      const response = await apiFetch('/api/account/stalwart/principal', {
-        method: 'PATCH',
-        headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
-        body: JSON.stringify([
-          { action: 'set', field: 'description', value: displayName },
-        ]),
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || `HTTP ${response.status}`);
+      const j = jmap(client);
+      if (j) {
+        await j.stalwartUpdateDisplayName(displayName);
+      } else {
+        await legacyUpdateDisplayName(displayName);
       }
-
       set({ displayName, isSaving: false });
     } catch (error) {
       set({
@@ -217,23 +357,18 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     }
   },
 
-  enableTotp: async () => {
+  enableTotp: async (client) => {
     set({ isSaving: true, error: null });
     try {
-      const response = await apiFetch('/api/account/stalwart/auth', {
-        method: 'POST',
-        headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
-        body: JSON.stringify([{ type: 'enableOtpAuth' }]),
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || data.details || `HTTP ${response.status}`);
+      const j = jmap(client);
+      let url: string;
+      if (j) {
+        url = await j.stalwartEnableTotp();
+      } else {
+        url = await legacyEnableTotp();
       }
-
-      const data = await response.json();
       set({ otpEnabled: true, isSaving: false });
-      return data.data;
+      return url;
     } catch (error) {
       set({
         isSaving: false,
@@ -243,20 +378,15 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     }
   },
 
-  disableTotp: async () => {
+  disableTotp: async (client) => {
     set({ isSaving: true, error: null });
     try {
-      const response = await apiFetch('/api/account/stalwart/auth', {
-        method: 'POST',
-        headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
-        body: JSON.stringify([{ type: 'disableOtpAuth' }]),
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || data.details || `HTTP ${response.status}`);
+      const j = jmap(client);
+      if (j) {
+        await j.stalwartDisableTotp();
+      } else {
+        await legacyDisableTotp();
       }
-
       set({ otpEnabled: false, isSaving: false });
     } catch (error) {
       set({
@@ -267,23 +397,20 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     }
   },
 
-  addAppPassword: async (name, password) => {
+  addAppPassword: async (client, name, password) => {
     set({ isSaving: true, error: null });
     try {
-      const response = await apiFetch('/api/account/stalwart/auth', {
-        method: 'POST',
-        headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
-        body: JSON.stringify([{ type: 'addAppPassword', name, password }]),
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || data.details || `HTTP ${response.status}`);
+      let serverSecret: string | undefined;
+      const j = jmap(client);
+      if (j) {
+        const created = await j.stalwartCreateAppPassword(name);
+        serverSecret = created.secret;
+      } else {
+        await legacyAddAppPassword(name, password);
       }
-
-      // Refresh auth info to get updated app passwords list
-      await get().fetchAuthInfo();
+      await get().fetchAuthInfo(client);
       set({ isSaving: false });
+      return serverSecret;
     } catch (error) {
       set({
         isSaving: false,
@@ -293,22 +420,19 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     }
   },
 
-  removeAppPassword: async (name) => {
+  removeAppPassword: async (client, name) => {
     set({ isSaving: true, error: null });
     try {
-      const response = await apiFetch('/api/account/stalwart/auth', {
-        method: 'POST',
-        headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
-        body: JSON.stringify([{ type: 'removeAppPassword', name }]),
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || data.details || `HTTP ${response.status}`);
+      const j = jmap(client);
+      if (j) {
+        const passwords = await j.stalwartGetAppPasswords();
+        const match = passwords.find(ap => ap.description === name);
+        if (!match) throw new Error(`App password "${name}" not found`);
+        await j.stalwartDestroyAppPassword(match.id);
+      } else {
+        await legacyRemoveAppPassword(name);
       }
-
-      // Refresh auth info to get updated app passwords list
-      await get().fetchAuthInfo();
+      await get().fetchAuthInfo(client);
       set({ isSaving: false });
     } catch (error) {
       set({
@@ -319,20 +443,15 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     }
   },
 
-  updateEncryption: async (settings) => {
+  updateEncryption: async (client, settings) => {
     set({ isSaving: true, error: null });
     try {
-      const response = await apiFetch('/api/account/stalwart/crypto', {
-        method: 'POST',
-        headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
-        body: JSON.stringify(settings),
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || data.details || `HTTP ${response.status}`);
+      const j = jmap(client);
+      if (j) {
+        await j.stalwartUpdateEncryption(settings);
+      } else {
+        await legacyUpdateEncryption(settings);
       }
-
       set({ encryptionType: settings.type, isSaving: false });
     } catch (error) {
       set({


### PR DESCRIPTION
## Summary

This PR adds support to managed App Passwords via JMAP (with fallback to previous behavior) and fixes a race condition caused by lazy mailbox initialization on first login (via OIDC).

## Changes

<!-- A bulleted list of the key changes made. -->

- added JMAP App Password support
- updated UI component as Stalwart 0.16 does not allow specifying passwords but will generate a password during creation
- fixed race condition after login when mailbox is not yet available 

## Related Issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #217 
Closes #218 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ x New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->
<img width="915" height="525" alt="Screenshot From 2026-04-22 17-17-45" src="https://github.com/user-attachments/assets/b85ec870-839d-4702-923d-a9c1368c590f" />
<img width="915" height="525" alt="Screenshot From 2026-04-22 17-17-56" src="https://github.com/user-attachments/assets/932e09c2-978c-4267-b64d-aefce0d5dfc9" />
<img width="915" height="525" alt="Screenshot From 2026-04-22 17-18-00" src="https://github.com/user-attachments/assets/18ba665e-4275-4f45-99f1-4a90cbd67d1e" />


## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->

Some additional context regarding the root cause of the race condition:

  1. getAllMailboxes() succeeds but returns 0 mailboxes (server hasn't provisioned them yet)
  2. fetchMailboxes sets mailboxes: [], selectedMailbox: '', isLoading: false
  3. Since selectedMailbox is empty, fetchEmails doesn't run meaningfully
  4. The effect guard mailboxes.length === 0 stays true, but loadData already ran once — the effect won't
  re-fire unless dependencies change
  5. The user sees an empty UI with no way to recover without refreshing

  The fix: if mailboxes come back empty while authenticated, retry after a short delay.
