### PR TITLE
fix: prevent incomplete JMAP server entries from being submitted

### DIFF
--- a/app/(main)/admin/_tabs/_jmap-servers-section.tsx
+++ b/app/(main)/admin/_tabs/_jmap-servers-section.tsx
@@ -97,11 +97,20 @@ export function JmapServersSection({ value, source, onChange, onRevert }: Props)
   function commit(next: RowDraft[]) {
     setDrafts(next);
     const entries: JmapServerEntry[] = [];
+    let hasIncomplete = false;
+
     for (const d of next) {
       const e = draftToEntry(d);
-      if (e) entries.push(e);
+      if (e) {
+        entries.push(e);
+      } else if (d.id.trim() || d.url.trim() || d.domains.trim() || d.oauthClientId.trim() || d.oauthIssuerUrl.trim() || d.oauthClientSecret) {
+        hasIncomplete = true;
+      }
     }
-    onChange(entries);
+
+    if (!hasIncomplete) {
+      onChange(entries);
+    }
   }
 
   function update(idx: number, patch: Partial<RowDraft>) {


### PR DESCRIPTION
## Summary

Admin > Settings > JMAP Servers (multi-server) > Fix bug where editing any field closed the form.

## Changes

commit() previously called onChange() on every edit, which could propagate an empty array when a row was partially filled and cause the parent to reset/unmount the form. Now onChange() is only called when there are no incomplete drafts, preventing accidental form closure.

- 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

https://github.com/user-attachments/assets/2f9ee627-0fec-4968-abc9-576fcf82c0a9


## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
