### PR TITLE
feat: route Sent copy to shared-mailbox account on per-identity send

### DIFF
--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -2153,7 +2153,13 @@ export class JMAPClient implements IJMAPClient {
   ): Promise<SendEmailResult> {
     const holdForSeconds = delayedUntil ? this.validateDelayedUntil(delayedUntil) : undefined;
     const emailId = `send-${Date.now()}`;
-    const mailboxes = await this.getMailboxes();
+    const targetAccountId = (fromEmail && Object.keys(this.accounts).find(id =>
+      this.accounts[id]?.name?.toLowerCase() === fromEmail.toLowerCase()
+    )) || this.accountId;
+    const mboxResp = await this.request([
+      ["Mailbox/get", { accountId: targetAccountId }, "0"]
+    ]);
+    const mailboxes = (mboxResp.methodResponses?.[0]?.[1]?.list || []) as Mailbox[];
     const sentMailbox = mailboxes.find(mb => mb.role === 'sent');
     if (!sentMailbox) {
       throw new Error('No sent mailbox found');
@@ -2167,25 +2173,25 @@ export class JMAPClient implements IJMAPClient {
     let identityReplyTo: EmailAddress[] | undefined;
     {
       const identityResponse = await this.request([
-        ["Identity/get", { accountId: this.accountId }, "0"]
+        ["Identity/get", { accountId: targetAccountId }, "0"]
       ]);
 
       if (!finalIdentityId) {
-        finalIdentityId = this.accountId;
+        finalIdentityId = targetAccountId;
       }
       if (identityResponse.methodResponses?.[0]?.[0] === "Identity/get") {
         const identities = (identityResponse.methodResponses[0][1].list || []) as Identity[];
         if (identities.length > 0) {
-          if (!identityId) {
+          let matchingIdentity = identityId
+            ? identities.find((id) => id.id === identityId)
+            : undefined;
+          if (!matchingIdentity) {
             const target = fromEmail || this.username;
-            const matchingIdentity = identities.find((id) => id.email === target)
+            matchingIdentity = identities.find((id) => id.email === target)
               || (!target.includes('@') ? identities.find((id) => id.email.split('@')[0] === target) : undefined);
-            finalIdentityId = matchingIdentity?.id || identities[0].id;
-            identityReplyTo = matchingIdentity?.replyTo || identities[0].replyTo;
-          } else {
-            const matchedIdentity = identities.find((id) => id.id === identityId);
-            identityReplyTo = matchedIdentity?.replyTo;
           }
+          finalIdentityId = matchingIdentity?.id || identities[0].id;
+          identityReplyTo = matchingIdentity?.replyTo || identities[0].replyTo;
         }
       }
     }
@@ -2278,21 +2284,21 @@ export class JMAPClient implements IJMAPClient {
         destroy: [draftId],
       }, "0"]);
       methodCalls.push(["Email/set", {
-        accountId: this.accountId,
+        accountId: targetAccountId,
         create: { [emailId]: emailCreate },
       }, "1"]);
       methodCalls.push(["EmailSubmission/set", {
-        accountId: this.getSubmissionAccountId(),
+        accountId: this.getSubmissionAccountId(targetAccountId),
         create: buildSubmissionCreate("1"),
         onSuccessUpdateEmail,
       }, "2"]);
     } else {
       methodCalls.push(["Email/set", {
-        accountId: this.accountId,
+        accountId: targetAccountId,
         create: { [emailId]: emailCreate },
       }, "0"]);
       methodCalls.push(["EmailSubmission/set", {
-        accountId: this.getSubmissionAccountId(),
+        accountId: this.getSubmissionAccountId(targetAccountId),
         create: buildSubmissionCreate("1"),
         onSuccessUpdateEmail,
       }, "1"]);


### PR DESCRIPTION
## Summary

When you send from a Principal with shared mailboxes the Sent copy lands in the primary Sent folder, not the shared one. 
This Feature puts the Email in the sent of the used Shared mailbox.


## Changes

  - route send-path through `targetAccountId` when `fromEmail` matches a shared-mailbox account
  - fall back to email-match for identity when id lookup fails in the target account
  -   -   - 
## Related Issues

Related to Group mails from #61 

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

You can test it out by sending from a Email from a Principal which has shared emails 

## Notes for Reviewers

This could also be done for drafts but would maybe need a small discussion beforehand
