### PR TITLE
fix: add a proper viewport export to the root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { headers } from "next/headers";
 import { getLocale } from "next-intl/server";
@@ -16,6 +16,11 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
 
 export async function generateMetadata(): Promise<Metadata> {
   await configManager.ensureLoaded();


### PR DESCRIPTION
## Summary

<!-- A brief, one-paragraph description of what this PR does and why. -->

Next.js App Router emits a default `<meta name="viewport" content="width=device-width">` but omits `initial-scale=1`. Without `initial-scale=1`, iOS Safari applies its own scale heuristics and triggers auto-zoom-on-focus regardless of the focused element's CSS font-size. This adds a proper `viewport` export to the root layout so the meta tag includes `initial-scale=1`, eliminating the unwanted zoom when tapping inputs and the rich-text editor on mobile.

## Changes

<!-- A bulleted list of the key changes made. -->

- Add `viewport: Viewport` export to `app/layout.tsx` with `width: "device-width"` and `initialScale: 1`.
- Import `Viewport` type from `next` alongside the existing `Metadata` import.

## Related Issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

Before: tapping an input field or the TipTap editor on iOS Safari (and thus PWA) zooms the viewport in.
After: focus stays at the current zoom level.

## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->

Considered a CSS-only fix forcing `font-size: 16px` on inputs and `[contenteditable]` (iOS Safari auto-zooms when the focused element renders below 16px). Rejected it: bumping every editable surface to 16px caused inconsistent text sizes across the app (e.g. signature vs. composer) and would have required a broader refactor of the type scale to stay visually coherent.
Setting `initial-scale=1` on the viewport is minimal and global, and doesn't disable pinch-to-zoom (no `maximumScale` set), so accessibility is preserved.