### PR TITLE
Feature: admin toggle for search-engine indexing (robots)

### DIFF
--- a/app/(main)/admin/_tabs/settings.tsx
+++ b/app/(main)/admin/_tabs/settings.tsx
@@ -125,6 +125,7 @@ export function SettingsTab() {
         )}
         <ToggleSetting label="Stalwart Features" description="Enable Stalwart Mail Server-specific features" configKey="stalwartFeaturesEnabled" value={currentValue('stalwartFeaturesEnabled') as boolean} source={config.stalwartFeaturesEnabled?.source} onChange={handleChange} onRevert={handleRevert} />
         <ToggleSetting label="Demo Mode" description="Enable demo mode with sample data" configKey="demoMode" value={currentValue('demoMode') as boolean} source={config.demoMode?.source} onChange={handleChange} onRevert={handleRevert} />
+        <ToggleSetting label="Search Engine Indexing" description="Allow search engines to index this webmail. Off (the default) sends noindex/nofollow in the page head, recommended for private deployments." configKey="searchEngineIndexing" value={currentValue('searchEngineIndexing') as boolean} source={config.searchEngineIndexing?.source} onChange={handleChange} onRevert={handleRevert} />
       </SettingsSection>
 
       <SettingsSection title="JMAP Servers (multi-server)">

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -49,6 +49,11 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: process.env.APP_NAME || process.env.NEXT_PUBLIC_APP_NAME || "Webmail",
     description: t("meta_description"),
+    // A private webmail should not be indexed by search engines. This is opt-in
+    // via Settings -> General; the default (false) emits noindex/nofollow.
+    robots: configManager.get<boolean>("searchEngineIndexing", false)
+      ? { index: true, follow: true }
+      : { index: false, follow: false },
     appleWebApp: {
       capable: true,
       statusBarStyle: "black-translucent",

--- a/lib/admin/types.ts
+++ b/lib/admin/types.ts
@@ -136,6 +136,7 @@ export const CONFIG_ENV_MAP: Record<string, { envVar: string; fileEnvVar?: strin
   appName: { envVar: 'APP_NAME', type: 'string', defaultValue: 'Webmail' },
   appShortName: { envVar: 'APP_SHORT_NAME', type: 'string', defaultValue: '' },
   appDescription: { envVar: 'APP_DESCRIPTION', type: 'string', defaultValue: '' },
+  searchEngineIndexing: { envVar: 'SEARCH_ENGINE_INDEXING', type: 'boolean', defaultValue: false },
   jmapServerUrl: { envVar: 'JMAP_SERVER_URL', type: 'url', defaultValue: '' },
   stalwartFeaturesEnabled: { envVar: 'STALWART_FEATURES', type: 'boolean', defaultValue: true },
   demoMode: { envVar: 'DEMO_MODE', type: 'boolean', defaultValue: false },


### PR DESCRIPTION
## Summary

Adds a "Search Engine Indexing" toggle under Settings -> General so an operator can control whether the webmail emits `robots: noindex, nofollow` in the document head. A private webmail login generally shouldn't appear in search results, but that policy belongs to the operator rather than being hardcoded.

## Changes

- New admin config key `searchEngineIndexing` (boolean, default `false`), wired through the existing `CONFIG_ENV_MAP`, so it automatically gets a value/source/revert in the admin UI, PATCH validation, and an env var (`SEARCH_ENGINE_INDEXING`).
- `generateMetadata()` in the root layout reads it: `false` -> `robots: { index: false, follow: false }`; `true` -> `{ index: true, follow: true }`.
- Toggle added to the General section of the admin Settings tab (next to the existing toggles).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] Contributing Guide read
- [x] Code follows project style and conventions
- [x] `npm run typecheck && npm run lint` passes
- [x] Build passes (`npm run build`)
- [x] Changes tested locally
- [x] Translations updated (`locales/`) - n/a, the admin General toggles use literal English labels (like the existing ones)

## Notes for Reviewers

- **Default-behavior note:** `main` currently emits no `robots` meta on the app (indexable); this PR makes the default `noindex, nofollow`. Rationale: a webmail login page generally shouldn't be indexed, and `app/(sandbox)/layout.tsx` already hardcodes the same for plugin iframes. If you'd prefer a purely additive default (toggle defaults to "indexing on", no change to current behavior), that's a one-line flip of `defaultValue` - happy to adjust.
- No new dependency and no new locale keys.
- The value is read server-side in `generateMetadata()` via the existing `configManager`, so it takes effect at runtime (in-process admin override) without a restart.
- `next lint` errors on Next 16 repo-wide (unrelated to this change); ESLint run directly on the changed files passes clean.