### PR TITLE
Fix push preview JMAP query

### DIFF
--- a/app/api/push/preview/route.ts
+++ b/app/api/push/preview/route.ts
@@ -40,17 +40,53 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Incomplete JMAP session' }, { status: 502 });
     }
 
-    // Find the inbox, then pull the most recent unread message in it. We use
-    // a single batched JMAP request with back-references so this round-trip
-    // is one POST regardless of how many messages exist.
+    const inboxRes = await fetch(apiUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: creds.authHeader,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+        methodCalls: [
+          [
+            'Mailbox/query',
+            { accountId, filter: { role: 'inbox' }, limit: 1 },
+            'mb',
+          ],
+        ],
+      }),
+    });
+
+    if (!inboxRes.ok) {
+      return NextResponse.json({ error: 'JMAP mailbox query failed' }, { status: 502 });
+    }
+
+    const inboxData = (await inboxRes.json()) as {
+      methodResponses: [string, Record<string, unknown>, string][];
+    };
+
+    const inboxBody = inboxData.methodResponses.find(
+      ([method]) => method === 'Mailbox/query',
+    )?.[1] as { ids?: string[] } | undefined;
+
+    const inboxId = inboxBody?.ids?.[0];
+
+    if (!inboxId) {
+      return NextResponse.json({
+        email: null,
+        unreadTotal: 0,
+      }, {
+        headers: {
+          'Cache-Control': 'no-store',
+        },
+      });
+    }
+
+    // Pull the most recent unread message from the resolved Inbox mailbox.
     const requestBody = {
       using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
       methodCalls: [
-        [
-          'Mailbox/query',
-          { accountId, filter: { role: 'inbox' }, limit: 1 },
-          'mb',
-        ],
         [
           'Email/query',
           {
@@ -58,7 +94,7 @@ export async function GET(request: NextRequest) {
             filter: {
               operator: 'AND',
               conditions: [
-                { inMailbox: { resultOf: 'mb', name: 'Mailbox/query', path: '/ids/0' } },
+                { inMailbox: inboxId },
                 { notKeyword: '$seen' },
               ],
             },


### PR DESCRIPTION
## Summary

Fixes push notification previews falling back to the generic “New mail” text when `/api/push/preview` fails on Stalwart.

The previous JMAP request passed a result reference object directly into the `inMailbox` filter. This resolves the Inbox mailbox id first, then passes the plain mailbox id string into `Email/query`.

## Changes

- Resolve the Inbox mailbox id with `Mailbox/query` before running `Email/query`
- Pass the resolved `inboxId` string to the `inMailbox` filter
- Keep the existing service worker notification enrichment flow unchanged

## Related Issues

None

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [ ] I have run `npm run typecheck && npm run lint` and there are no errors
- [ ] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

Before:
<img width="234" height="87" alt="image" src="https://github.com/user-attachments/assets/305f17e8-5646-4e78-b774-865f37e88367" />

After:
<img width="231" height="80" alt="image" src="https://github.com/user-attachments/assets/753a4c5f-e741-45ac-a629-50746e59b55a" />


## Notes for Reviewers

Tested against a self-hosted Stalwart setup.

Before the change, calling:

```js
fetch('/api/push/preview', { credentials: 'include', cache: 'no-store' })
  .then(async r => console.log(r.status, await r.text()))
```

returned:

```text
502 {"error":"JMAP request failed"}
```

After resolving the Inbox mailbox id first, the same endpoint returns `200` with the latest unread email and `unreadTotal`, allowing the service worker to show enriched push notification content instead of the generic fallback.

