### PR TITLE
fix: preserve HTML signature when sending a quick reply

### DIFF
--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -55,7 +55,7 @@ import { useProMultiAccountMailboxes } from "@/hooks/use-pro-multi-account-mailb
 import { Input } from "@/components/ui/input";
 import { FilePreviewModal } from "@/components/files/file-preview-modal";
 import { isFilePreviewable } from "@/lib/file-preview";
-import { appendPlainTextSignature } from "@/lib/signature-utils";
+import { appendHtmlSignature, appendPlainTextSignature } from "@/lib/signature-utils";
 import { computeReplyThreadingHeaders } from "@/lib/email-threading";
 import { EML_IMPORT_ACCEPT, expandImportableEmails } from "@/lib/eml-import";
 import { resolveReplyFrom } from "@/lib/reply-identity";
@@ -2090,9 +2090,21 @@ export default function Home() {
 
     // Append signature from the sending identity (fall back to primary
     // when the reply-from lives on the same identity but a different alias).
-    const finalBody = appendPlainTextSignature(body, sendingIdentity, {
-      separator: useSettingsStore.getState().signatureSeparatorEnabled,
-    });
+    const separator = useSettingsStore.getState().signatureSeparatorEnabled;
+    const finalBody = appendPlainTextSignature(body, sendingIdentity, { separator });
+
+    // When the identity has an HTML signature, send a matching HTML body so the
+    // signature keeps its formatting; appendPlainTextSignature would otherwise
+    // flatten it to plain text. Text-only identities keep the plain-text-only
+    // behavior (htmlBody stays undefined).
+    const escapedBody = body
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\n/g, '<br>');
+    const finalHtmlBody = sendingIdentity?.htmlSignature?.trim()
+      ? appendHtmlSignature(`<div>${escapedBody}</div>`, sendingIdentity, { separator })
+      : undefined;
 
     const originalEmailId = selectedEmail.id;
     const sendDelaySeconds = useSettingsStore.getState().sendDelaySeconds;
@@ -2124,7 +2136,7 @@ export default function Home() {
       headerFromEmail,
       undefined,
       headerFromName,
-      undefined,
+      finalHtmlBody,
       undefined,
       threading?.inReplyTo,
       threading?.references,

--- a/app/api/dev-jmap/[...path]/route.ts
+++ b/app/api/dev-jmap/[...path]/route.ts
@@ -723,7 +723,18 @@ const emails: MockEmail[] = [
 // Identities
 // ---------------------------------------------------------------------------
 
-const IDENTITIES = [
+type MockIdentity = {
+  id: string;
+  name: string;
+  email: string;
+  replyTo: Array<{ name?: string; email: string }> | null;
+  bcc: Array<{ name?: string; email: string }> | null;
+  textSignature: string | null;
+  htmlSignature: string | null;
+  mayDelete: boolean;
+};
+
+const IDENTITIES: MockIdentity[] = [
   {
     id: 'identity-001',
     name: 'Dev User',
@@ -1562,13 +1573,55 @@ function handleIdentityGet(_args: MethodArgs, callId: string): MethodResult {
 
 function handleIdentitySet(args: MethodArgs, callId: string): MethodResult {
   const created: Record<string, { id: string }> = {};
-  const create = args.create as Record<string, unknown> | undefined;
+  const updated: Record<string, null> = {};
+  const destroyed: string[] = [];
+
+  const create = args.create as Record<string, Record<string, unknown>> | undefined;
   if (create) {
-    for (const key of Object.keys(create)) {
-      created[key] = { id: `identity-new-${Date.now()}-${key}` };
+    for (const [key, data] of Object.entries(create)) {
+      const newId = `identity-${Date.now()}-${key}`;
+      IDENTITIES.push({
+        id: newId,
+        name: (data.name as string) || '',
+        email: (data.email as string) || '',
+        replyTo: (data.replyTo as MockIdentity['replyTo']) ?? null,
+        bcc: (data.bcc as MockIdentity['bcc']) ?? null,
+        textSignature: (data.textSignature as string | null) ?? null,
+        htmlSignature: (data.htmlSignature as string | null) ?? null,
+        mayDelete: true,
+      });
+      created[key] = { id: newId };
     }
   }
-  return ['Identity/set', { accountId: ACCOUNT_ID, oldState: nextState(), newState: nextState(), created, updated: null, destroyed: null }, callId];
+
+  const update = args.update as Record<string, Record<string, unknown>> | undefined;
+  if (update) {
+    for (const [id, changes] of Object.entries(update)) {
+      const identity = IDENTITIES.find((i) => i.id === id);
+      if (identity) {
+        // Email is immutable per the identity form, so it's never in `changes`.
+        if (changes.name !== undefined) identity.name = changes.name as string;
+        if (changes.replyTo !== undefined) identity.replyTo = changes.replyTo as MockIdentity['replyTo'];
+        if (changes.bcc !== undefined) identity.bcc = changes.bcc as MockIdentity['bcc'];
+        if (changes.textSignature !== undefined) identity.textSignature = changes.textSignature as string | null;
+        if (changes.htmlSignature !== undefined) identity.htmlSignature = changes.htmlSignature as string | null;
+        updated[id] = null;
+      }
+    }
+  }
+
+  const destroy = args.destroy as string[] | undefined;
+  if (destroy) {
+    for (const id of destroy) {
+      const idx = IDENTITIES.findIndex((i) => i.id === id);
+      if (idx !== -1) {
+        IDENTITIES.splice(idx, 1);
+        destroyed.push(id);
+      }
+    }
+  }
+
+  return ['Identity/set', { accountId: ACCOUNT_ID, oldState: nextState(), newState: nextState(), created, updated, destroyed, notCreated: null, notUpdated: null, notDestroyed: null }, callId];
 }
 
 function handleThreadGet(args: MethodArgs, callId: string): MethodResult {

--- a/lib/__tests__/signature-utils.test.ts
+++ b/lib/__tests__/signature-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  appendHtmlSignature,
   appendPlainTextSignature,
   getPlainTextSignature,
   hasMeaningfulHtmlBody,
@@ -24,6 +25,27 @@ describe('signature-utils', () => {
 
     it('leaves the body untouched when no signature exists', () => {
       expect(appendPlainTextSignature('Hello there', {})).toBe('Hello there');
+    });
+  });
+
+  describe('appendHtmlSignature', () => {
+    it('appends a sanitized html signature, preserving formatting', () => {
+      expect(appendHtmlSignature('<div>Hello</div>', { htmlSignature: '<strong>Alice</strong>' }))
+        .toBe('<div>Hello</div><br><br>-- <br><strong>Alice</strong>');
+    });
+
+    it('escapes and appends a text signature when no html signature exists', () => {
+      expect(appendHtmlSignature('<div>Hello</div>', { textSignature: 'Alice\nEng' }))
+        .toBe('<div>Hello</div><br><br>-- <br>Alice<br>Eng');
+    });
+
+    it('omits the separator marker when disabled', () => {
+      expect(appendHtmlSignature('<div>Hi</div>', { htmlSignature: '<strong>A</strong>' }, { separator: false }))
+        .toBe('<div>Hi</div><br><br><strong>A</strong>');
+    });
+
+    it('leaves the body untouched when no signature exists', () => {
+      expect(appendHtmlSignature('<div>Hi</div>', {})).toBe('<div>Hi</div>');
     });
   });
 

--- a/lib/signature-utils.ts
+++ b/lib/signature-utils.ts
@@ -124,6 +124,35 @@ export function appendPlainTextSignature(
   return `${body}${sep}${plainTextSignature}`;
 }
 
+/**
+ * Append a signature to an HTML body, preserving rich formatting. Used by the
+ * quick-reply path so an HTML signature keeps its markup instead of being
+ * flattened to plain text. Mirrors the composer's send-time signature block
+ * (`buildSignatureHtml` in email-composer.tsx).
+ */
+export function appendHtmlSignature(
+  htmlBody: string,
+  signature?: SignatureSource | null,
+  options: { separator?: boolean } = {},
+): string {
+  const sep = options.separator === false ? '<br><br>' : '<br><br>-- <br>';
+
+  if (signature?.htmlSignature?.trim()) {
+    return `${htmlBody}${sep}${sanitizeSignatureHtml(signature.htmlSignature)}`;
+  }
+
+  if (signature?.textSignature?.trim()) {
+    const escaped = signature.textSignature
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\n/g, '<br>');
+    return `${htmlBody}${sep}${escaped}`;
+  }
+
+  return htmlBody;
+}
+
 export function hasMeaningfulHtmlBody(html: string): boolean {
   if (!html.trim()) return false;
 


### PR DESCRIPTION
## What

Quick replies (the **"Write a quick reply…"** box in the reading pane) sent the
identity's signature as **plain text**, even when the identity has an HTML
signature that previews correctly in the identity editor.

`handleQuickReply` built its body with `appendPlainTextSignature`, which runs the
HTML signature through `htmlToPlainText`, and passed `undefined` for `sendEmail`'s
`htmlBody`. So a formatted signature (e.g. `<strong>…</strong>`) was flattened to
plain text in the sent mail. The full `EmailComposer` already builds an HTML
signature block on send (`buildSignatureHtml`); the quick-reply path did not.

## Fix

- Add `appendHtmlSignature(htmlBody, signature, { separator })` to `lib/signature-utils.ts`,
  mirroring the composer's send-time signature block (sanitized HTML signature, or an
  escaped text signature as fallback).
- In `handleQuickReply`, when the sending identity has an HTML signature, build a
  matching HTML body and pass it as `htmlBody`. Text-only identities keep the existing
  plain-text-only behavior (no `htmlBody`).

## Why two commits

- `feat(dev-jmap): persist identity create/update/destroy in mock server` — the dev mock's
  `Identity/set` discarded its payload, so identities didn't round-trip locally. Persisting
  them (mirroring `handleMailboxSet`) was needed to exercise/verify signature behavior
  without a real JMAP server.
- `fix: preserve HTML signature when sending a quick reply` — the actual bug fix.

## Testing

- `npm run typecheck` — passes.
- `eslint` on changed files — clean (0 errors).
- New unit tests for `appendHtmlSignature` (formatting preserved, text fallback, separator
  toggle, empty signature).
- Drove the app end-to-end in a browser (dev mock) and intercepted the outgoing JMAP
  `Email/set`. The sent payload now contains both a text part **and** an HTML part whose
  signature markup is preserved:

  ```
  textBody:  …\n-- \nDev User\nBulwark Webmail Developer
  htmlBody:  <div>…</div><br><br>-- <br><p>Dev User<br><em>Bulwark Webmail Developer</em></p>
  ```

  Before the fix, `htmlBody` was absent and the signature arrived as plain text.

No new user-facing strings, so no i18n changes.
