### PR TITLE
fix: fall back to primary identity signature on reply

### DIFF
--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -281,6 +281,12 @@ export function EmailComposer({
   const currentIdentity = selectedIdentityId
     ? identities.find((identity) => identity.id === selectedIdentityId) || primaryIdentity
     : primaryIdentity;
+  // Alias identities often lack a configured signature — fall back to the primary
+  // identity's signature so replies (which auto-select a matching alias) still
+  // populate the user's signature.
+  const signatureIdentity = (currentIdentity?.htmlSignature || currentIdentity?.textSignature)
+    ? currentIdentity
+    : primaryIdentity;
   useEffect(() => {
     if (!autoSelectReplyIdentity) return;
     if (selectedIdentityId || initialData?.selectedIdentityId) return;
@@ -322,10 +328,10 @@ export function EmailComposer({
     selectedIdentityId,
   ]);
 
-  const composerSignatureHtml = currentIdentity?.htmlSignature
-    ? `<div>${sanitizeEmailHtml(currentIdentity.htmlSignature)}</div>`
-    : currentIdentity?.textSignature
-      ? `<div>${getPlainTextSignature(currentIdentity).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '<br>')}</div>`
+  const composerSignatureHtml = signatureIdentity?.htmlSignature
+    ? `<div>${sanitizeEmailHtml(signatureIdentity.htmlSignature)}</div>`
+    : signatureIdentity?.textSignature
+      ? `<div>${getPlainTextSignature(signatureIdentity).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '<br>')}</div>`
       : '';
   const getAutocomplete = useContactStore((s) => s.getAutocomplete);
   const addToTrustedSendersBook = useContactStore((s) => s.addToTrustedSendersBook);
@@ -954,11 +960,11 @@ export function EmailComposer({
     // Body is already HTML from the rich text editor (or plain text in plain text mode).
     // Build HTML signature block (used only in rich text mode)
     const buildSignatureHtml = (): string => {
-      if (currentIdentity?.htmlSignature) {
-        return `<br><br>-- <br>${sanitizeEmailHtml(currentIdentity.htmlSignature)}`;
+      if (signatureIdentity?.htmlSignature) {
+        return `<br><br>-- <br>${sanitizeEmailHtml(signatureIdentity.htmlSignature)}`;
       }
-      if (currentIdentity?.textSignature) {
-        return `<br><br>-- <br>${currentIdentity.textSignature.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '<br>')}`;
+      if (signatureIdentity?.textSignature) {
+        return `<br><br>-- <br>${signatureIdentity.textSignature.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '<br>')}`;
       }
       return '';
     };
@@ -970,8 +976,8 @@ export function EmailComposer({
 
     // In plain text mode, send text/plain only (no HTML body)
     const finalBody = plainTextMode
-      ? appendPlainTextSignature(body, currentIdentity)
-      : appendPlainTextSignature(htmlToPlainText(body), currentIdentity);
+      ? appendPlainTextSignature(body, signatureIdentity)
+      : appendPlainTextSignature(htmlToPlainText(body), signatureIdentity);
 
     const rewritten = plainTextMode ? null : rewriteInlineImages(body);
     const finalHtmlBody = plainTextMode
@@ -1500,9 +1506,9 @@ export function EmailComposer({
         )}
 
         {plainTextMode ? (
-          getPlainTextSignature(currentIdentity) ? (
+          getPlainTextSignature(signatureIdentity) ? (
             <div className="px-4 pb-3 text-sm leading-6 text-muted-foreground break-words whitespace-pre-wrap font-mono">
-              {'-- \n'}{getPlainTextSignature(currentIdentity)}
+              {'-- \n'}{getPlainTextSignature(signatureIdentity)}
             </div>
           ) : null
         ) : composerSignatureHtml ? (


### PR DESCRIPTION
## Summary

When replying to an email, the composer would auto-select the alias identity matching the original recipient address (via `findReplyIdentityId`). In typical setups (Cyrus, Fastmail, etc.) only the primary canonical identity has a signature configured — alias identities have empty signatures. The composer was then using the alias's empty signature for both the visual preview and the appended signature on send, so neither showed up. New mail worked correctly because no auto-select runs there, leaving the primary identity in use.

## Changes

- Add a `signatureIdentity` constant that falls back to `primaryIdentity` when the currently selected identity has no `htmlSignature` or `textSignature`.
- Use `signatureIdentity` for the visual signature preview, `buildSignatureHtml()`, and the `appendPlainTextSignature()` calls during send.
- Continue using `currentIdentity` for the From address, identity ID, S/MIME, and draft saves so the email still goes out from the right alias — only the signature lookup falls back.

## Test plan

- [ ] Reply to a message addressed to an alias identity that has no configured signature → signature preview appears below the editor and is included in the sent email.
- [ ] Reply to a message addressed to a non-primary identity that *does* have its own signature → that identity's signature is used (not the primary's).
- [ ] Compose a new message → primary identity signature appears (unchanged behavior).
- [ ] Reply with `autoSelectReplyIdentity` disabled → primary signature appears (unchanged).
- [ ] Send goes out with the alias in From: and the primary's signature in the body.
- [ ] Plain text mode and rich text mode both render the fallback signature correctly.