### PR TITLE
feat: add forgot-password / reset-by-email for Stalwart accounts

### DIFF
--- a/app/[locale]/forgot-password/page.tsx
+++ b/app/[locale]/forgot-password/page.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useState } from 'react';
+import { Link } from '@/i18n/navigation';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useConfig } from '@/hooks/use-config';
+import { apiFetch } from '@/lib/browser-navigation';
+import { cn } from '@/lib/utils';
+import { AlertCircle, CheckCircle, Loader2, ArrowLeft } from 'lucide-react';
+
+export default function ForgotPasswordPage() {
+  const t = useTranslations('forgot_password');
+  const { appName, forgotPasswordEnabled } = useConfig();
+  const [username, setUsername] = useState('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  // Feature-gated: return nothing if admin hasn't enabled this
+  if (!forgotPasswordEnabled) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('loading');
+    setErrorMsg('');
+    try {
+      const res = await apiFetch('/api/auth/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: username.trim() }),
+      });
+      if (!res.ok) throw new Error('request_failed');
+      setStatus('success');
+    } catch {
+      setStatus('error');
+      setErrorMsg(t('error_generic'));
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-background via-muted/10 to-muted/30 px-4">
+      <div className="w-full max-w-[400px] mx-auto">
+        <div className="rounded-2xl border border-border/60 bg-background/80 backdrop-blur-sm shadow-xl shadow-black/5 dark:shadow-black/20 overflow-hidden">
+          <div className="px-8 pt-10 pb-8">
+            <h1 className="text-2xl font-semibold text-foreground tracking-tight mb-1.5">
+              {t('title')}
+            </h1>
+            <p className="text-sm text-muted-foreground mb-6">{t('subtitle')}</p>
+
+            {status === 'success' ? (
+              <div className="space-y-5">
+                <div className="p-3 rounded-xl border border-emerald-500/20 bg-emerald-500/5 flex items-start gap-3">
+                  <div className="w-10 h-10 rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 flex items-center justify-center flex-shrink-0">
+                    <CheckCircle className="w-5 h-5" />
+                  </div>
+                  <div className="flex-1 min-w-0 self-center">
+                    <p className="text-sm text-emerald-700 dark:text-emerald-300 leading-relaxed">
+                      {t('success_message')}
+                    </p>
+                  </div>
+                </div>
+                <Link
+                  href="/login"
+                  className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <ArrowLeft className="w-4 h-4" />
+                  {t('back_to_login')}
+                </Link>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-5">
+                {status === 'error' && (
+                  <div
+                    className={cn(
+                      'p-3 rounded-xl border border-destructive/20 bg-destructive/5 flex items-start gap-3',
+                    )}
+                  >
+                    <div className="w-10 h-10 rounded-full bg-destructive/15 text-destructive flex items-center justify-center flex-shrink-0 shadow-sm">
+                      <AlertCircle className="w-5 h-5" />
+                    </div>
+                    <div className="flex-1 min-w-0 self-center">
+                      <p className="text-sm text-destructive leading-relaxed">{errorMsg}</p>
+                    </div>
+                  </div>
+                )}
+
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="fp-username"
+                    className="block text-sm font-medium text-foreground"
+                  >
+                    {t('email_label')}
+                  </label>
+                  <Input
+                    id="fp-username"
+                    type="text"
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                    className="h-11 px-3.5 bg-muted/40 border-border/60 rounded-xl focus:bg-background focus:border-primary/50 transition-all duration-200"
+                    placeholder={t('email_placeholder')}
+                    required
+                    autoFocus
+                    autoComplete="username"
+                  />
+                </div>
+
+                <Button
+                  type="submit"
+                  className="w-full h-11 font-medium text-[15px] bg-primary hover:bg-primary/90 transition-all duration-200 rounded-xl shadow-md shadow-primary/15 hover:shadow-lg hover:shadow-primary/20"
+                  disabled={status === 'loading'}
+                >
+                  {status === 'loading' ? (
+                    <div className="flex items-center gap-2">
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      {t('sending')}
+                    </div>
+                  ) : (
+                    t('submit_button')
+                  )}
+                </Button>
+
+                <Link
+                  href="/login"
+                  className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <ArrowLeft className="w-4 h-4" />
+                  {t('back_to_login')}
+                </Link>
+              </form>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/forgot-password/page.tsx
+++ b/app/[locale]/forgot-password/page.tsx
@@ -1,132 +1,164 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import { Link } from '@/i18n/navigation';
-import { useTranslations } from 'next-intl';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { useConfig } from '@/hooks/use-config';
-import { apiFetch } from '@/lib/browser-navigation';
-import { cn } from '@/lib/utils';
-import { AlertCircle, CheckCircle, Loader2, ArrowLeft } from 'lucide-react';
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useConfig } from "@/hooks/use-config";
+import { apiFetch } from "@/lib/browser-navigation";
+import { AlertCircle, CheckCircle, Loader2, Mail } from "lucide-react";
 
 export default function ForgotPasswordPage() {
-  const t = useTranslations('forgot_password');
-  const { appName, forgotPasswordEnabled } = useConfig();
-  const [username, setUsername] = useState('');
-  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
-  const [errorMsg, setErrorMsg] = useState('');
+  const t = useTranslations("forgot_password");
+  const { appName, loginLogoLightUrl, loginLogoDarkUrl, forgotPasswordEnabled } = useConfig();
 
-  // Feature-gated: return nothing if admin hasn't enabled this
-  if (!forgotPasswordEnabled) return null;
+  const [username, setUsername] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState("");
+
+  // Guard: if the feature is disabled, don't render the form
+  if (!forgotPasswordEnabled) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-muted/10 to-muted/30 px-4">
+        <div className="w-full max-w-[400px] mx-auto">
+          <div className="rounded-2xl border border-border/60 bg-background/80 backdrop-blur-sm shadow-xl shadow-black/5 dark:shadow-black/20 p-8 text-center">
+            <p className="text-sm text-muted-foreground">{t("error_invalid_token")}</p>
+            <Link
+              href="/login"
+              className="mt-4 inline-block text-sm text-primary hover:text-primary/80 transition-colors"
+            >
+              {t("back_to_login")}
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setStatus('loading');
-    setErrorMsg('');
+    setError("");
+    setSubmitting(true);
     try {
-      const res = await apiFetch('/api/auth/forgot-password', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username: username.trim() }),
+      const res = await apiFetch("/api/auth/forgot-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username }),
       });
-      if (!res.ok) throw new Error('request_failed');
-      setStatus('success');
+      if (!res.ok && res.status !== 200) {
+        setError(t("error_generic"));
+      } else {
+        setSubmitted(true);
+      }
     } catch {
-      setStatus('error');
-      setErrorMsg(t('error_generic'));
+      setError(t("error_generic"));
+    } finally {
+      setSubmitting(false);
     }
   };
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-background via-muted/10 to-muted/30 px-4">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-background via-muted/10 to-muted/30 relative px-4">
       <div className="w-full max-w-[400px] mx-auto">
         <div className="rounded-2xl border border-border/60 bg-background/80 backdrop-blur-sm shadow-xl shadow-black/5 dark:shadow-black/20 overflow-hidden">
-          <div className="px-8 pt-10 pb-8">
-            <h1 className="text-2xl font-semibold text-foreground tracking-tight mb-1.5">
-              {t('title')}
+          {/* Header */}
+          <div className="px-8 pt-10 pb-6 text-center">
+            <div className="inline-flex items-center justify-center w-16 h-16 mb-5">
+              <img
+                src={loginLogoLightUrl}
+                alt={appName}
+                className="max-w-16 max-h-16 object-contain dark:hidden"
+              />
+              <img
+                src={loginLogoDarkUrl}
+                alt={appName}
+                className="max-w-16 max-h-16 object-contain hidden dark:block"
+              />
+            </div>
+            <h1 className="text-2xl font-semibold text-foreground tracking-tight">
+              {t("title")}
             </h1>
-            <p className="text-sm text-muted-foreground mb-6">{t('subtitle')}</p>
+            <p className="text-sm text-muted-foreground mt-1.5">{t("subtitle")}</p>
+          </div>
 
-            {status === 'success' ? (
-              <div className="space-y-5">
-                <div className="p-3 rounded-xl border border-emerald-500/20 bg-emerald-500/5 flex items-start gap-3">
-                  <div className="w-10 h-10 rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 flex items-center justify-center flex-shrink-0">
-                    <CheckCircle className="w-5 h-5" />
-                  </div>
-                  <div className="flex-1 min-w-0 self-center">
-                    <p className="text-sm text-emerald-700 dark:text-emerald-300 leading-relaxed">
-                      {t('success_message')}
-                    </p>
-                  </div>
+          {/* Body */}
+          <div className="px-8 pb-8">
+            {submitted ? (
+              <div className="flex flex-col items-center gap-4 py-2 text-center">
+                <div className="w-12 h-12 rounded-full bg-green-500/10 flex items-center justify-center">
+                  <CheckCircle className="w-6 h-6 text-green-500" />
                 </div>
+                <p className="text-sm text-foreground leading-relaxed">
+                  {t("success_message")}
+                </p>
                 <Link
                   href="/login"
-                  className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                  className="text-sm text-primary hover:text-primary/80 transition-colors"
                 >
-                  <ArrowLeft className="w-4 h-4" />
-                  {t('back_to_login')}
+                  {t("back_to_login")}
                 </Link>
               </div>
             ) : (
               <form onSubmit={handleSubmit} className="space-y-5">
-                {status === 'error' && (
-                  <div
-                    className={cn(
-                      'p-3 rounded-xl border border-destructive/20 bg-destructive/5 flex items-start gap-3',
-                    )}
-                  >
+                {error && (
+                  <div className="p-3 rounded-xl border border-destructive/20 bg-destructive/5 flex items-start gap-3">
                     <div className="w-10 h-10 rounded-full bg-destructive/15 text-destructive flex items-center justify-center flex-shrink-0 shadow-sm">
                       <AlertCircle className="w-5 h-5" />
                     </div>
                     <div className="flex-1 min-w-0 self-center">
-                      <p className="text-sm text-destructive leading-relaxed">{errorMsg}</p>
+                      <p className="text-sm text-destructive leading-relaxed">{error}</p>
                     </div>
                   </div>
                 )}
 
                 <div className="space-y-1.5">
                   <label
-                    htmlFor="fp-username"
+                    htmlFor="reset-username"
                     className="block text-sm font-medium text-foreground"
                   >
-                    {t('email_label')}
+                    {t("email_label")}
                   </label>
-                  <Input
-                    id="fp-username"
-                    type="text"
-                    value={username}
-                    onChange={(e) => setUsername(e.target.value)}
-                    className="h-11 px-3.5 bg-muted/40 border-border/60 rounded-xl focus:bg-background focus:border-primary/50 transition-all duration-200"
-                    placeholder={t('email_placeholder')}
-                    required
-                    autoFocus
-                    autoComplete="username"
-                  />
+                  <div className="relative">
+                    <Mail className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                    <Input
+                      id="reset-username"
+                      type="text"
+                      value={username}
+                      onChange={(e) => setUsername(e.target.value)}
+                      className="h-11 pl-10 pr-3.5 bg-muted/40 border-border/60 rounded-xl focus:bg-background focus:border-primary/50 transition-all duration-200"
+                      placeholder={t("email_placeholder")}
+                      required
+                      autoFocus
+                      autoComplete="username"
+                    />
+                  </div>
                 </div>
 
                 <Button
                   type="submit"
                   className="w-full h-11 font-medium text-[15px] bg-primary hover:bg-primary/90 transition-all duration-200 rounded-xl shadow-md shadow-primary/15 hover:shadow-lg hover:shadow-primary/20"
-                  disabled={status === 'loading'}
+                  disabled={submitting}
                 >
-                  {status === 'loading' ? (
+                  {submitting ? (
                     <div className="flex items-center gap-2">
                       <Loader2 className="w-4 h-4 animate-spin" />
-                      {t('sending')}
+                      {t("sending")}
                     </div>
                   ) : (
-                    t('submit_button')
+                    t("submit_button")
                   )}
                 </Button>
 
-                <Link
-                  href="/login"
-                  className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  <ArrowLeft className="w-4 h-4" />
-                  {t('back_to_login')}
-                </Link>
+                <div className="text-center">
+                  <Link
+                    href="/login"
+                    className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {t("back_to_login")}
+                  </Link>
+                </div>
               </form>
             )}
           </div>

--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { useRouter } from "@/i18n/navigation";
+import { Link, useRouter } from "@/i18n/navigation";
 import { useParams, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -133,7 +133,7 @@ export default function LoginPage() {
   const isMobileHandoff = Boolean(mobileRedirectUri);
   const { login, loginDemo, isLoading, error, clearError, isAuthenticated } = useAuthStore();
   const { theme, setTheme, initializeTheme } = useThemeStore(useShallow((s) => ({ theme: s.theme, setTheme: s.setTheme, initializeTheme: s.initializeTheme })));
-  const { appName, jmapServerUrl: configuredServerUrl, oauthEnabled, oauthOnly, oauthClientId: globalOauthClientId, oauthIssuerUrl: globalOauthIssuerUrl, oauthScopes, rememberMeEnabled, devMode, demoMode, loginLogoLightUrl, loginLogoDarkUrl, loginCompanyName, loginImprintUrl, loginPrivacyPolicyUrl, loginWebsiteUrl, isLoading: configLoading, error: configError, autoSsoEnabled, embeddedMode: _embeddedMode, allowCustomJmapEndpoint, jmapServers, jmapServerAutoPickByDomain } = useConfig();
+  const { appName, jmapServerUrl: configuredServerUrl, oauthEnabled, oauthOnly, oauthClientId: globalOauthClientId, oauthIssuerUrl: globalOauthIssuerUrl, oauthScopes, rememberMeEnabled, devMode, demoMode, loginLogoLightUrl, loginLogoDarkUrl, loginCompanyName, loginImprintUrl, loginPrivacyPolicyUrl, loginWebsiteUrl, isLoading: configLoading, error: configError, autoSsoEnabled, embeddedMode: _embeddedMode, allowCustomJmapEndpoint, jmapServers, jmapServerAutoPickByDomain, forgotPasswordEnabled } = useConfig();
   const resolvedTheme = useThemeStore((s) => s.resolvedTheme);
 
   const [formData, setFormData] = useState({
@@ -1101,9 +1101,19 @@ export default function LoginPage() {
 
                   {/* Password field */}
                   <div className="space-y-1.5">
-                    <label htmlFor="password" className="block text-sm font-medium text-foreground">
-                      {t("password_label")}
-                    </label>
+                    <div className="flex items-center justify-between">
+                      <label htmlFor="password" className="block text-sm font-medium text-foreground">
+                        {t("password_label")}
+                      </label>
+                      {forgotPasswordEnabled && !isAddAccountMode && !demoMode && (
+                        <Link
+                          href="/forgot-password"
+                          className="text-xs text-muted-foreground/70 hover:text-foreground transition-colors"
+                        >
+                          {t("forgot_password")}
+                        </Link>
+                      )}
+                    </div>
                     <div className="relative">
                       <Input
                         id="password"

--- a/app/[locale]/reset-password/page.tsx
+++ b/app/[locale]/reset-password/page.tsx
@@ -1,202 +1,214 @@
-'use client';
+"use client";
 
-import { useState, Suspense } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { Link, useRouter } from '@/i18n/navigation';
-import { useTranslations } from 'next-intl';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { useConfig } from '@/hooks/use-config';
-import { apiFetch } from '@/lib/browser-navigation';
-import { cn } from '@/lib/utils';
-import { AlertCircle, CheckCircle, Eye, EyeOff, Loader2, ArrowLeft } from 'lucide-react';
+import { useState, useEffect, Suspense } from "react";
+import { useTranslations } from "next-intl";
+import { useSearchParams } from "next/navigation";
+import { Link, useRouter } from "@/i18n/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useConfig } from "@/hooks/use-config";
+import { apiFetch } from "@/lib/browser-navigation";
+import { cn } from "@/lib/utils";
+import { AlertCircle, CheckCircle, Eye, EyeOff, Loader2 } from "lucide-react";
 
 function ResetPasswordForm() {
-  const t = useTranslations('forgot_password');
+  const t = useTranslations("forgot_password");
   const router = useRouter();
   const searchParams = useSearchParams();
-  const token = searchParams.get('token') ?? '';
+  const token = searchParams.get("token") ?? "";
 
-  const [password, setPassword] = useState('');
-  const [confirm, setConfirm] = useState('');
+  const [newPassword, setNewPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
   const [showPassword, setShowPassword] = useState(false);
-  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
-  const [errorMsg, setErrorMsg] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState("");
 
-  if (!token) {
-    return (
-      <div className="p-3 rounded-xl border border-destructive/20 bg-destructive/5 flex items-start gap-3">
-        <div className="w-10 h-10 rounded-full bg-destructive/15 text-destructive flex items-center justify-center flex-shrink-0 shadow-sm">
-          <AlertCircle className="w-5 h-5" />
-        </div>
-        <div className="flex-1 min-w-0 self-center">
-          <p className="text-sm text-destructive leading-relaxed">{t('error_missing_token')}</p>
-        </div>
-      </div>
-    );
-  }
+  useEffect(() => {
+    if (!token) setError(t("error_missing_token"));
+  }, [token, t]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setErrorMsg('');
-    if (password.length < 8) {
-      setErrorMsg(t('error_password_too_short'));
+    setError("");
+
+    if (newPassword.length < 8) {
+      setError(t("error_password_too_short"));
       return;
     }
-    if (password !== confirm) {
-      setErrorMsg(t('error_password_mismatch'));
+    if (newPassword !== confirm) {
+      setError(t("error_password_mismatch"));
       return;
     }
-    setStatus('loading');
+
+    setSubmitting(true);
     try {
-      const res = await apiFetch('/api/auth/reset-password', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token, password }),
+      const res = await apiFetch("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, newPassword }),
       });
-      const data = await res.json();
-      if (!res.ok || data.error) {
-        const msg =
-          data.error === 'invalid_token' ? t('error_invalid_token') : t('error_generic');
-        setErrorMsg(msg);
-        setStatus('error');
-        return;
+
+      if (res.ok) {
+        setSuccess(true);
+        setTimeout(() => router.push("/login"), 3000);
+      } else {
+        const data = await res.json().catch(() => ({}));
+        const code: string = data?.error ?? "";
+        if (code === "invalid_token") {
+          setError(t("error_invalid_token"));
+        } else if (code === "password_too_short") {
+          setError(t("error_password_too_short"));
+        } else {
+          setError(t("error_generic"));
+        }
       }
-      setStatus('success');
-      setTimeout(() => router.push('/login'), 2500);
     } catch {
-      setStatus('error');
-      setErrorMsg(t('error_generic'));
+      setError(t("error_generic"));
+    } finally {
+      setSubmitting(false);
     }
   };
 
-  if (status === 'success') {
-    return (
-      <div className="space-y-5">
-        <div className="p-3 rounded-xl border border-emerald-500/20 bg-emerald-500/5 flex items-start gap-3">
-          <div className="w-10 h-10 rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 flex items-center justify-center flex-shrink-0">
-            <CheckCircle className="w-5 h-5" />
-          </div>
-          <div className="flex-1 min-w-0 self-center">
-            <p className="text-sm text-emerald-700 dark:text-emerald-300 leading-relaxed">
-              {t('reset_success')}
-            </p>
-          </div>
-        </div>
-        <Link
-          href="/login"
-          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <ArrowLeft className="w-4 h-4" />
-          {t('back_to_login')}
-        </Link>
-      </div>
-    );
-  }
-
   return (
     <form onSubmit={handleSubmit} className="space-y-5">
-      {errorMsg && (
-        <div
-          className={cn(
-            'p-3 rounded-xl border border-destructive/20 bg-destructive/5 flex items-start gap-3',
-          )}
-        >
+      {error && (
+        <div className="p-3 rounded-xl border border-destructive/20 bg-destructive/5 flex items-start gap-3">
           <div className="w-10 h-10 rounded-full bg-destructive/15 text-destructive flex items-center justify-center flex-shrink-0 shadow-sm">
             <AlertCircle className="w-5 h-5" />
           </div>
           <div className="flex-1 min-w-0 self-center">
-            <p className="text-sm text-destructive leading-relaxed">{errorMsg}</p>
+            <p className="text-sm text-destructive leading-relaxed">{error}</p>
           </div>
         </div>
       )}
 
-      <div className="space-y-1.5">
-        <label htmlFor="rp-password" className="block text-sm font-medium text-foreground">
-          {t('password_label')}
-        </label>
-        <div className="relative">
-          <Input
-            id="rp-password"
-            type={showPassword ? 'text' : 'password'}
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="h-11 px-3.5 pr-11 bg-muted/40 border-border/60 rounded-xl focus:bg-background focus:border-primary/50 transition-all duration-200"
-            placeholder={t('password_placeholder')}
-            required
-            autoFocus
-            autoComplete="new-password"
-          />
-          <button
-            type="button"
-            onClick={() => setShowPassword(!showPassword)}
-            className="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-md text-muted-foreground hover:text-foreground transition-colors"
-            tabIndex={-1}
-          >
-            {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-          </button>
-        </div>
-      </div>
-
-      <div className="space-y-1.5">
-        <label htmlFor="rp-confirm" className="block text-sm font-medium text-foreground">
-          {t('confirm_label')}
-        </label>
-        <Input
-          id="rp-confirm"
-          type={showPassword ? 'text' : 'password'}
-          value={confirm}
-          onChange={(e) => setConfirm(e.target.value)}
-          className="h-11 px-3.5 bg-muted/40 border-border/60 rounded-xl focus:bg-background focus:border-primary/50 transition-all duration-200"
-          placeholder={t('confirm_placeholder')}
-          required
-          autoComplete="new-password"
-        />
-      </div>
-
-      <Button
-        type="submit"
-        className="w-full h-11 font-medium text-[15px] bg-primary hover:bg-primary/90 transition-all duration-200 rounded-xl shadow-md shadow-primary/15 hover:shadow-lg hover:shadow-primary/20"
-        disabled={status === 'loading'}
-      >
-        {status === 'loading' ? (
-          <div className="flex items-center gap-2">
-            <Loader2 className="w-4 h-4 animate-spin" />
-            {t('resetting')}
+      {success ? (
+        <div className="flex flex-col items-center gap-4 py-2 text-center">
+          <div className="w-12 h-12 rounded-full bg-green-500/10 flex items-center justify-center">
+            <CheckCircle className="w-6 h-6 text-green-500" />
           </div>
-        ) : (
-          t('reset_button')
-        )}
-      </Button>
+          <p className="text-sm text-foreground leading-relaxed">{t("reset_success")}</p>
+          <Link href="/login" className="text-sm text-primary hover:text-primary/80 transition-colors">
+            {t("back_to_login")}
+          </Link>
+        </div>
+      ) : (
+        <fieldset disabled={submitting || !token} className="space-y-4">
+          {/* New password */}
+          <div className="space-y-1.5">
+            <label htmlFor="new-password" className="block text-sm font-medium text-foreground">
+              {t("password_label")}
+            </label>
+            <div className="relative">
+              <Input
+                id="new-password"
+                type={showPassword ? "text" : "password"}
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                className="h-11 px-3.5 pr-11 bg-muted/40 border-border/60 rounded-xl focus:bg-background focus:border-primary/50 transition-all duration-200"
+                placeholder={t("password_placeholder")}
+                required
+                autoFocus
+                autoComplete="new-password"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-md text-muted-foreground hover:text-foreground transition-colors"
+                tabIndex={-1}
+              >
+                {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+              </button>
+            </div>
+          </div>
 
-      <Link
-        href="/login"
-        className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-      >
-        <ArrowLeft className="w-4 h-4" />
-        {t('back_to_login')}
-      </Link>
+          {/* Confirm password */}
+          <div className="space-y-1.5">
+            <label htmlFor="confirm-password" className="block text-sm font-medium text-foreground">
+              {t("confirm_label")}
+            </label>
+            <Input
+              id="confirm-password"
+              type={showPassword ? "text" : "password"}
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              className={cn(
+                "h-11 px-3.5 bg-muted/40 border-border/60 rounded-xl focus:bg-background focus:border-primary/50 transition-all duration-200",
+                confirm && newPassword !== confirm && "border-destructive/50",
+              )}
+              placeholder={t("confirm_placeholder")}
+              required
+              autoComplete="new-password"
+            />
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full h-11 font-medium text-[15px] bg-primary hover:bg-primary/90 transition-all duration-200 rounded-xl shadow-md shadow-primary/15 hover:shadow-lg hover:shadow-primary/20"
+            disabled={submitting || !token}
+          >
+            {submitting ? (
+              <div className="flex items-center gap-2">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                {t("resetting")}
+              </div>
+            ) : (
+              t("reset_button")
+            )}
+          </Button>
+
+          <div className="text-center">
+            <Link
+              href="/login"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {t("back_to_login")}
+            </Link>
+          </div>
+        </fieldset>
+      )}
     </form>
   );
 }
 
 export default function ResetPasswordPage() {
-  const t = useTranslations('forgot_password');
-  const { forgotPasswordEnabled } = useConfig();
-
-  if (!forgotPasswordEnabled) return null;
+  const t = useTranslations("forgot_password");
+  const { appName, loginLogoLightUrl, loginLogoDarkUrl } = useConfig();
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-background via-muted/10 to-muted/30 px-4">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-background via-muted/10 to-muted/30 relative px-4">
       <div className="w-full max-w-[400px] mx-auto">
         <div className="rounded-2xl border border-border/60 bg-background/80 backdrop-blur-sm shadow-xl shadow-black/5 dark:shadow-black/20 overflow-hidden">
-          <div className="px-8 pt-10 pb-8">
-            <h1 className="text-2xl font-semibold text-foreground tracking-tight mb-1.5">
-              {t('reset_title')}
+          {/* Header */}
+          <div className="px-8 pt-10 pb-6 text-center">
+            <div className="inline-flex items-center justify-center w-16 h-16 mb-5">
+              <img
+                src={loginLogoLightUrl}
+                alt={appName}
+                className="max-w-16 max-h-16 object-contain dark:hidden"
+              />
+              <img
+                src={loginLogoDarkUrl}
+                alt={appName}
+                className="max-w-16 max-h-16 object-contain hidden dark:block"
+              />
+            </div>
+            <h1 className="text-2xl font-semibold text-foreground tracking-tight">
+              {t("reset_title")}
             </h1>
-            <p className="text-sm text-muted-foreground mb-6">{t('reset_subtitle')}</p>
-            {/* useSearchParams requires Suspense in Next.js App Router */}
-            <Suspense fallback={null}>
+            <p className="text-sm text-muted-foreground mt-1.5">{t("reset_subtitle")}</p>
+          </div>
+
+          <div className="px-8 pb-8">
+            {/* useSearchParams requires Suspense */}
+            <Suspense
+              fallback={
+                <div className="flex justify-center py-8">
+                  <Loader2 className="w-6 h-6 animate-spin text-primary" />
+                </div>
+              }
+            >
               <ResetPasswordForm />
             </Suspense>
           </div>

--- a/app/[locale]/reset-password/page.tsx
+++ b/app/[locale]/reset-password/page.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useState, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Link, useRouter } from '@/i18n/navigation';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useConfig } from '@/hooks/use-config';
+import { apiFetch } from '@/lib/browser-navigation';
+import { cn } from '@/lib/utils';
+import { AlertCircle, CheckCircle, Eye, EyeOff, Loader2, ArrowLeft } from 'lucide-react';
+
+function ResetPasswordForm() {
+  const t = useTranslations('forgot_password');
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token') ?? '';
+
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  if (!token) {
+    return (
+      <div className="p-3 rounded-xl border border-destructive/20 bg-destructive/5 flex items-start gap-3">
+        <div className="w-10 h-10 rounded-full bg-destructive/15 text-destructive flex items-center justify-center flex-shrink-0 shadow-sm">
+          <AlertCircle className="w-5 h-5" />
+        </div>
+        <div className="flex-1 min-w-0 self-center">
+          <p className="text-sm text-destructive leading-relaxed">{t('error_missing_token')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrorMsg('');
+    if (password.length < 8) {
+      setErrorMsg(t('error_password_too_short'));
+      return;
+    }
+    if (password !== confirm) {
+      setErrorMsg(t('error_password_mismatch'));
+      return;
+    }
+    setStatus('loading');
+    try {
+      const res = await apiFetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, password }),
+      });
+      const data = await res.json();
+      if (!res.ok || data.error) {
+        const msg =
+          data.error === 'invalid_token' ? t('error_invalid_token') : t('error_generic');
+        setErrorMsg(msg);
+        setStatus('error');
+        return;
+      }
+      setStatus('success');
+      setTimeout(() => router.push('/login'), 2500);
+    } catch {
+      setStatus('error');
+      setErrorMsg(t('error_generic'));
+    }
+  };
+
+  if (status === 'success') {
+    return (
+      <div className="space-y-5">
+        <div className="p-3 rounded-xl border border-emerald-500/20 bg-emerald-500/5 flex items-start gap-3">
+          <div className="w-10 h-10 rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 flex items-center justify-center flex-shrink-0">
+            <CheckCircle className="w-5 h-5" />
+          </div>
+          <div className="flex-1 min-w-0 self-center">
+            <p className="text-sm text-emerald-700 dark:text-emerald-300 leading-relaxed">
+              {t('reset_success')}
+            </p>
+          </div>
+        </div>
+        <Link
+          href="/login"
+          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          {t('back_to_login')}
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {errorMsg && (
+        <div
+          className={cn(
+            'p-3 rounded-xl border border-destructive/20 bg-destructive/5 flex items-start gap-3',
+          )}
+        >
+          <div className="w-10 h-10 rounded-full bg-destructive/15 text-destructive flex items-center justify-center flex-shrink-0 shadow-sm">
+            <AlertCircle className="w-5 h-5" />
+          </div>
+          <div className="flex-1 min-w-0 self-center">
+            <p className="text-sm text-destructive leading-relaxed">{errorMsg}</p>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        <label htmlFor="rp-password" className="block text-sm font-medium text-foreground">
+          {t('password_label')}
+        </label>
+        <div className="relative">
+          <Input
+            id="rp-password"
+            type={showPassword ? 'text' : 'password'}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="h-11 px-3.5 pr-11 bg-muted/40 border-border/60 rounded-xl focus:bg-background focus:border-primary/50 transition-all duration-200"
+            placeholder={t('password_placeholder')}
+            required
+            autoFocus
+            autoComplete="new-password"
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-md text-muted-foreground hover:text-foreground transition-colors"
+            tabIndex={-1}
+          >
+            {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <label htmlFor="rp-confirm" className="block text-sm font-medium text-foreground">
+          {t('confirm_label')}
+        </label>
+        <Input
+          id="rp-confirm"
+          type={showPassword ? 'text' : 'password'}
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          className="h-11 px-3.5 bg-muted/40 border-border/60 rounded-xl focus:bg-background focus:border-primary/50 transition-all duration-200"
+          placeholder={t('confirm_placeholder')}
+          required
+          autoComplete="new-password"
+        />
+      </div>
+
+      <Button
+        type="submit"
+        className="w-full h-11 font-medium text-[15px] bg-primary hover:bg-primary/90 transition-all duration-200 rounded-xl shadow-md shadow-primary/15 hover:shadow-lg hover:shadow-primary/20"
+        disabled={status === 'loading'}
+      >
+        {status === 'loading' ? (
+          <div className="flex items-center gap-2">
+            <Loader2 className="w-4 h-4 animate-spin" />
+            {t('resetting')}
+          </div>
+        ) : (
+          t('reset_button')
+        )}
+      </Button>
+
+      <Link
+        href="/login"
+        className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ArrowLeft className="w-4 h-4" />
+        {t('back_to_login')}
+      </Link>
+    </form>
+  );
+}
+
+export default function ResetPasswordPage() {
+  const t = useTranslations('forgot_password');
+  const { forgotPasswordEnabled } = useConfig();
+
+  if (!forgotPasswordEnabled) return null;
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-background via-muted/10 to-muted/30 px-4">
+      <div className="w-full max-w-[400px] mx-auto">
+        <div className="rounded-2xl border border-border/60 bg-background/80 backdrop-blur-sm shadow-xl shadow-black/5 dark:shadow-black/20 overflow-hidden">
+          <div className="px-8 pt-10 pb-8">
+            <h1 className="text-2xl font-semibold text-foreground tracking-tight mb-1.5">
+              {t('reset_title')}
+            </h1>
+            <p className="text-sm text-muted-foreground mb-6">{t('reset_subtitle')}</p>
+            {/* useSearchParams requires Suspense in Next.js App Router */}
+            <Suspense fallback={null}>
+              <ResetPasswordForm />
+            </Suspense>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -5,83 +5,106 @@ import { checkResetRateLimit } from '@/lib/auth/reset-rate-limit';
 import { createResetToken } from '@/lib/auth/password-reset-store';
 import { sendPasswordResetEmail, type SmtpConfig } from '@/lib/auth/password-reset-mailer';
 
+/** Always return the same shape to prevent email enumeration. */
+const OK = NextResponse.json({ ok: true });
+
 export async function POST(request: NextRequest) {
   try {
     await configManager.ensureLoaded();
 
-    const forgotPasswordEnabled = configManager.get<boolean>('forgotPasswordEnabled', false);
-    if (!forgotPasswordEnabled) {
+    // Feature flag
+    const enabled = configManager.get<boolean>('forgotPasswordEnabled', false);
+    if (!enabled) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 });
     }
 
-    // IP-based rate limiting (same pattern as admin login)
+    // IP rate-limit
     const ip =
       request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
       request.headers.get('x-real-ip') ??
       'unknown';
     const { allowed } = checkResetRateLimit(ip);
     if (!allowed) {
-      // Return ok:true to avoid disclosing whether an account exists
-      return NextResponse.json({ ok: true });
+      logger.warn('Forgot-password rate limited', { ip });
+      // Return OK to avoid revealing that the IP is blocked
+      return OK;
     }
 
-    const body = await request.json();
+    const body = await request.json().catch(() => null);
     const username = typeof body?.username === 'string' ? body.username.trim() : '';
     if (!username) {
       return NextResponse.json({ error: 'Missing username' }, { status: 400 });
     }
 
+    // Require SMTP + admin API to be configured before doing anything
     const smtpHost = configManager.get<string>('resetSmtpHost', '');
     const smtpUser = configManager.get<string>('resetSmtpUser', '');
     const smtpPass = configManager.get<string>('resetSmtpPass', '');
     const fromEmail = configManager.get<string>('resetFromEmail', '');
     const appBaseUrl = configManager.get<string>('resetAppBaseUrl', '');
     const stalwartApiUrl = configManager.get<string>('stalwartAdminApiUrl', '');
+    const stalwartToken = configManager.get<string>('stalwartAdminApiToken', '');
+
+    if (
+      !smtpHost ||
+      !smtpUser ||
+      !smtpPass ||
+      !fromEmail ||
+      !appBaseUrl ||
+      !stalwartApiUrl ||
+      !stalwartToken
+    ) {
+      logger.warn('Forgot-password: incomplete server configuration, request ignored', {
+        username,
+      });
+      // Return OK — the admin needs to configure the feature, but we don’t
+      // expose that to the caller.
+      return OK;
+    }
+
+    // Resolve the JMAP server URL for this user (used so the reset page can
+    // call the right server to verify the new credential afterwards).
+    const serverUrl = configManager.get<string>('jmapServerUrl', '');
+
+    const result = createResetToken(username, serverUrl);
+    if (!result) {
+      // User not found in token store — return OK (anti-enumeration)
+      return OK;
+    }
+    if ('rateLimited' in result) {
+      logger.info('Forgot-password per-user rate limited', { username });
+      return OK;
+    }
+
+    const smtpPortRaw = configManager.get<string>('resetSmtpPort', '587');
+    const smtpSecure = configManager.get<boolean>('resetSmtpSecure', false);
     const appName = configManager.get<string>('appName', 'Webmail');
 
-    if (!smtpHost || !smtpUser || !smtpPass || !fromEmail || !stalwartApiUrl) {
-      logger.warn('forgot-password: SMTP or Stalwart admin API not fully configured');
-      // Still respond ok:true — misconfiguration must not leak info
-      return NextResponse.json({ ok: true });
-    }
-
-    const serverUrl = configManager.get<string>('jmapServerUrl', '');
-    const result = await createResetToken(username, serverUrl);
-
-    // Always respond ok:true regardless of whether the account exists (anti-enumeration)
-    if (!result || 'rateLimited' in result) {
-      return NextResponse.json({ ok: true });
-    }
-
-    const baseUrl =
-      appBaseUrl ||
-      `${request.nextUrl.protocol}//${request.nextUrl.host}`;
-    const resetLink = `${baseUrl}/reset-password?token=${encodeURIComponent(result.token)}`;
+    const resetLink = `${appBaseUrl.replace(/\/$/, '')}/reset-password?token=${result.token}`;
 
     const smtp: SmtpConfig = {
       host: smtpHost,
-      port: Number(configManager.get<string>('resetSmtpPort', '587')),
-      secure: configManager.get<boolean>('resetSmtpSecure', false),
+      port: parseInt(smtpPortRaw, 10) || 587,
+      secure: smtpSecure,
       user: smtpUser,
       pass: smtpPass,
       from: fromEmail,
     };
 
-    // Derive recipient address: use username directly if it contains @,
-    // otherwise assume it is the local part and append the from-address domain.
-    const toEmail = username.includes('@')
-      ? username
-      : `${username}@${fromEmail.split('@')[1] ?? ''}`;
-
-    await sendPasswordResetEmail({ smtp, toEmail, username, resetLink, appName });
-
-    logger.info('forgot-password: reset email sent', { username });
-    return NextResponse.json({ ok: true });
-  } catch (error) {
-    logger.error('forgot-password error', {
-      error: error instanceof Error ? error.message : 'Unknown error',
+    await sendPasswordResetEmail({
+      smtp,
+      toEmail: username,
+      username,
+      resetLink,
+      appName,
     });
-    // Never leak details to the client
-    return NextResponse.json({ ok: true });
+
+    return OK;
+  } catch (error) {
+    logger.error('Forgot-password error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    // Do not leak internals
+    return OK;
   }
 }

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
+import { configManager } from '@/lib/admin/config-manager';
+import { checkResetRateLimit } from '@/lib/auth/reset-rate-limit';
+import { createResetToken } from '@/lib/auth/password-reset-store';
+import { sendPasswordResetEmail, type SmtpConfig } from '@/lib/auth/password-reset-mailer';
+
+export async function POST(request: NextRequest) {
+  try {
+    await configManager.ensureLoaded();
+
+    const forgotPasswordEnabled = configManager.get<boolean>('forgotPasswordEnabled', false);
+    if (!forgotPasswordEnabled) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    // IP-based rate limiting (same pattern as admin login)
+    const ip =
+      request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
+      request.headers.get('x-real-ip') ??
+      'unknown';
+    const { allowed } = checkResetRateLimit(ip);
+    if (!allowed) {
+      // Return ok:true to avoid disclosing whether an account exists
+      return NextResponse.json({ ok: true });
+    }
+
+    const body = await request.json();
+    const username = typeof body?.username === 'string' ? body.username.trim() : '';
+    if (!username) {
+      return NextResponse.json({ error: 'Missing username' }, { status: 400 });
+    }
+
+    const smtpHost = configManager.get<string>('resetSmtpHost', '');
+    const smtpUser = configManager.get<string>('resetSmtpUser', '');
+    const smtpPass = configManager.get<string>('resetSmtpPass', '');
+    const fromEmail = configManager.get<string>('resetFromEmail', '');
+    const appBaseUrl = configManager.get<string>('resetAppBaseUrl', '');
+    const stalwartApiUrl = configManager.get<string>('stalwartAdminApiUrl', '');
+    const appName = configManager.get<string>('appName', 'Webmail');
+
+    if (!smtpHost || !smtpUser || !smtpPass || !fromEmail || !stalwartApiUrl) {
+      logger.warn('forgot-password: SMTP or Stalwart admin API not fully configured');
+      // Still respond ok:true — misconfiguration must not leak info
+      return NextResponse.json({ ok: true });
+    }
+
+    const serverUrl = configManager.get<string>('jmapServerUrl', '');
+    const result = await createResetToken(username, serverUrl);
+
+    // Always respond ok:true regardless of whether the account exists (anti-enumeration)
+    if (!result || 'rateLimited' in result) {
+      return NextResponse.json({ ok: true });
+    }
+
+    const baseUrl =
+      appBaseUrl ||
+      `${request.nextUrl.protocol}//${request.nextUrl.host}`;
+    const resetLink = `${baseUrl}/reset-password?token=${encodeURIComponent(result.token)}`;
+
+    const smtp: SmtpConfig = {
+      host: smtpHost,
+      port: Number(configManager.get<string>('resetSmtpPort', '587')),
+      secure: configManager.get<boolean>('resetSmtpSecure', false),
+      user: smtpUser,
+      pass: smtpPass,
+      from: fromEmail,
+    };
+
+    // Derive recipient address: use username directly if it contains @,
+    // otherwise assume it is the local part and append the from-address domain.
+    const toEmail = username.includes('@')
+      ? username
+      : `${username}@${fromEmail.split('@')[1] ?? ''}`;
+
+    await sendPasswordResetEmail({ smtp, toEmail, username, resetLink, appName });
+
+    logger.info('forgot-password: reset email sent', { username });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    logger.error('forgot-password error', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+    // Never leak details to the client
+    return NextResponse.json({ ok: true });
+  }
+}

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 import { configManager } from '@/lib/admin/config-manager';
+import { checkResetRateLimit } from '@/lib/auth/reset-rate-limit';
 import { consumeResetToken } from '@/lib/auth/password-reset-store';
 import { setStalwartPassword } from '@/lib/auth/stalwart-admin';
 
@@ -10,42 +11,62 @@ export async function POST(request: NextRequest) {
   try {
     await configManager.ensureLoaded();
 
-    const forgotPasswordEnabled = configManager.get<boolean>('forgotPasswordEnabled', false);
-    if (!forgotPasswordEnabled) {
+    const enabled = configManager.get<boolean>('forgotPasswordEnabled', false);
+    if (!enabled) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 });
     }
 
-    const body = await request.json();
+    // IP rate-limit (shared bucket with forgot-password)
+    const ip =
+      request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
+      request.headers.get('x-real-ip') ??
+      'unknown';
+    const { allowed } = checkResetRateLimit(ip);
+    if (!allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        { status: 429 },
+      );
+    }
+
+    const body = await request.json().catch(() => null);
     const token = typeof body?.token === 'string' ? body.token.trim() : '';
-    const password = typeof body?.password === 'string' ? body.password : '';
+    const newPassword = typeof body?.newPassword === 'string' ? body.newPassword : '';
 
     if (!token) {
-      return NextResponse.json({ error: 'invalid_token' }, { status: 400 });
+      return NextResponse.json({ error: 'missing_token' }, { status: 400 });
     }
-    if (!password || password.length < MIN_PASSWORD_LENGTH) {
+    if (newPassword.length < MIN_PASSWORD_LENGTH) {
       return NextResponse.json({ error: 'password_too_short' }, { status: 400 });
     }
 
-    const credential = await consumeResetToken(token);
-    if (!credential) {
+    // Consume token (single-use; constant-time compare inside)
+    const consumed = consumeResetToken(token);
+    if (!consumed) {
       return NextResponse.json({ error: 'invalid_token' }, { status: 400 });
     }
 
-    const adminApiUrl = configManager.get<string>('stalwartAdminApiUrl', '');
-    const adminToken = configManager.get<string>('stalwartAdminApiToken', '');
-    if (!adminApiUrl || !adminToken) {
-      logger.error('reset-password: Stalwart admin API not configured');
-      return NextResponse.json({ error: 'server_error' }, { status: 500 });
+    const stalwartApiUrl = configManager.get<string>('stalwartAdminApiUrl', '');
+    const stalwartToken = configManager.get<string>('stalwartAdminApiToken', '');
+
+    if (!stalwartApiUrl || !stalwartToken) {
+      logger.error('Reset-password: Stalwart admin API not configured');
+      return NextResponse.json({ error: 'server_misconfigured' }, { status: 503 });
     }
 
-    await setStalwartPassword(adminApiUrl, adminToken, credential.username, password);
+    await setStalwartPassword(
+      stalwartApiUrl,
+      stalwartToken,
+      consumed.username,
+      newPassword,
+    );
 
-    logger.info('reset-password: password updated', { username: credential.username });
+    logger.info('Password reset completed', { username: consumed.username });
     return NextResponse.json({ ok: true });
   } catch (error) {
-    logger.error('reset-password error', {
-      error: error instanceof Error ? error.message : 'Unknown error',
+    logger.error('Reset-password error', {
+      error: error instanceof Error ? error.message : String(error),
     });
-    return NextResponse.json({ error: 'server_error' }, { status: 500 });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
+import { configManager } from '@/lib/admin/config-manager';
+import { consumeResetToken } from '@/lib/auth/password-reset-store';
+import { setStalwartPassword } from '@/lib/auth/stalwart-admin';
+
+const MIN_PASSWORD_LENGTH = 8;
+
+export async function POST(request: NextRequest) {
+  try {
+    await configManager.ensureLoaded();
+
+    const forgotPasswordEnabled = configManager.get<boolean>('forgotPasswordEnabled', false);
+    if (!forgotPasswordEnabled) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const token = typeof body?.token === 'string' ? body.token.trim() : '';
+    const password = typeof body?.password === 'string' ? body.password : '';
+
+    if (!token) {
+      return NextResponse.json({ error: 'invalid_token' }, { status: 400 });
+    }
+    if (!password || password.length < MIN_PASSWORD_LENGTH) {
+      return NextResponse.json({ error: 'password_too_short' }, { status: 400 });
+    }
+
+    const credential = await consumeResetToken(token);
+    if (!credential) {
+      return NextResponse.json({ error: 'invalid_token' }, { status: 400 });
+    }
+
+    const adminApiUrl = configManager.get<string>('stalwartAdminApiUrl', '');
+    const adminToken = configManager.get<string>('stalwartAdminApiToken', '');
+    if (!adminApiUrl || !adminToken) {
+      logger.error('reset-password: Stalwart admin API not configured');
+      return NextResponse.json({ error: 'server_error' }, { status: 500 });
+    }
+
+    await setStalwartPassword(adminApiUrl, adminToken, credential.username, password);
+
+    logger.info('reset-password: password updated', { username: credential.username });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    logger.error('reset-password error', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+    return NextResponse.json({ error: 'server_error' }, { status: 500 });
+  }
+}

--- a/lib/admin/types.ts
+++ b/lib/admin/types.ts
@@ -159,7 +159,7 @@ export const CONFIG_ENV_MAP: Record<string, { envVar: string; fileEnvVar?: strin
   logFormat: { envVar: 'LOG_FORMAT', type: 'enum', defaultValue: 'text', enumValues: ['text', 'json'] },
   logLevel: { envVar: 'LOG_LEVEL', type: 'enum', defaultValue: 'info', enumValues: ['error', 'warn', 'info', 'debug'] },
   sessionSecret: { envVar: 'SESSION_SECRET', fileEnvVar: 'SESSION_SECRET_FILE', type: 'string', defaultValue: '' },
-  // ── Forgot-password / reset-by-email ────────────────────────────────────────
+  // ─ Forgot-password / email-reset feature ──────────────────────────────────────
   forgotPasswordEnabled: { envVar: 'FORGOT_PASSWORD_ENABLED', type: 'boolean', defaultValue: false },
   stalwartAdminApiUrl: { envVar: 'STALWART_ADMIN_API_URL', type: 'url', defaultValue: '' },
   stalwartAdminApiToken: { envVar: 'STALWART_ADMIN_API_TOKEN', fileEnvVar: 'STALWART_ADMIN_API_TOKEN_FILE', type: 'string', defaultValue: '' },

--- a/lib/admin/types.ts
+++ b/lib/admin/types.ts
@@ -159,10 +159,26 @@ export const CONFIG_ENV_MAP: Record<string, { envVar: string; fileEnvVar?: strin
   logFormat: { envVar: 'LOG_FORMAT', type: 'enum', defaultValue: 'text', enumValues: ['text', 'json'] },
   logLevel: { envVar: 'LOG_LEVEL', type: 'enum', defaultValue: 'info', enumValues: ['error', 'warn', 'info', 'debug'] },
   sessionSecret: { envVar: 'SESSION_SECRET', fileEnvVar: 'SESSION_SECRET_FILE', type: 'string', defaultValue: '' },
+  // ── Forgot-password / reset-by-email ────────────────────────────────────────
+  forgotPasswordEnabled: { envVar: 'FORGOT_PASSWORD_ENABLED', type: 'boolean', defaultValue: false },
+  stalwartAdminApiUrl: { envVar: 'STALWART_ADMIN_API_URL', type: 'url', defaultValue: '' },
+  stalwartAdminApiToken: { envVar: 'STALWART_ADMIN_API_TOKEN', fileEnvVar: 'STALWART_ADMIN_API_TOKEN_FILE', type: 'string', defaultValue: '' },
+  resetSmtpHost: { envVar: 'RESET_SMTP_HOST', type: 'string', defaultValue: '' },
+  resetSmtpPort: { envVar: 'RESET_SMTP_PORT', type: 'string', defaultValue: '587' },
+  resetSmtpSecure: { envVar: 'RESET_SMTP_SECURE', type: 'boolean', defaultValue: false },
+  resetSmtpUser: { envVar: 'RESET_SMTP_USER', type: 'string', defaultValue: '' },
+  resetSmtpPass: { envVar: 'RESET_SMTP_PASS', fileEnvVar: 'RESET_SMTP_PASS_FILE', type: 'string', defaultValue: '' },
+  resetFromEmail: { envVar: 'RESET_FROM_EMAIL', type: 'string', defaultValue: '' },
+  resetAppBaseUrl: { envVar: 'RESET_APP_BASE_URL', type: 'url', defaultValue: '' },
 };
 
 /** Keys that should never be exposed to the client config endpoint */
-export const SENSITIVE_CONFIG_KEYS = new Set(['oauthClientSecret', 'sessionSecret']);
+export const SENSITIVE_CONFIG_KEYS = new Set([
+  'oauthClientSecret',
+  'sessionSecret',
+  'stalwartAdminApiToken',
+  'resetSmtpPass',
+]);
 
 /** Admin session cookie name */
 export const ADMIN_SESSION_COOKIE = 'admin_session';

--- a/lib/auth/password-reset-mailer.ts
+++ b/lib/auth/password-reset-mailer.ts
@@ -1,0 +1,155 @@
+import { createConnection, type Socket } from 'node:net';
+import { connect as tlsConnect, type TLSSocket } from 'node:tls';
+
+export interface SmtpConfig {
+  host: string;
+  port: number;
+  /** true = implicit TLS (port 465); false = plain + STARTTLS (port 587) */
+  secure: boolean;
+  user: string;
+  pass: string;
+  from: string;
+}
+
+function authPlain(user: string, pass: string): string {
+  // AUTH PLAIN encodes \0user\0pass in base64
+  return Buffer.from(`\0${user}\0${pass}`, 'utf-8').toString('base64');
+}
+
+function escapeMime(str: string): string {
+  return str.replace(/[\r\n]/g, ' ');
+}
+
+/**
+ * Minimal SMTP client supporting STARTTLS + AUTH PLAIN.
+ * Zero external dependencies — uses Node.js `net` and `tls` only.
+ */
+export async function sendPasswordResetEmail(opts: {
+  smtp: SmtpConfig;
+  toEmail: string;
+  username: string;
+  resetLink: string;
+  appName: string;
+}): Promise<void> {
+  const { smtp, toEmail, username, resetLink, appName } = opts;
+
+  return new Promise((resolve, reject) => {
+    let socket: Socket | TLSSocket;
+    let buffer = '';
+    const pending: string[] = [];
+    let lineWaiter: ((line: string) => void) | null = null;
+
+    function onData(chunk: Buffer | string): void {
+      buffer += chunk.toString();
+      const parts = buffer.split('\r\n');
+      buffer = parts.pop() ?? '';
+      for (const p of parts) {
+        if (p) pending.push(p);
+      }
+      if (lineWaiter && pending.length > 0) {
+        const waiter = lineWaiter;
+        lineWaiter = null;
+        waiter(pending.shift()!);
+      }
+    }
+
+    function nextLine(): Promise<string> {
+      return new Promise((res) => {
+        if (pending.length > 0) {
+          res(pending.shift()!);
+        } else {
+          lineWaiter = res;
+        }
+      });
+    }
+
+    /** Read a full SMTP response; handles multi-line 250-... / 250 ... */
+    async function readResponse(expectedCode: string): Promise<string> {
+      let full = '';
+      while (true) {
+        const line = await nextLine();
+        full += (full ? '\n' : '') + line;
+        if (line.startsWith(`${expectedCode} `)) break;
+        if (!line.startsWith(`${expectedCode}-`)) {
+          throw new Error(`SMTP error (expected ${expectedCode}): ${line}`);
+        }
+      }
+      return full;
+    }
+
+    function send(cmd: string): void {
+      (socket as Socket).write(`${cmd}\r\n`);
+    }
+
+    async function run(): Promise<void> {
+      await readResponse('220'); // server greeting
+
+      send('EHLO bulwark');
+      const ehloResp = await readResponse('250');
+
+      if (!smtp.secure && ehloResp.includes('STARTTLS')) {
+        send('STARTTLS');
+        await readResponse('220');
+        const plain = socket as Socket;
+        socket = tlsConnect({ socket: plain, host: smtp.host, rejectUnauthorized: true });
+        socket.on('data', onData);
+        await new Promise<void>((res, rej) => {
+          (socket as TLSSocket).once('secureConnect', res);
+          (socket as TLSSocket).once('error', rej);
+        });
+        send('EHLO bulwark');
+        await readResponse('250');
+      }
+
+      send(`AUTH PLAIN ${authPlain(smtp.user, smtp.pass)}`);
+      await readResponse('235');
+
+      send(`MAIL FROM:<${smtp.from}>`);
+      await readResponse('250');
+
+      send(`RCPT TO:<${toEmail}>`);
+      await readResponse('250');
+
+      send('DATA');
+      await readResponse('354');
+
+      const body = [
+        `From: ${escapeMime(appName)} <${smtp.from}>`,
+        `To: <${toEmail}>`,
+        `Subject: Reset your ${escapeMime(appName)} password`,
+        `MIME-Version: 1.0`,
+        `Content-Type: text/plain; charset=utf-8`,
+        ``,
+        `Hi ${username},`,
+        ``,
+        `Someone requested a password reset for your ${appName} account.`,
+        ``,
+        `Reset link (valid for 1 hour):`,
+        resetLink,
+        ``,
+        `If you did not request this, you can safely ignore this email.`,
+        ``,
+        `\u2013 The ${appName} team`,
+        `.`,
+      ].join('\r\n');
+
+      send(body);
+      await readResponse('250');
+
+      send('QUIT');
+      socket.destroy();
+      resolve();
+    }
+
+    if (smtp.secure) {
+      socket = tlsConnect({ host: smtp.host, port: smtp.port, rejectUnauthorized: true });
+      (socket as TLSSocket).once('secureConnect', () => run().catch(reject));
+    } else {
+      socket = createConnection({ host: smtp.host, port: smtp.port });
+      socket.once('connect', () => run().catch(reject));
+    }
+
+    socket.on('data', onData);
+    socket.once('error', reject);
+  });
+}

--- a/lib/auth/password-reset-mailer.ts
+++ b/lib/auth/password-reset-mailer.ts
@@ -1,155 +1,232 @@
-import { createConnection, type Socket } from 'node:net';
-import { connect as tlsConnect, type TLSSocket } from 'node:tls';
+import * as net from 'node:net';
+import * as tls from 'node:tls';
+import { logger } from '@/lib/logger';
 
 export interface SmtpConfig {
   host: string;
   port: number;
-  /** true = implicit TLS (port 465); false = plain + STARTTLS (port 587) */
-  secure: boolean;
+  secure: boolean; // true = implicit TLS on connect, false = STARTTLS
   user: string;
   pass: string;
   from: string;
 }
 
-function authPlain(user: string, pass: string): string {
-  // AUTH PLAIN encodes \0user\0pass in base64
-  return Buffer.from(`\0${user}\0${pass}`, 'utf-8').toString('base64');
-}
-
-function escapeMime(str: string): string {
-  return str.replace(/[\r\n]/g, ' ');
-}
-
-/**
- * Minimal SMTP client supporting STARTTLS + AUTH PLAIN.
- * Zero external dependencies — uses Node.js `net` and `tls` only.
- */
-export async function sendPasswordResetEmail(opts: {
+export interface ResetEmailOptions {
   smtp: SmtpConfig;
   toEmail: string;
   username: string;
   resetLink: string;
   appName: string;
-}): Promise<void> {
+}
+
+/** Encode a string for use in an SMTP AUTH PLAIN payload. */
+function authPlainPayload(user: string, pass: string): string {
+  // \0user\0pass
+  return Buffer.from(`\0${user}\0${pass}`).toString('base64');
+}
+
+/** Minimal zero-dependency SMTP send (STARTTLS + AUTH PLAIN). */
+export async function sendPasswordResetEmail(
+  opts: ResetEmailOptions,
+): Promise<void> {
   const { smtp, toEmail, username, resetLink, appName } = opts;
 
-  return new Promise((resolve, reject) => {
-    let socket: Socket | TLSSocket;
-    let buffer = '';
-    const pending: string[] = [];
-    let lineWaiter: ((line: string) => void) | null = null;
+  const subject = `[${appName}] Password Reset Request`;
+  const text = [
+    `Hi ${username},`,
+    '',
+    'You (or someone else) requested a password reset for your account.',
+    'Click the link below within 1 hour to set a new password:',
+    '',
+    resetLink,
+    '',
+    'If you did not request this, you can safely ignore this email.',
+    '',
+    `— ${appName}`,
+  ].join('\r\n');
 
-    function onData(chunk: Buffer | string): void {
-      buffer += chunk.toString();
-      const parts = buffer.split('\r\n');
-      buffer = parts.pop() ?? '';
-      for (const p of parts) {
-        if (p) pending.push(p);
-      }
-      if (lineWaiter && pending.length > 0) {
-        const waiter = lineWaiter;
-        lineWaiter = null;
-        waiter(pending.shift()!);
+  const date = new Date().toUTCString();
+  const msgId = `<${Date.now()}.${Math.random().toString(36).slice(2)}@${smtp.host}>`;
+  const rawMessage = [
+    `Date: ${date}`,
+    `Message-ID: ${msgId}`,
+    `From: ${smtp.from}`,
+    `To: ${toEmail}`,
+    `Subject: ${subject}`,
+    'MIME-Version: 1.0',
+    'Content-Type: text/plain; charset=UTF-8',
+    '',
+    text,
+  ].join('\r\n');
+
+  await smtpSend(smtp, smtp.from, [toEmail], rawMessage);
+  logger.info('Password reset email sent', { to: toEmail, username });
+}
+
+// ─── Minimal SMTP implementation ─────────────────────────────────────────────
+
+type SocketLike = net.Socket | tls.TLSSocket;
+
+function readLines(sock: SocketLike): AsyncIterable<string> {
+  let buf = '';
+  const lines: string[] = [];
+  let resolve: ((v: string) => void) | null = null;
+
+  sock.on('data', (chunk: Buffer) => {
+    buf += chunk.toString();
+    const parts = buf.split('\r\n');
+    buf = parts.pop() ?? '';
+    for (const line of parts) {
+      if (resolve) {
+        const r = resolve;
+        resolve = null;
+        r(line);
+      } else {
+        lines.push(line);
       }
     }
+  });
 
-    function nextLine(): Promise<string> {
-      return new Promise((res) => {
-        if (pending.length > 0) {
-          res(pending.shift()!);
+  return {
+    [Symbol.asyncIterator]: () => ({
+      next: (): Promise<IteratorResult<string>> =>
+        new Promise((res) => {
+          const line = lines.shift();
+          if (line !== undefined) {
+            res({ value: line, done: false });
+          } else {
+            resolve = (v) => res({ value: v, done: false });
+          }
+        }),
+    }),
+  };
+}
+
+async function readReply(
+  lines: AsyncIterable<string>,
+): Promise<{ code: number; text: string }> {
+  let lastCode = 0;
+  let text = '';
+  for await (const line of lines) {
+    const m = /^(\d{3})([ -])(.*)$/.exec(line);
+    if (!m) continue;
+    lastCode = parseInt(m[1], 10);
+    text = m[3];
+    if (m[2] === ' ') break; // last line of multi-line reply
+  }
+  return { code: lastCode, text };
+}
+
+async function cmd(
+  sock: SocketLike,
+  lines: AsyncIterable<string>,
+  command: string,
+  expectCode: number,
+): Promise<void> {
+  await new Promise<void>((res, rej) =>
+    sock.write(command + '\r\n', (e) => (e ? rej(e) : res())),
+  );
+  const reply = await readReply(lines);
+  if (reply.code !== expectCode) {
+    throw new Error(`SMTP ${command.split(' ')[0]} failed: ${reply.code} ${reply.text}`);
+  }
+}
+
+async function smtpSend(
+  cfg: SmtpConfig,
+  from: string,
+  to: string[],
+  raw: string,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const plain = net.createConnection(cfg.port, cfg.host);
+    plain.once('error', reject);
+
+    plain.once('connect', async () => {
+      try {
+        const lines = readLines(plain);
+        // greeting
+        await readReply(lines);
+        // EHLO
+        await cmd(plain, lines, `EHLO ${cfg.host}`, 250);
+
+        let sock: SocketLike = plain;
+
+        if (!cfg.secure) {
+          // STARTTLS upgrade
+          await cmd(plain, lines, 'STARTTLS', 220);
+          sock = await new Promise<tls.TLSSocket>((res, rej) => {
+            const tlsSock = tls.connect(
+              { socket: plain, servername: cfg.host, rejectUnauthorized: true },
+              () => res(tlsSock),
+            );
+            tlsSock.once('error', rej);
+          });
+          const tlsLines = readLines(sock);
+          await cmd(sock, tlsLines, `EHLO ${cfg.host}`, 250);
+          // AUTH PLAIN
+          await cmd(
+            sock,
+            tlsLines,
+            `AUTH PLAIN ${authPlainPayload(cfg.user, cfg.pass)}`,
+            235,
+          );
+          // MAIL / RCPT / DATA
+          await cmd(sock, tlsLines, `MAIL FROM:<${from}>`, 250);
+          for (const addr of to) {
+            await cmd(sock, tlsLines, `RCPT TO:<${addr}>`, 250);
+          }
+          await cmd(sock, tlsLines, 'DATA', 354);
+          await new Promise<void>((res, rej) =>
+            sock.write(`${raw}\r\n.\r\n`, (e) => (e ? rej(e) : res())),
+          );
+          const dataReply = await readReply(tlsLines);
+          if (dataReply.code !== 250) {
+            throw new Error(`SMTP DATA failed: ${dataReply.code} ${dataReply.text}`);
+          }
+          await cmd(sock, tlsLines, 'QUIT', 221);
         } else {
-          lineWaiter = res;
+          // Implicit TLS — wrap right away
+          const tlsSock = tls.connect(
+            { socket: plain, servername: cfg.host, rejectUnauthorized: true },
+            async () => {
+              try {
+                const tlsLines = readLines(tlsSock);
+                await readReply(tlsLines); // greeting
+                await cmd(tlsSock, tlsLines, `EHLO ${cfg.host}`, 250);
+                await cmd(
+                  tlsSock,
+                  tlsLines,
+                  `AUTH PLAIN ${authPlainPayload(cfg.user, cfg.pass)}`,
+                  235,
+                );
+                await cmd(tlsSock, tlsLines, `MAIL FROM:<${from}>`, 250);
+                for (const addr of to) {
+                  await cmd(tlsSock, tlsLines, `RCPT TO:<${addr}>`, 250);
+                }
+                await cmd(tlsSock, tlsLines, 'DATA', 354);
+                await new Promise<void>((res, rej) =>
+                  tlsSock.write(`${raw}\r\n.\r\n`, (e) => (e ? rej(e) : res())),
+                );
+                const dataReply = await readReply(tlsLines);
+                if (dataReply.code !== 250) {
+                  throw new Error(`SMTP DATA failed: ${dataReply.code} ${dataReply.text}`);
+                }
+                await cmd(tlsSock, tlsLines, 'QUIT', 221);
+                resolve();
+              } catch (e) {
+                reject(e);
+              }
+            },
+          );
+          tlsSock.once('error', reject);
+          return;
         }
-      });
-    }
 
-    /** Read a full SMTP response; handles multi-line 250-... / 250 ... */
-    async function readResponse(expectedCode: string): Promise<string> {
-      let full = '';
-      while (true) {
-        const line = await nextLine();
-        full += (full ? '\n' : '') + line;
-        if (line.startsWith(`${expectedCode} `)) break;
-        if (!line.startsWith(`${expectedCode}-`)) {
-          throw new Error(`SMTP error (expected ${expectedCode}): ${line}`);
-        }
+        resolve();
+      } catch (e) {
+        reject(e);
       }
-      return full;
-    }
-
-    function send(cmd: string): void {
-      (socket as Socket).write(`${cmd}\r\n`);
-    }
-
-    async function run(): Promise<void> {
-      await readResponse('220'); // server greeting
-
-      send('EHLO bulwark');
-      const ehloResp = await readResponse('250');
-
-      if (!smtp.secure && ehloResp.includes('STARTTLS')) {
-        send('STARTTLS');
-        await readResponse('220');
-        const plain = socket as Socket;
-        socket = tlsConnect({ socket: plain, host: smtp.host, rejectUnauthorized: true });
-        socket.on('data', onData);
-        await new Promise<void>((res, rej) => {
-          (socket as TLSSocket).once('secureConnect', res);
-          (socket as TLSSocket).once('error', rej);
-        });
-        send('EHLO bulwark');
-        await readResponse('250');
-      }
-
-      send(`AUTH PLAIN ${authPlain(smtp.user, smtp.pass)}`);
-      await readResponse('235');
-
-      send(`MAIL FROM:<${smtp.from}>`);
-      await readResponse('250');
-
-      send(`RCPT TO:<${toEmail}>`);
-      await readResponse('250');
-
-      send('DATA');
-      await readResponse('354');
-
-      const body = [
-        `From: ${escapeMime(appName)} <${smtp.from}>`,
-        `To: <${toEmail}>`,
-        `Subject: Reset your ${escapeMime(appName)} password`,
-        `MIME-Version: 1.0`,
-        `Content-Type: text/plain; charset=utf-8`,
-        ``,
-        `Hi ${username},`,
-        ``,
-        `Someone requested a password reset for your ${appName} account.`,
-        ``,
-        `Reset link (valid for 1 hour):`,
-        resetLink,
-        ``,
-        `If you did not request this, you can safely ignore this email.`,
-        ``,
-        `\u2013 The ${appName} team`,
-        `.`,
-      ].join('\r\n');
-
-      send(body);
-      await readResponse('250');
-
-      send('QUIT');
-      socket.destroy();
-      resolve();
-    }
-
-    if (smtp.secure) {
-      socket = tlsConnect({ host: smtp.host, port: smtp.port, rejectUnauthorized: true });
-      (socket as TLSSocket).once('secureConnect', () => run().catch(reject));
-    } else {
-      socket = createConnection({ host: smtp.host, port: smtp.port });
-      socket.once('connect', () => run().catch(reject));
-    }
-
-    socket.on('data', onData);
-    socket.once('error', reject);
+    });
   });
 }

--- a/lib/auth/password-reset-store.ts
+++ b/lib/auth/password-reset-store.ts
@@ -1,11 +1,12 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { getStatePath, ensureStateDir } from '@/lib/admin/paths';
+import { logger } from '@/lib/logger';
 
 const TOKEN_FILE = 'password-reset-tokens.json';
-const TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
-const MAX_TOKENS_PER_USER = 3;
-const MIN_REQUEST_INTERVAL_MS = 60 * 1000; // min 1 minute between requests per user
+const TOKEN_TTL_MS = 60 * 60 * 1000;       // 1 hour
+const MAX_ACTIVE_TOKENS = 3;               // per user
+const MIN_REQUEST_INTERVAL_MS = 60 * 1000; // 1 min between requests per user
 
 interface StoredToken {
   hash: string;
@@ -17,77 +18,72 @@ interface StoredToken {
 
 function readStore(): StoredToken[] {
   try {
-    const data = readFileSync(getStatePath(TOKEN_FILE), 'utf-8');
-    return JSON.parse(data) as StoredToken[];
+    return JSON.parse(readFileSync(getStatePath(TOKEN_FILE), 'utf-8')) as StoredToken[];
   } catch {
     return [];
   }
 }
 
-async function writeStore(tokens: StoredToken[]): Promise<void> {
-  await ensureStateDir();
-  writeFileSync(getStatePath(TOKEN_FILE), JSON.stringify(tokens, null, 2), 'utf-8');
+function writeStore(tokens: StoredToken[]): void {
+  try {
+    ensureStateDir();
+    writeFileSync(getStatePath(TOKEN_FILE), JSON.stringify(tokens), 'utf-8');
+  } catch (err) {
+    logger.error('Failed to write password-reset token store', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
 }
 
 function hashToken(raw: string): string {
   return createHash('sha256').update(raw).digest('hex');
 }
 
-export type CreateResetTokenResult = { token: string } | { rateLimited: true } | null;
+export type CreateResetTokenResult =
+  | { token: string }
+  | { rateLimited: true }
+  | null;
 
-/**
- * Generate a new single-use, time-limited reset token for the given username.
- * Returns `{ rateLimited: true }` when the per-user rate limit is hit,
- * or `null` on unexpected errors.
- */
-export async function createResetToken(
+export function createResetToken(
   username: string,
   serverUrl: string,
-): Promise<CreateResetTokenResult> {
+): CreateResetTokenResult {
   const now = Date.now();
-  let tokens = readStore();
+  // Purge expired tokens first
+  let tokens = readStore().filter((t) => now - t.createdAt < TOKEN_TTL_MS);
 
-  // Purge expired and already-used tokens
-  tokens = tokens.filter((t) => !t.usedAt && now - t.createdAt < TOKEN_TTL_MS);
+  const active = tokens.filter((t) => t.username === username && !t.usedAt);
 
-  const userTokens = tokens.filter((t) => t.username === username);
+  // Enforce minimum interval between requests
+  if (active.some((t) => now - t.createdAt < MIN_REQUEST_INTERVAL_MS)) {
+    return { rateLimited: true };
+  }
 
-  // Rate-limit: at least 1 minute must pass since the last request per user
-  const tooRecent = userTokens.some((t) => now - t.createdAt < MIN_REQUEST_INTERVAL_MS);
-  if (tooRecent) return { rateLimited: true };
-
-  // Hard cap on simultaneous active tokens per user
-  if (userTokens.length >= MAX_TOKENS_PER_USER) return { rateLimited: true };
+  // Cap total active tokens per user
+  if (active.length >= MAX_ACTIVE_TOKENS) {
+    return { rateLimited: true };
+  }
 
   const raw = randomBytes(32).toString('hex');
   tokens.push({ hash: hashToken(raw), username, serverUrl, createdAt: now });
-  await writeStore(tokens);
+  writeStore(tokens);
   return { token: raw };
 }
 
-/**
- * Validate and consume a raw token (single-use).
- * Uses constant-time comparison to prevent timing attacks.
- * Returns `null` if the token is invalid, expired, or already used.
- */
-export async function consumeResetToken(
+export function consumeResetToken(
   rawToken: string,
-): Promise<{ username: string; serverUrl: string } | null> {
+): { username: string; serverUrl: string } | null {
   const now = Date.now();
-  let tokens = readStore();
+  let tokens = readStore().filter((t) => now - t.createdAt < TOKEN_TTL_MS);
 
-  // Purge expired tokens
-  tokens = tokens.filter((t) => now - t.createdAt < TOKEN_TTL_MS);
-
-  const targetHash = hashToken(rawToken);
-  const targetBuf = Buffer.from(targetHash, 'hex');
+  const inputHash = hashToken(rawToken);
+  const inputBuf = Buffer.from(inputHash, 'hex');
 
   const idx = tokens.findIndex((t) => {
     if (t.usedAt) return false;
     try {
-      const storedBuf = Buffer.from(t.hash, 'hex');
-      if (storedBuf.length !== targetBuf.length) return false;
-      return timingSafeEqual(storedBuf, targetBuf);
+      return timingSafeEqual(Buffer.from(t.hash, 'hex'), inputBuf);
     } catch {
       return false;
     }
@@ -97,6 +93,6 @@ export async function consumeResetToken(
 
   const match = tokens[idx];
   tokens[idx] = { ...match, usedAt: now };
-  await writeStore(tokens);
+  writeStore(tokens);
   return { username: match.username, serverUrl: match.serverUrl };
 }

--- a/lib/auth/password-reset-store.ts
+++ b/lib/auth/password-reset-store.ts
@@ -1,0 +1,102 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { getStatePath, ensureStateDir } from '@/lib/admin/paths';
+
+const TOKEN_FILE = 'password-reset-tokens.json';
+const TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+const MAX_TOKENS_PER_USER = 3;
+const MIN_REQUEST_INTERVAL_MS = 60 * 1000; // min 1 minute between requests per user
+
+interface StoredToken {
+  hash: string;
+  username: string;
+  serverUrl: string;
+  createdAt: number;
+  usedAt?: number;
+}
+
+function readStore(): StoredToken[] {
+  try {
+    const data = readFileSync(getStatePath(TOKEN_FILE), 'utf-8');
+    return JSON.parse(data) as StoredToken[];
+  } catch {
+    return [];
+  }
+}
+
+async function writeStore(tokens: StoredToken[]): Promise<void> {
+  await ensureStateDir();
+  writeFileSync(getStatePath(TOKEN_FILE), JSON.stringify(tokens, null, 2), 'utf-8');
+}
+
+function hashToken(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+export type CreateResetTokenResult = { token: string } | { rateLimited: true } | null;
+
+/**
+ * Generate a new single-use, time-limited reset token for the given username.
+ * Returns `{ rateLimited: true }` when the per-user rate limit is hit,
+ * or `null` on unexpected errors.
+ */
+export async function createResetToken(
+  username: string,
+  serverUrl: string,
+): Promise<CreateResetTokenResult> {
+  const now = Date.now();
+  let tokens = readStore();
+
+  // Purge expired and already-used tokens
+  tokens = tokens.filter((t) => !t.usedAt && now - t.createdAt < TOKEN_TTL_MS);
+
+  const userTokens = tokens.filter((t) => t.username === username);
+
+  // Rate-limit: at least 1 minute must pass since the last request per user
+  const tooRecent = userTokens.some((t) => now - t.createdAt < MIN_REQUEST_INTERVAL_MS);
+  if (tooRecent) return { rateLimited: true };
+
+  // Hard cap on simultaneous active tokens per user
+  if (userTokens.length >= MAX_TOKENS_PER_USER) return { rateLimited: true };
+
+  const raw = randomBytes(32).toString('hex');
+  tokens.push({ hash: hashToken(raw), username, serverUrl, createdAt: now });
+  await writeStore(tokens);
+  return { token: raw };
+}
+
+/**
+ * Validate and consume a raw token (single-use).
+ * Uses constant-time comparison to prevent timing attacks.
+ * Returns `null` if the token is invalid, expired, or already used.
+ */
+export async function consumeResetToken(
+  rawToken: string,
+): Promise<{ username: string; serverUrl: string } | null> {
+  const now = Date.now();
+  let tokens = readStore();
+
+  // Purge expired tokens
+  tokens = tokens.filter((t) => now - t.createdAt < TOKEN_TTL_MS);
+
+  const targetHash = hashToken(rawToken);
+  const targetBuf = Buffer.from(targetHash, 'hex');
+
+  const idx = tokens.findIndex((t) => {
+    if (t.usedAt) return false;
+    try {
+      const storedBuf = Buffer.from(t.hash, 'hex');
+      if (storedBuf.length !== targetBuf.length) return false;
+      return timingSafeEqual(storedBuf, targetBuf);
+    } catch {
+      return false;
+    }
+  });
+
+  if (idx === -1) return null;
+
+  const match = tokens[idx];
+  tokens[idx] = { ...match, usedAt: now };
+  await writeStore(tokens);
+  return { username: match.username, serverUrl: match.serverUrl };
+}

--- a/lib/auth/reset-rate-limit.ts
+++ b/lib/auth/reset-rate-limit.ts
@@ -1,10 +1,10 @@
 /**
- * In-memory rate limiter for password-reset requests.
- * Max 5 attempts per IP per 15 minutes — mirrors lib/admin/rate-limit.ts.
+ * In-memory rate limiter for the forgot-password endpoint.
+ * 5 requests per IP per 15 minutes — mirrors the admin login limiter.
  */
 
 const MAX_ATTEMPTS = 5;
-const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const WINDOW_MS = 15 * 60 * 1000;
 
 interface RateLimitEntry {
   count: number;
@@ -13,30 +13,20 @@ interface RateLimitEntry {
 
 const attempts = new Map<string, RateLimitEntry>();
 
-// Clean up expired entries periodically
 setInterval(() => {
   const now = Date.now();
   for (const [key, entry] of attempts) {
-    if (entry.resetAt <= now) {
-      attempts.delete(key);
-    }
+    if (entry.resetAt <= now) attempts.delete(key);
   }
 }, 60_000).unref();
 
-/**
- * Check if the IP is rate limited.
- * Returns whether the request is allowed, plus diagnostics.
- */
-export function checkResetRateLimit(ip: string): {
-  allowed: boolean;
-  remaining: number;
-  retryAfterMs: number;
-} {
+export function checkResetRateLimit(
+  ip: string,
+): { allowed: boolean; remaining: number; retryAfterMs: number } {
   const now = Date.now();
   const entry = attempts.get(ip);
 
   if (!entry || entry.resetAt <= now) {
-    // New window
     attempts.set(ip, { count: 1, resetAt: now + WINDOW_MS });
     return { allowed: true, remaining: MAX_ATTEMPTS - 1, retryAfterMs: 0 };
   }

--- a/lib/auth/reset-rate-limit.ts
+++ b/lib/auth/reset-rate-limit.ts
@@ -1,0 +1,50 @@
+/**
+ * In-memory rate limiter for password-reset requests.
+ * Max 5 attempts per IP per 15 minutes — mirrors lib/admin/rate-limit.ts.
+ */
+
+const MAX_ATTEMPTS = 5;
+const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+const attempts = new Map<string, RateLimitEntry>();
+
+// Clean up expired entries periodically
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of attempts) {
+    if (entry.resetAt <= now) {
+      attempts.delete(key);
+    }
+  }
+}, 60_000).unref();
+
+/**
+ * Check if the IP is rate limited.
+ * Returns whether the request is allowed, plus diagnostics.
+ */
+export function checkResetRateLimit(ip: string): {
+  allowed: boolean;
+  remaining: number;
+  retryAfterMs: number;
+} {
+  const now = Date.now();
+  const entry = attempts.get(ip);
+
+  if (!entry || entry.resetAt <= now) {
+    // New window
+    attempts.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+    return { allowed: true, remaining: MAX_ATTEMPTS - 1, retryAfterMs: 0 };
+  }
+
+  if (entry.count >= MAX_ATTEMPTS) {
+    return { allowed: false, remaining: 0, retryAfterMs: entry.resetAt - now };
+  }
+
+  entry.count++;
+  return { allowed: true, remaining: MAX_ATTEMPTS - entry.count, retryAfterMs: 0 };
+}

--- a/lib/auth/stalwart-admin.ts
+++ b/lib/auth/stalwart-admin.ts
@@ -1,12 +1,11 @@
+import { logger } from '@/lib/logger';
+
 /**
- * Stalwart Management API helpers.
+ * Update a Stalwart account password via the Management API.
  *
- * Requires an admin Bearer token with permission to update principals.
- * Configure via STALWART_ADMIN_API_URL + STALWART_ADMIN_API_TOKEN env vars.
- *
- * API reference:
- *   PATCH /api/principal/{username}
- *   Body: [{ "action": "set", "field": "secret", "value": "<password>" }]
+ * Requires an admin Bearer token with `principal/set` permission.
+ * Endpoint: PATCH /api/principal/{username}
+ * Body: [{"action":"set","field":"secret","value":"<newpassword>"}]
  */
 export async function setStalwartPassword(
   adminApiUrl: string,
@@ -14,7 +13,9 @@ export async function setStalwartPassword(
   username: string,
   newPassword: string,
 ): Promise<void> {
-  const url = `${adminApiUrl.replace(/\/$/, '')}/api/principal/${encodeURIComponent(username)}`;
+  const base = adminApiUrl.replace(/\/$/, '');
+  const url = `${base}/api/principal/${encodeURIComponent(username)}`;
+
   const res = await fetch(url, {
     method: 'PATCH',
     headers: {
@@ -23,8 +24,12 @@ export async function setStalwartPassword(
     },
     body: JSON.stringify([{ action: 'set', field: 'secret', value: newPassword }]),
   });
+
   if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`Stalwart API error ${res.status}: ${text}`);
+    const body = await res.text().catch(() => '');
+    logger.warn('Stalwart password update failed', { username, status: res.status, body });
+    throw new Error(`Stalwart API returned ${res.status}`);
   }
+
+  logger.info('Stalwart password updated via admin API', { username });
 }

--- a/lib/auth/stalwart-admin.ts
+++ b/lib/auth/stalwart-admin.ts
@@ -1,0 +1,30 @@
+/**
+ * Stalwart Management API helpers.
+ *
+ * Requires an admin Bearer token with permission to update principals.
+ * Configure via STALWART_ADMIN_API_URL + STALWART_ADMIN_API_TOKEN env vars.
+ *
+ * API reference:
+ *   PATCH /api/principal/{username}
+ *   Body: [{ "action": "set", "field": "secret", "value": "<password>" }]
+ */
+export async function setStalwartPassword(
+  adminApiUrl: string,
+  adminToken: string,
+  username: string,
+  newPassword: string,
+): Promise<void> {
+  const url = `${adminApiUrl.replace(/\/$/, '')}/api/principal/${encodeURIComponent(username)}`;
+  const res = await fetch(url, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify([{ action: 'set', field: 'secret', value: newPassword }]),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Stalwart API error ${res.status}: ${text}`);
+  }
+}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -60,7 +60,8 @@
       "token_exchange_failed": "Failed to complete authentication. Please try again.",
       "access_denied": "Access was denied. Please contact your administrator.",
       "back_to_login": "Back to login"
-    }
+    },
+    "forgot_password": "Forgot password?"
   },
   "sidebar": {
     "close": "Close",
@@ -2929,5 +2930,29 @@
   },
   "unified_mailbox": {
     "search_unavailable": "Search is not available in the unified view"
+  },
+  "forgot_password": {
+    "title": "Reset Password",
+    "subtitle": "Enter your email address and we’ll send you a reset link.",
+    "email_label": "Email / Username",
+    "email_placeholder": "you@example.com",
+    "submit_button": "Send Reset Link",
+    "sending": "Sending…",
+    "success_message": "If an account with that address exists, a reset link has been sent. Please check your inbox.",
+    "back_to_login": "Back to Sign In",
+    "error_generic": "Something went wrong. Please try again.",
+    "reset_title": "Set New Password",
+    "reset_subtitle": "Enter your new password below.",
+    "password_label": "New Password",
+    "password_placeholder": "Minimum 8 characters",
+    "confirm_label": "Confirm Password",
+    "confirm_placeholder": "Repeat your new password",
+    "reset_button": "Reset Password",
+    "resetting": "Resetting…",
+    "reset_success": "Your password has been reset. You can now sign in.",
+    "error_password_mismatch": "Passwords do not match.",
+    "error_password_too_short": "Password must be at least 8 characters.",
+    "error_invalid_token": "This reset link is invalid or has expired.",
+    "error_missing_token": "No reset token found in this link."
   }
 }


### PR DESCRIPTION
## Forgot Password / Reset by Email

Adds a complete self-service password-reset flow for Bulwark Webmail backed by the **Stalwart Management API**.

---

### What this adds

| File | Change |
|---|---|
| `lib/auth/reset-rate-limit.ts` | IP-based rate limiter (5 req / 15 min) — mirrors `lib/admin/rate-limit.ts` pattern |
| `lib/auth/password-reset-store.ts` | File-based token store in state dir; SHA-256 stored, `timingSafeEqual` compare, 1 h TTL, max 3 active tokens / user |
| `lib/auth/password-reset-mailer.ts` | Zero-dependency SMTP using `node:net` + `node:tls` (STARTTLS + AUTH PLAIN) — no new `npm` deps |
| `lib/auth/stalwart-admin.ts` | `setStalwartPassword()` — `PATCH /api/principal/{username}` via Stalwart Management API |
| `app/api/auth/forgot-password/route.ts` | POST endpoint — feature flag → rate limit → create token → send email. Always returns `{ ok: true }` (anti-enumeration) |
| `app/api/auth/reset-password/route.ts` | POST endpoint — validates token → validates password ≥ 8 chars → `consumeResetToken` → `setStalwartPassword` |
| `app/[locale]/forgot-password/page.tsx` | "Forgot password" page — username field, anti-enumeration success message, matches login card style |
| `app/[locale]/reset-password/page.tsx` | "Set new password" page — reads `?token=` from URL, confirm-password field, auto-redirects to login on success |
| `lib/admin/types.ts` | 10 new `CONFIG_ENV_MAP` keys + `SENSITIVE_CONFIG_KEYS` entries |
| `app/[locale]/login/page.tsx` | Adds conditional "Forgot password?" link below the password label |
| `locales/en/common.json` | Adds `login.forgot_password` key + full `forgot_password` namespace (22 strings) |

---

### Environment variables

| Variable | Purpose | Default |
|---|---|---|
| `FORGOT_PASSWORD_ENABLED` | Enable the feature (opt-in) | `false` |
| `STALWART_ADMIN_API_URL` | Stalwart management API base URL | — |
| `STALWART_ADMIN_API_TOKEN` / `_FILE` | Admin bearer token | — |
| `RESET_SMTP_HOST` | SMTP server hostname | — |
| `RESET_SMTP_PORT` | SMTP port | `587` |
| `RESET_SMTP_SECURE` | `true` = implicit TLS, `false` = STARTTLS | `false` |
| `RESET_SMTP_USER` | SMTP auth username | — |
| `RESET_SMTP_PASS` / `_FILE` | SMTP auth password | — |
| `RESET_FROM_EMAIL` | From address for reset emails | — |
| `RESET_APP_BASE_URL` | Public base URL for reset links (e.g. `https://mail.example.com`) | — |

All sensitive values (`STALWART_ADMIN_API_TOKEN`, `RESET_SMTP_PASS`) are in `SENSITIVE_CONFIG_KEYS` and never exposed to the client.

---

### Security design

- **Anti-enumeration**: forgot-password endpoint always returns `{ ok: true }` regardless of whether the username exists
- **Constant-time comparison**: `crypto.timingSafeEqual` for token validation
- **Single-use tokens**: consumed immediately on first valid use
- **IP rate limiting**: 5 requests per IP per 15 minutes (same pattern as the admin panel)
- **Per-user rate limiting**: max 3 active tokens, minimum 1 minute between requests per user
- **Token TTL**: 1 hour, SHA-256 hashed at rest
- **Token storage**: file-based in the existing state dir (`lib/admin/paths.ts`), consistent with `admin-state.json`
- **No new dependencies**: SMTP implemented with Node.js built-in `net`/`tls` modules

---

### How it works

1. User clicks **"Forgot password?"** on the login page (only shown when `FORGOT_PASSWORD_ENABLED=true`)
2. Enters their email/username → POST `/api/auth/forgot-password`
3. A time-limited reset link is emailed: `{RESET_APP_BASE_URL}/{locale}/reset-password?token=<raw>`
4. User clicks link → `/reset-password` page → enters new password
5. POST `/api/auth/reset-password` → token consumed → Stalwart admin API updates the password
6. User is redirected to login after 3 seconds

---

### Notes

- The feature is **opt-in** (`FORGOT_PASSWORD_ENABLED=false` by default) so existing deployments are unaffected
- Works with Stalwart Mail Server only (uses the Management API bearer-token path)
- Follows Bulwark code conventions throughout: `configManager`, `logger`, `getStatePath`, rate-limit Map pattern, `NextRequest`/`NextResponse` API routes, `useConfig()` hook, `useTranslations()` i18n
