### PR TITLE
fix(email-viewer): stop shattering table cells with word-break: break-word

### DIFF
--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -2866,7 +2866,7 @@ export function EmailViewer({
   img { max-width: 100% !important; height: auto !important; }
   a { color: #1a73e8; }
   table { max-width: 100% !important; table-layout: auto; overflow-wrap: break-word; }
-  td, th { word-break: break-word; }
+  td, th { overflow-wrap: anywhere; }
   pre { white-space: pre-wrap; word-wrap: break-word; }
   ${wordHtmlCSS}
   ${darkModeCSS}


### PR DESCRIPTION
### Issue

Closes #341.

### What changed

components/email/email-viewer.tsx:

\`\`\`diff
-  td, th { word-break: break-word; }
+  td, th { overflow-wrap: anywhere; }
\`\`\`

### Why

\`word-break: break-word\` is a non-standard alias that some engines treat as \`break-all\` — it breaks ordinary words at arbitrary character boundaries, even when the word would fit if the column auto-expanded. The result for HTML-email tables with short Hebrew/Arabic/CJK headers (or long English strings) is column content collapsing to one glyph per row.

\`overflow-wrap: anywhere\` is the spec-blessed equivalent of "break long words ONLY when they would otherwise overflow", and it also relaxes the cell's min-content width so RTL tables no longer force horizontal scroll.

The rest of the iframe CSS already sets \`overflow-wrap: break-word\` on \`body\` and the table, so swapping the td/th rule keeps the same overflow semantics without re-introducing break-all behaviour.

### Test plan

* Hebrew/RTL transactional email — column headers now render single-line.
* English email with long unbroken strings (e.g. raw URLs in a table cell) — still wraps correctly.
* Mixed-language tables — no regressions observed.