### PR TITLE
fix: add useTranslations for "selected emails" and "cancel" on email list batch operations

### DIFF
--- a/components/email/email-list.tsx
+++ b/components/email/email-list.tsx
@@ -275,7 +275,7 @@ export function EmailList({
         <div className="px-4 py-2 border-b bg-accent/30 border-border flex items-center justify-between">
           <div className="flex items-center gap-2 animate-in fade-in slide-in-from-left-3 duration-300">
             <span className="text-sm font-medium text-foreground">
-              {selectedEmailIds.size} {selectedEmailIds.size === 1 ? 'email' : 'emails'} selected
+              {t('batch_actions.selected_messages', { count: selectedEmailIds.size })}
             </span>
           </div>
           <div className="flex items-center gap-1 animate-in fade-in slide-in-from-right-3 duration-300">
@@ -330,7 +330,7 @@ export function EmailList({
               disabled={isProcessing}
               className="text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
             >
-              Cancel
+              {t('batch_actions.clear_selection')}
             </Button>
           </div>
         </div>

--- a/locales/cs/common.json
+++ b/locales/cs/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "Vybrat zprávy",
       "select_all": "Vybrat vše",
+      "selected_messages": "{count, plural, one {Vybraný 1 e-mail} other {Vybrané # e-maily}}",
       "mark_read": "Označit jako přečtené",
       "mark_unread": "Označit jako nepřečtené",
       "delete": "Odstranit",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "E-Mails auswählen",
       "select_all": "Alle auswählen",
+      "selected_messages": "{count, plural, one {1 E-Mail} other {# E-Mails}} ausgewählt",
       "mark_read": "Als gelesen markieren",
       "mark_unread": "Als ungelesen markieren",
       "delete": "Löschen",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "Select emails",
       "select_all": "Select all",
+      "selected_messages": "{count, plural, one {1 email} other {# emails}} selected",
       "mark_read": "Mark as read",
       "mark_unread": "Mark as unread",
       "delete": "Delete",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "Seleccionar correos",
       "select_all": "Seleccionar todo",
+      "selected_messages": "{count, plural, one {1 correo electrónico seleccionado} other {# correos electrónicos seleccionados}}",
       "mark_read": "Marcar como leído",
       "mark_unread": "Marcar como no leído",
       "delete": "Eliminar",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "Sélectionner les e-mails",
       "select_all": "Tout sélectionner",
+      "selected_messages": "{count, plural, one {1 e-mail sélectionné} other {# e-mails sélectionnés}}",
       "mark_read": "Marquer comme lu",
       "mark_unread": "Marquer comme non lu",
       "delete": "Supprimer",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "Seleziona e-mail",
       "select_all": "Seleziona tutto",
+      "selected_messages": "{count} email {count, plural, one {selezionata} other {selezionate}}",
       "mark_read": "Segna come letto",
       "mark_unread": "Segna come non letto",
       "delete": "Elimina",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "メールを選択",
       "select_all": "すべて選択",
+      "selected_messages": "{count, plural, one {1} other {#}}通のメールが選択されました",
       "mark_read": "既読にする",
       "mark_unread": "未読にする",
       "delete": "削除",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "메일 선택",
       "select_all": "모두 선택",
+      "selected_messages": "이메일 {count, plural, one {1개} other {#건}} 선택됨",
       "mark_read": "읽은 상태로 표시",
       "mark_unread": "읽지 않은 상태로 표시",
       "delete": "삭제",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "Atlasīt vēstules",
       "select_all": "Atlasīt visas",
+      "selected_messages": "{count, plural, one {Izvēlēta 1 e-pasta vēstule} other {Izvēlētas # e-pasta vēstules}}",
       "mark_read": "Atzīmēt kā izlasītu",
       "mark_unread": "Atzīmēt kā nelasītu",
       "delete": "Dzēst",

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -185,6 +185,7 @@
       "select": "E-mails selecteren",
       "select_all": "Alles selecteren",
       "mark_read": "Markeren als gelezen",
+      "selected_messages": "{count, plural, one {1 e-mail} other {# e-mails}} geselecteerd",
       "mark_unread": "Markeren als ongelezen",
       "delete": "Verwijderen",
       "delete_confirm_title": "E-mails verwijderen",

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "Zaznacz wiadomości",
       "select_all": "Zaznacz wszystkie",
+      "selected_messages": "Wybrano {count, plural, one {1 wiadomość} other {# wiadomości}} e-mail",
       "mark_read": "Oznacz jako przeczytane",
       "mark_unread": "Oznacz jako nieprzeczytane",
       "delete": "Usuń",

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "Selecionar e-mails",
       "select_all": "Selecionar tudo",
+      "selected_messages": "{count, plural, one {1 e-mail selecionado} other {# e-mails selecionados}}",
       "mark_read": "Marcar como lido",
       "mark_unread": "Marcar como não lido",
       "delete": "Excluir",

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "Выбрать письма",
       "select_all": "Выбрать все",
+      "selected_messages": "Выбрано {count, plural, one {1 письмо} other {# письма}}",
       "mark_read": "Отметить прочитанными",
       "mark_unread": "Отметить непрочитанными",
       "delete": "Удалить",

--- a/locales/tr/common.json
+++ b/locales/tr/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "E-postaları seç",
       "select_all": "Tümünü seç",
+      "selected_messages": "{count, plural, one {1 e-posta} other {# e-posta}} seçildi",
       "mark_read": "Okundu olarak işaretle",
       "mark_unread": "Okunmadı olarak işaretle",
       "delete": "Sil",

--- a/locales/uk/common.json
+++ b/locales/uk/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "Виберіть електронні листи",
       "select_all": "Вибрати все",
+      "selected_messages": "Вибрано {count, plural, one {1 електронний лист} other {# електронні листи}}",
       "mark_read": "Позначити як прочитане",
       "mark_unread": "Позначити як непрочитане",
       "delete": "Видалити",

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -184,6 +184,7 @@
     "batch_actions": {
       "select": "选择邮件",
       "select_all": "全选",
+      "selected_messages": "已選取 {count, plural, one {1} other {#}} 封電子郵件",
       "mark_read": "标记为已读",
       "mark_unread": "标记为未读",
       "delete": "删除",


### PR DESCRIPTION
## Summary

Fixes missing i18n support for the "selected emails" and "cancel" labels used in the email list batch operations toolbar. The component email-list.tsx was updated to use useTranslations instead of hardcoded strings, and the corresponding translation keys were added across 16 locales (en, fr, cs, de, es, it, ja, ko, lv, nl, pl, pt, ru, tr, uk, zh).

## Changes

- Updated components/email/email-list.tsx to use useTranslations for "selected emails" and "cancel" labels in batch operations

- Added missing translation keys to locales/en/common.json and locales/fr/common.json

- Added missing translation keys across 14 additional locales: cs, de, es, it, ja, ko, lv, nl, pl, pt, ru, tr, uk, zh

## Related Issues

None

## Type of Change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [X] I have added or updated documentation if needed
- [X] I have updated translations (`locales/`) if my changes affect user-facing text
- [X] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<img width="1232" height="711" alt="en-01" src="https://github.com/user-attachments/assets/674d61f8-8040-41a2-ae5d-fc8854eb8e5c" />

<img width="1254" height="747" alt="en-02" src="https://github.com/user-attachments/assets/a1ee03f2-f9a6-4e34-a402-a7e3699331a0" />

<img width="1252" height="728" alt="fr-01" src="https://github.com/user-attachments/assets/42e88954-6aa2-4dcc-b80c-9fa4f9bcb9b7" />

<img width="1232" height="729" alt="fr-02" src="https://github.com/user-attachments/assets/28e27ae5-bb5d-4783-8ec5-b70496fd217c" />

<img width="1226" height="711" alt="cs-01" src="https://github.com/user-attachments/assets/0530c3dd-52d8-4f0b-b632-b10d48af3d82" />

<img width="1245" height="729" alt="cs-02" src="https://github.com/user-attachments/assets/f09336b6-bd7f-4a2b-9976-cac79d056382" />

<img width="1238" height="746" alt="de-01" src="https://github.com/user-attachments/assets/0999d9ba-8d14-4ef2-a0ef-55207a7be595" />

<img width="1244" height="729" alt="de-02" src="https://github.com/user-attachments/assets/f6e5cfb9-4c93-4c25-b984-2ae0d7e39ce9" />

<img width="1216" height="728" alt="es-01" src="https://github.com/user-attachments/assets/210e2af9-0e9c-4411-8d13-64fd79ef71e1" />

<img width="1231" height="737" alt="es-02" src="https://github.com/user-attachments/assets/bb8c5078-76cf-4969-b095-5ed908d6a088" />

<img width="1228" height="711" alt="it-01" src="https://github.com/user-attachments/assets/e1a452c4-e872-43b0-ba85-aceab586ec7e" />

<img width="1239" height="729" alt="it-02" src="https://github.com/user-attachments/assets/b1da72c2-731d-4f5f-be0c-96eb4d905060" />

<img width="1254" height="709" alt="ja-01" src="https://github.com/user-attachments/assets/f1b656e4-c2ce-4413-b405-25c3de715902" />

<img width="1229" height="722" alt="ja-02" src="https://github.com/user-attachments/assets/24d3e8c8-b9dc-4d81-a669-41c5c1e56b85" />

<img width="1224" height="717" alt="ko-01" src="https://github.com/user-attachments/assets/bd987f74-4dcd-4ade-b169-29f6cc3ef200" />

<img width="1235" height="712" alt="ko-02" src="https://github.com/user-attachments/assets/c1e41274-ccf5-499c-bfcf-d13b4420bac7" />

<img width="1224" height="714" alt="lv-01" src="https://github.com/user-attachments/assets/dbd58f84-2dfe-4e51-9e0c-27771abf22c5" />

<img width="1194" height="710" alt="lv-02" src="https://github.com/user-attachments/assets/d67c776a-eeaf-4b82-ad6e-e9ee343da16b" />

<img width="1255" height="720" alt="nl-01" src="https://github.com/user-attachments/assets/be65cf41-b810-4fc9-b63f-2609f15095f8" />

<img width="1247" height="714" alt="nl-02" src="https://github.com/user-attachments/assets/d9671cda-109b-4a11-a150-b368be44b042" />

<img width="1245" height="752" alt="pl-01" src="https://github.com/user-attachments/assets/a60e6f24-90ed-496b-a581-a282ef708184" />

<img width="1226" height="729" alt="pl-02" src="https://github.com/user-attachments/assets/1bead63e-1db1-4029-8d64-16671e9b90e5" />

<img width="1259" height="733" alt="pt-01" src="https://github.com/user-attachments/assets/bd425340-81f5-4367-b238-ff7a2d053291" />

<img width="1232" height="725" alt="pt-02" src="https://github.com/user-attachments/assets/67db94bf-541b-44e3-9943-b4d9a3d407d4" />

<img width="1250" height="716" alt="ru-01" src="https://github.com/user-attachments/assets/9c835d21-dda3-46e6-8a32-c490e21be0af" />

<img width="1244" height="732" alt="ru-02" src="https://github.com/user-attachments/assets/1b46a7ea-878d-4587-a3de-67465648e628" />

<img width="1254" height="719" alt="tr-01" src="https://github.com/user-attachments/assets/f8ec2361-9eec-4f49-92e6-9fdca6657df9" />

<img width="1220" height="720" alt="tr-02" src="https://github.com/user-attachments/assets/d520a281-4699-47fb-a1fe-3fa3efc91d96" />

<img width="1229" height="720" alt="uk-01" src="https://github.com/user-attachments/assets/d3f4ff2b-ef4a-437e-bef9-7528a38bd2bd" />

<img width="1244" height="733" alt="uk-02" src="https://github.com/user-attachments/assets/ed11da65-c4d0-407f-bc78-873c54593b8b" />

<img width="1264" height="700" alt="zh-01" src="https://github.com/user-attachments/assets/33bd7dfc-10c0-439c-b66b-4a2a4486617e" />

<img width="1231" height="737" alt="zh-02" src="https://github.com/user-attachments/assets/7a5077e1-3a9b-4cde-bb57-67baede912e5" />

## Notes for Reviewers

This fix ensures the batch operations toolbar is fully internationalized and consistent with the rest of the application's i18n pattern.