### PR TITLE
fix: add missing Czech flag icon to settings / language and region

### DIFF
--- a/components/ui/flag-icons.tsx
+++ b/components/ui/flag-icons.tsx
@@ -190,6 +190,17 @@ export function FlagCN(props: FlagProps) {
   );
 }
 
+/** Czech Republic - White and red horizontal bands with a blue triangle */
+export function FlagCS(props: FlagProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2" width={W} height={H} className={flagClass} {...props}>
+      <rect width="3" height="2" fill="#fff" />
+      <rect y="1" width="3" height="1" fill="#D7141A" />
+      <polygon points="0,0 1.5,1 0,2" fill="#11457E" />
+    </svg>
+  );
+}
+
 /** Map locale codes to flag components */
 export const flagComponents: Record<string, (props: FlagProps) => ReactElement> = {
   en: FlagGB,
@@ -207,4 +218,5 @@ export const flagComponents: Record<string, (props: FlagProps) => ReactElement> 
   tr: FlagTR,
   uk: FlagUA,
   zh: FlagCN,
+  cs: FlagCS,
 };


### PR DESCRIPTION
## Summary

Add missing [Czech flag](https://en.wikipedia.org/wiki/Flag_of_the_Czech_Republic) icon to settings / language and region

## Changes

- Updated components/ui/flag-icons.tsx to add missing Czech flag icon

## Type of Change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [X] I have added or updated documentation if needed
- [X] I have updated translations (`locales/`) if my changes affect user-facing text
- [X] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<img width="1404" height="776" alt="Screenshot_1" src="https://github.com/user-attachments/assets/42c8c1d8-58ce-4a8c-97ba-366f9ef6df2b" />

<img width="1418" height="774" alt="Screenshot_2" src="https://github.com/user-attachments/assets/9f79620e-d3c0-4d6b-b30a-c74e567cd388" />