### PR TITLE
fix: prevent draft emails from being marked as unread

### DIFF
--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -2078,7 +2078,7 @@ export class JMAPClient implements IJMAPClient {
       cc: cc?.length ? cc.map(email => ({ email })) : undefined,
       bcc: bcc?.length ? bcc.map(email => ({ email })) : undefined,
       subject,
-      keywords: { "$draft": true },
+      keywords: { "$seen": true, "$draft": true },
       mailboxIds: { [draftsMailbox.id]: true },
       bodyValues: htmlBody
         ? { "text": { value: body }, "html": { value: htmlBody } }
@@ -6002,6 +6002,7 @@ export class JMAPClient implements IJMAPClient {
     const update: Record<string, unknown> = {
       [`mailboxIds/${draftMailboxId}`]: true,
       'keywords/$draft': true,
+      'keywords/$seen': true,
     };
     if (sentMailboxId) {
       update[`mailboxIds/${sentMailboxId}`] = null;


### PR DESCRIPTION
## Summary

Newly created draft emails would previously be marked as unread. This is not standard behavior for email clients. 

## Changes


- Quick update to the `clients.ts` to create new drafts with the "seen" flag as true. 

## Related Issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
