### PR TITLE
fix(email-viewer): mobile body padding + no-wrap Show details

### DIFF
--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -3781,7 +3781,7 @@ export function EmailViewer({
                 )}
                 <button
                   onClick={() => setShowFullHeaders(!showFullHeaders)}
-                  className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-0.5 transition-colors ml-1"
+                  className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-0.5 transition-colors ml-1 whitespace-nowrap shrink-0"
                 >
                   {showFullHeaders ? (
                     <>
@@ -4575,7 +4575,7 @@ export function EmailViewer({
           <PluginSlot name="email-banner" extraProps={{ email }} />
 
           {/* Email Body */}
-          <div className="email-content-wrapper overflow-x-auto">
+          <div className="email-content-wrapper overflow-x-auto px-4 py-2">
             {effectiveEmailContent.isHtml ? (
               <iframe
                 ref={iframeRef}


### PR DESCRIPTION
On mobile the message body renders flush to the edge (no side padding), and the `Show details` toggle wraps to two lines.

**Changes** (`components/email/email-viewer.tsx`):
- `email-content-wrapper`: add `px-4 py-2` so body text/plain-text emails aren't flush to the container edge.
- Show/Hide details toggle: add `whitespace-nowrap shrink-0` so the label stays on one line.

Cosmetic only; no logic change. Tested on a 320px viewport.