### PR TITLE
feat: add passwordHashFile to admin.json

### DIFF
--- a/lib/admin/migrate.ts
+++ b/lib/admin/migrate.ts
@@ -98,7 +98,7 @@ async function migrateAdminJson(): Promise<boolean> {
     lastLogin: data.lastLogin ?? null,
     passwordChangedAt: data.passwordChangedAt ?? now,
   };
-  const configData: AdminConfigData = { passwordHash: data.passwordHash };
+  const configData: AdminConfigData = { passwordHash: data.passwordHash, passwordHashFile: undefined };
 
   await ensureStateDir();
   const statePath = getStatePath('admin-state.json');

--- a/lib/admin/password.ts
+++ b/lib/admin/password.ts
@@ -9,6 +9,7 @@ import {
   assertWritable,
 } from './paths';
 import type { AdminConfigData, AdminStateData } from './types';
+import { readFileEnv } from '../read-file-env';
 
 const SCRYPT_KEYLEN = 64;
 const SCRYPT_COST = 16384; // 2^14
@@ -146,7 +147,7 @@ export async function initAdminPassword(): Promise<boolean> {
   }
 
   const hash = isHashed(envPassword) ? envPassword : await hashPassword(envPassword);
-  cachedConfig = { passwordHash: hash };
+  cachedConfig = { passwordHash: hash, passwordHashFile: undefined };
   cachedState = freshState();
   await writeConfigData(cachedConfig);
   await writeStateData(cachedState);
@@ -165,7 +166,16 @@ export async function initAdminPassword(): Promise<boolean> {
 export async function verifyAdminPassword(password: string): Promise<boolean> {
   if (!cachedConfig) cachedConfig = await readConfigData();
   if (!cachedConfig) return false;
-  return verifyPassword(password, cachedConfig.passwordHash);
+  if (cachedConfig.passwordHash) {
+    return verifyPassword(password, cachedConfig.passwordHash);
+  } else if (cachedConfig.passwordHashFile) {
+    let passwordHash = readFileEnv(cachedConfig.passwordHashFile);
+    if (passwordHash) {
+      return verifyPassword(password, passwordHash);
+    }
+  }
+  logger.error('The admin password hash could neither be retrieved from passwordHash nor from passwordHashFile in admin.json');
+  return false;
 }
 
 /**
@@ -176,7 +186,7 @@ export async function changeAdminPassword(currentPassword: string, newPassword: 
   if (!valid) return false;
 
   const hash = await hashPassword(newPassword);
-  cachedConfig = { passwordHash: hash };
+  cachedConfig = { passwordHash: hash, passwordHashFile: undefined };
   await writeConfigData(cachedConfig);
 
   cachedState = {
@@ -205,7 +215,7 @@ export async function setInitialAdminPassword(
   const existing = await readConfigData();
   if (existing && !options.allowOverwrite) return false;
   const hash = await hashPassword(newPassword);
-  cachedConfig = { passwordHash: hash };
+  cachedConfig = { passwordHash: hash, passwordHashFile: undefined };
   cachedState = freshState();
   await writeConfigData(cachedConfig);
   await writeStateData(cachedState);

--- a/lib/admin/types.ts
+++ b/lib/admin/types.ts
@@ -6,7 +6,8 @@
  * is config; mutable timestamps live in AdminStateData.
  */
 export interface AdminConfigData {
-  passwordHash: string;
+  passwordHash: string | undefined;
+  passwordHashFile: string | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Add a `passwordHashFile` to `admin.json`, allowing us to specify a file containing the password hash. I think this is important because the hash also contains the salt which is sensible information.

## Changes

- allowed `passwordHash` to be `undefined`
- added `passwordHashFile`
- `verifyAdminPassword(...)` falls back to `passwordHashFile`

## Related Issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
