### PR TITLE
Fix: email body clipped under the fold when it sets html/body { height: 100% }

### DIFF
--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -2899,7 +2899,10 @@ export function EmailViewer({
 <html style="color-scheme: ${colorScheme};"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="Content-Security-Policy" content="${iframeCsp}">
 <style>
-  html, body { overflow: hidden; }
+  /* Force content height: some emails set html/body { height: 100% }, which -
+     combined with overflow:hidden and our scrollHeight-based auto-resize -
+     collapses the measured height and clips everything below the fold. */
+  html, body { overflow: hidden; height: auto !important; }
   body { margin: 0; padding: ${bodyPadding}; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 14px; line-height: 1.6; color: #1a1a1a; background: #ffffff; word-wrap: break-word; overflow-wrap: break-word; }
   @media (max-width: 640px) { body { padding-left: ${mobileBodyPaddingX}; padding-right: ${mobileBodyPaddingX}; } }
   img { max-width: 100% !important; height: auto !important; }


### PR DESCRIPTION
## Summary

Some emails (Outlook / templated HTML) set `html, body { height: 100% }` in their own `<style>`. In the message viewer the body then gets cut off - everything below the first screenful (often just the header/logo) is invisible.

## Cause

The viewer renders the email in a sandboxed iframe and auto-sizes it via `document.documentElement.scrollHeight`. The srcDoc sets `html, body { overflow: hidden }`. When the email also sets `html, body { height: 100% }`, the document height collapses to the iframe's initial (small) size and `overflow: hidden` clips the rest, so the measured `scrollHeight` is too small and the iframe never grows to fit the content.

## Fix

Force `html, body { height: auto !important }` in the srcDoc styles, so the document grows to its real content height before `scrollHeight` is measured. One line; no effect on emails that don't set a height (auto is already the default in an auto-sized iframe).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Contributing Guide read
- [x] Code follows project style and conventions
- [x] `npm run typecheck && npm run lint` passes
- [x] Build passes (`npm run build`)
- [x] Changes tested locally
- [x] Translations updated (`locales/`) - n/a, no strings changed

## Notes for Reviewers

- One-line change in the email iframe srcDoc styles (`emailIframeSrcDoc`).
- Reproduced with a real Outlook/template-style message containing `html, body { height: 100% }`: before, the body was clipped right under the header logo; after, the full message renders. Verified on a live Stalwart deployment.