### PR TITLE
Fix: Settings section gears permanently hijack the active tab

### DIFF
--- a/app/(main)/[locale]/settings/page.tsx
+++ b/app/(main)/[locale]/settings/page.tsx
@@ -335,6 +335,14 @@ const LEGACY_TAB_MAP: Record<string, Tab> = {
 
 function readPersistedTab(): Tab {
   try {
+    // One-shot deep link from the sidebar section gears (Folders / Tags).
+    // Used only as the initial tab and intentionally NOT written to
+    // 'settings-active-tab', so a gear click never becomes the persisted
+    // default that the regular Settings button lands on. Cleared on mount.
+    const deepLink = sessionStorage.getItem('settings-deep-link-tab');
+    if (deepLink) {
+      return (deepLink in LEGACY_TAB_MAP ? LEGACY_TAB_MAP[deepLink] : deepLink) as Tab;
+    }
     const saved = localStorage.getItem('settings-active-tab');
     if (!saved) return 'appearance';
     if (saved in LEGACY_TAB_MAP) {
@@ -360,6 +368,11 @@ export default function SettingsPage() {
   const { stalwartFeaturesEnabled } = useConfig();
   const { isFeatureEnabled } = usePolicyStore();
   const [activeTab, setActiveTab] = useState<Tab>(readPersistedTab);
+  // Consume the one-shot deep-link key so a section gear only steers this one
+  // open, never the persisted default for future Settings-button clicks.
+  useEffect(() => {
+    try { sessionStorage.removeItem('settings-deep-link-tab'); } catch { /* ignore */ }
+  }, []);
   const [mobileShowContent, setMobileShowContent] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [pendingHighlight, setPendingHighlight] = useState<{ tab: Tab; label: string; pluginId?: string } | null>(null);
@@ -933,7 +946,7 @@ export default function SettingsPage() {
                   return (
                     <div key={tab.id}>
                       <button
-                        onClick={() => setActiveTab(tab.id)}
+                        onClick={() => handleTabSelect(tab.id)}
                         className={cn(
                           'w-full text-left px-3 py-2 rounded-md text-sm transition-colors duration-150 flex items-center gap-2.5',
                           effectiveActiveTab === tab.id

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -904,11 +904,11 @@ export function Sidebar({
   };
 
   const openFolderSettings = () => {
-    try { localStorage.setItem('settings-active-tab', 'folders'); } catch { /* */ }
+    try { sessionStorage.setItem('settings-deep-link-tab', 'folders'); } catch { /* */ }
     router.push('/settings');
   };
   const openKeywordSettings = () => {
-    try { localStorage.setItem('settings-active-tab', 'keywords'); } catch { /* */ }
+    try { sessionStorage.setItem('settings-deep-link-tab', 'keywords'); } catch { /* */ }
     router.push('/settings');
   };
 


### PR DESCRIPTION
## Summary

The folder and tag "section gears" in the mailbox sidebar deep-link into Settings by writing the persisted `settings-active-tab` localStorage key - the same key the page reads to restore the last-opened tab. As a result, clicking a section gear once makes that section the **permanent** default the main Settings button opens on, indefinitely.

A second issue compounds it: on desktop the Settings tab list calls `setActiveTab` directly without persisting, so normal tab navigation never updates the stored default - meaning the hijacked value can never self-correct through regular use.

## Changes

- The sidebar section gears (`openFolderSettings` / `openKeywordSettings`) now write a **one-shot** `sessionStorage` key (`settings-deep-link-tab`) instead of the persistent `settings-active-tab`. It steers only the next Settings open and is consumed on mount, so it never becomes the saved default.
- `readPersistedTab()` reads that one-shot key first (transient, not written back), then falls back to the persisted tab.
- The desktop Settings tab list now routes clicks through `handleTabSelect` (like the mobile list), so the last-used tab is persisted consistently. Its mobile-only behaviour is already `!isDesktop`-guarded, so this is a no-op on desktop beyond the persistence.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Verified manually: gear deep-link is transient, desktop tab navigation persists, the main Settings button no longer gets stuck on a section

## Notes for Reviewers

- Stale/removed tab IDs remain handled by the existing `effectiveActiveTab` → `appearance` fallback, so an outdated persisted value never breaks rendering.
- No new dependencies; only existing helpers (`handleTabSelect`) and web storage.