### PR TITLE
fix(nav): hide Add App button when sidebarAppsEnabled is false

### DIFF
--- a/components/layout/navigation-rail.tsx
+++ b/components/layout/navigation-rail.tsx
@@ -546,7 +546,7 @@ export function NavigationRail({
         })}
 
         {/* Manage apps button */}
-        {onManageApps && (
+        {sidebarAppsEnabled && onManageApps && (
           <button
             onClick={onManageApps}
             className={cn(


### PR DESCRIPTION
## Summary

When the `sidebarAppsEnabled` feature gate is `false` (admin policy / `policy.json`), added sidebar apps are correctly hidden, but the "+" Add App button in the navigation rail remains visible and still opens the Sidebar Apps modal. An operator disabling the feature instance-wide expects the button gone too.

## Steps to reproduce
1. Set `policy.json → {"features": {"sidebarAppsEnabled": false}}` (or toggle off in the admin dashboard).
2. Reload (cleared cache). Added apps disappear ✅, but the rail still shows the "+" "Add App" entry ❌.

## Expected
With `sidebarAppsEnabled = false`, the "+" Add App button is also hidden.

## Cause
In components/layout/navigation-rail.tsx, visibleSidebarApps is correctly gated (`sidebarAppsEnabled ? sidebarApps : []`), but the "Manage apps button" block is gated only on `onManageApps`, not on `sidebarAppsEnabled`.

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [X] I have added or updated documentation if needed
- [X] I have updated translations (`locales/`) if my changes affect user-facing text
- [X] I have included screenshots or a screen recording for UI changes