### PR TITLE
feat(composer): Ctrl+Enter / Cmd+Enter sends the open draft

### DIFF
--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -854,6 +854,7 @@ export function EmailComposer({
     return () => window.removeEventListener('keydown', handleTemplateKey);
   }, []);
 
+
   const addFiles = useCallback(async (files: File[]) => {
     if (!client || files.length === 0) return;
 
@@ -1573,6 +1574,28 @@ export function EmailComposer({
       toast.error(t('send_failed'));
     }
   };
+
+  // Ctrl+Enter (Windows/Linux) / Cmd+Enter (macOS) sends the open
+  // compose draft — same as every other major mail client. Fires
+  // even when focus is inside the To/Cc/Bcc chips, subject input,
+  // body textarea, or the rich-text editor's contentEditable region.
+  // Plain Enter in the body still inserts a newline; only Enter +
+  // the platform modifier sends. handleSend is rebound every render,
+  // so we route through a ref to keep the window listener stable.
+  const handleSendRef = useRef<(skipAttachmentCheck?: boolean) => Promise<void>>();
+  handleSendRef.current = handleSend;
+  useEffect(() => {
+    const handleSendShortcut = (e: KeyboardEvent) => {
+      if (e.key !== 'Enter') return;
+      if (!(e.ctrlKey || e.metaKey)) return;
+      // Don't hijack autocomplete-confirm or chip-commit Enters.
+      if (e.altKey || e.shiftKey) return;
+      e.preventDefault();
+      void handleSendRef.current?.();
+    };
+    window.addEventListener('keydown', handleSendShortcut);
+    return () => window.removeEventListener('keydown', handleSendShortcut);
+  }, []);
 
   const cleanClose = () => {
     if (saveTimeoutRef.current) {

--- a/hooks/use-keyboard-shortcuts.ts
+++ b/hooks/use-keyboard-shortcuts.ts
@@ -290,5 +290,6 @@ export const KEYBOARD_SHORTCUTS = {
   ],
   composer: [
     { key: "t", description: "shortcuts.composer.template_picker" },
+    { key: "Ctrl/Cmd + Enter", description: "shortcuts.composer.send" },
   ],
 } as const;

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1882,7 +1882,8 @@
       "expand_collapse": "Expand/collapse thread"
     },
     "composer": {
-      "template_picker": "Open template picker"
+      "template_picker": "Open template picker",
+      "send": "Send email"
     }
   },
   "threads": {


### PR DESCRIPTION
Closes #343.

### Summary

Adds the universal \"send-with-platform-modifier\" keyboard shortcut every mainstream mail client supports: \`Ctrl+Enter\` on Windows/Linux, \`Cmd+Enter\` on macOS. The shortcut routes through the existing \`handleSend\` path, so attachment warnings, draft-save, undo-send and all other validation flows continue to apply unchanged.

### What changed

* \`components/email/email-composer.tsx\` — new window-level keydown listener registered while the composer is mounted. Routes through a ref so per-render rebinds of \`handleSend\` don't re-register the listener.
* \`hooks/use-keyboard-shortcuts.ts\` — adds the entry to \`KEYBOARD_SHORTCUTS.composer\` so the dialog lists it.
* \`locales/en/common.json\` — adds the new translation key.

### Behaviour rules

| Keys | Effect |
|------|--------|
| Plain \`Enter\` in body / chip input | unchanged (newline / commit chip) |
| \`Ctrl + Enter\` (Win/Linux) | send |
| \`Cmd + Enter\` (macOS) | send |
| \`Shift/Alt + Ctrl/Cmd + Enter\` | ignored (lets existing chord patterns through) |

### Test plan

* Compose -> type body -> \`Ctrl+Enter\` -> goes to Outbox.
* \`Cmd+Enter\` on macOS Safari/Chrome -> same.
* Cc/Bcc autocomplete -> arrow + Enter still picks suggestion (no modifier, listener bails).
* Subject input focused + \`Ctrl+Enter\` -> sends.
* Body \`Enter\` without modifier -> newline.
* Send Failure (toast shown) -> shortcut can be retried.

### Notes

Locale strings are added for \`en\` only. Other languages fall back to the English key via next-intl's default chain until translators get to it.