### PR TITLE
Fix: honour basePath in plugin sandbox, http.post proxy, and branding

### DIFF
--- a/app/(main)/admin/_tabs/branding.tsx
+++ b/app/(main)/admin/_tabs/branding.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Save, Loader2, RotateCcw, ImageIcon, Upload, Trash2, Globe, Plus, X } from 'lucide-react';
-import { apiFetch } from '@/lib/browser-navigation';
+import { apiFetch, withBasePath } from '@/lib/browser-navigation';
 import {
   BRANDING_OVERRIDE_KEYS,
   parseDomainBranding,
@@ -528,7 +528,7 @@ export function BrandingTab() {
                   <ImageIcon className="w-3.5 h-3.5 text-muted-foreground" />
                   <div className="h-8 w-auto bg-muted rounded flex items-center justify-center px-2">
                     <img
-                      src={currentValue(field.key)}
+                      src={withBasePath(currentValue(field.key))}
                       alt={field.label}
                       className="max-h-6 max-w-[200px] object-contain"
                       onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
@@ -606,7 +606,7 @@ export function BrandingTab() {
                   <ImageIcon className="w-3.5 h-3.5 text-muted-foreground" />
                   <div className="h-8 w-auto bg-muted rounded flex items-center justify-center px-2">
                     <img
-                      src={currentValue(field.key)}
+                      src={withBasePath(currentValue(field.key))}
                       alt={field.label}
                       className="max-h-6 max-w-[200px] object-contain"
                       onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}

--- a/app/(sandbox)/layout.tsx
+++ b/app/(sandbox)/layout.tsx
@@ -1,17 +1,14 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
-import { Geist, Geist_Mono } from 'next/font/google';
-import '../globals.css';
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin'],
-});
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
-});
+// The plugin sandbox iframe runs with an opaque origin (the `sandbox`
+// attribute in production excludes `allow-same-origin` for isolation). Any
+// asset request from this layout - bundled fonts, globals.css, etc. - is then
+// cross-origin from the "null" origin to the host origin and gets blocked
+// (fonts in particular require CORS). So this layout is intentionally minimal:
+// no font imports, no CSS imports. Plugins ship their own styles, and both the
+// plugin bundle and all host API calls travel over the postMessage RPC bridge,
+// so the sandbox never fetches same-origin assets itself.
 
 export const metadata: Metadata = {
   title: 'Plugin sandbox',
@@ -21,10 +18,7 @@ export const metadata: Metadata = {
 export default function PluginSandboxLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-        style={{ margin: 0, padding: 0, background: 'transparent' }}
-      >
+      <body style={{ margin: 0, padding: 0, background: 'transparent' }}>
         {children}
       </body>
     </html>

--- a/lib/plugin-sandbox/host-api.ts
+++ b/lib/plugin-sandbox/host-api.ts
@@ -140,7 +140,7 @@ async function doHttpPost(plugin: InstalledPlugin, path: string, body: unknown):
     headers['Authorization'] = client.getAuthHeader();
     headers['X-JMAP-Username'] = client.getUsername();
   }
-  const res = await fetch(url.pathname + url.search, {
+  const res = await apiFetch(url.pathname + url.search, {
     method: 'POST',
     headers,
     body: JSON.stringify(body),

--- a/lib/plugin-sandbox/host-bridge.ts
+++ b/lib/plugin-sandbox/host-bridge.ts
@@ -10,6 +10,7 @@
 import type { InstalledPlugin, SlotName } from '../plugin-types';
 import { dispatchApiCall } from './host-api';
 import { SANDBOX_PATH } from './protocol';
+import { withBasePath } from '../browser-navigation';
 import type {
   SandboxToHost, HostToSandbox, InitMsg, InitPayload,
 } from './protocol';
@@ -143,7 +144,10 @@ export class SandboxInstance {
       this.iframe.style.width = '100%';
       this.iframe.style.height = '0px';
     }
-    this.iframe.src = SANDBOX_PATH;
+    // Prefix with the mount path so the sandbox route resolves under a
+    // subpath deployment (NEXT_PUBLIC_BASE_PATH=/webmail). A bare
+    // "/plugin-sandbox" would hit the origin root and 404, breaking plugins.
+    this.iframe.src = withBasePath(SANDBOX_PATH);
 
     this.listener = (ev) => this.onMessage(ev);
     window.addEventListener('message', this.listener);


### PR DESCRIPTION
## Summary

Under a subpath deployment (`NEXT_PUBLIC_BASE_PATH`, e.g. `/webmail`), a few hand-written URLs aren't prefixed with basePath and 404 - most importantly the plugin sandbox iframe, so all plugins fail to load. This prefixes the missed spots.

## Changes

- Wrap the plugin sandbox iframe `src` in `withBasePath` (was a bare `/plugin-sandbox` -> 404, breaking all plugins under a subpath).
- Route the plugin same-origin `api.http.post('/api/…')` proxy through `apiFetch` (was raw fetch on `url.pathname` -> 404).
- Prefix the Admin -> Branding image preview `<img src>` (was unprefixed -> broken thumbnail).
- Drop the Geist font + `globals.css` imports from the sandbox layout: the sandbox runs on an opaque origin so those same-origin assets are CORS-blocked; the bundle and all host API calls travel over the postMessage bridge.

## Related Issues

Closes #349

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style and conventions
- [ ] I have run `npm run typecheck && npm run lint` and there are no errors
- [ ] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Notes for Reviewers

Cherry-picked from our production fork (subpath deployment behind nginx), where it's been running live. No user-facing strings changed.