### PR TITLE
Fix: invisible dark-mode borders + mail view layout polish

### DIFF
--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -2466,7 +2466,7 @@ export default function Home() {
                 ),
             inlineApp && "hidden"
           )}
-          style={!isMobile && !isTablet ? { width: sidebarCollapsed ? 64 : sidebarWidth } : undefined}
+          style={!isMobile && !isTablet ? { width: sidebarCollapsed ? 48 : sidebarWidth } : undefined}
         >
           <ErrorBoundary fallback={SidebarErrorFallback}>
             <Sidebar

--- a/app/globals.css
+++ b/app/globals.css
@@ -70,7 +70,7 @@
 }
 
 .dark {
-  --color-border: #262626;
+  --color-border: rgba(128, 128, 128, 0.3);
   --color-input: #262626;
   --color-ring: #d4d4d4;
   --color-background: #0a0a0a;


### PR DESCRIPTION
## Summary

Two small fixes for the mail view:

**1. Dark-mode borders were invisible.** In the dark theme `--color-border` (`#262626`) is the *same* colour as `--color-secondary` / `--color-muted`, and a global `* { border-color: var(--color-border) }` rule paints every border with it. So any border sitting on a secondary/muted surface - the folder sidebar's edges, the account header, and others - blended into its own background and disappeared. Setting `--color-border` to a slightly lighter, semi-transparent grey makes borders visible on every dark surface again, and keeps them consistent (it's the same neutral the navigation rail already uses inline).

**2. Mail view layout polish.**
- The collapsed folder sidebar left a 16px empty strip on its right: the wrapper width was hard-coded to `64`px, but the sidebar itself is `w-12` (48px). Matched the wrapper to the sidebar.
- The panel resize handles reserved a 4px transparent gap at rest. Made them seamless (no reserved width) while keeping a comfortable grab zone (a higher `z-index` lifts the hit area above the neighbouring panels) and a subtle highlight on hover/drag.

## Changes

- `app/globals.css`: dark `--color-border` `#262626` → `rgba(128, 128, 128, 0.3)`.
- `app/(main)/[locale]/page.tsx`:
  - collapsed sidebar wrapper width `64` → `48` (matches the sidebar's own `w-12`).
  - sidebar↔list and list↔viewer resize handles get `w-0` + a `before:` highlight bar (with `z-[60]` so the ~8px hit area stays above the adjacent panels) - the visible gap is gone, dragging and double-click-reset still work.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Contributing Guide read
- [x] Code follows project style and conventions
- [x] `npm run typecheck && npm run lint` passes
- [x] Build passes (`npm run build`)
- [x] Changes tested locally
- [ ] Translations updated (locales/) — n/a, no new user-facing strings (CSS + layout only)