### PR TITLE
fix(email): small gutter for plain-text emails on mobile

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -242,8 +242,8 @@ body {
 
 @media (max-width: 640px) {
   .email-content-text {
-    padding-left: 0;
-    padding-right: 0;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
   }
 }
 


### PR DESCRIPTION
### Problem
On phones (`max-width: 640px`), `globals.css` zeroes the horizontal padding of `.email-content-text`:

```css
@media (max-width: 640px) {
  .email-content-text { padding-left: 0; padding-right: 0; }
}
```

Plain-text (prose) emails then render **flush against the viewport edge** on mobile, which hurts readability — the text touches the screen border with no gutter.

### Change
Use a reduced **0.75rem** gutter on mobile instead of `0` (desktop stays at `1rem 1.25rem`). This still maximizes width for wide/quoted content but keeps prose off the screen edge.

This only affects the plain-text branch (`.email-content-text`); styled HTML emails (iframe) are unaffected — they keep their own `hasStyleTag`-conditional padding.

Cosmetic, one rule.