### PR TITLE
feat: add Edit contact button to email viewer contact sidebar

### DIFF
--- a/app/(main)/[locale]/contacts/page.tsx
+++ b/app/(main)/[locale]/contacts/page.tsx
@@ -173,12 +173,13 @@ export default function ContactsPage() {
     const addEmail = searchParams.get('addEmail');
     const addName = searchParams.get('addName');
     const from = searchParams.get('from');
+    const viewParam = searchParams.get('view');
     if (!contactId && !addEmail && !from) return;
     intentAppliedRef.current = true;
     if (from === 'email') setReturnToEmail(true);
     if (contactId) {
       setSelectedContact(contactId);
-      setView('detail');
+      setView(viewParam === 'edit' ? 'edit' : 'detail');
     } else if (addEmail) {
       setCreatePrefill({ email: addEmail, name: addName ?? undefined });
       setSelectedContact(null);

--- a/components/email/__tests__/contact-sidebar-edit.test.tsx
+++ b/components/email/__tests__/contact-sidebar-edit.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ContactSidebarPanel } from '../email-viewer';
+import type { ContactCard } from '@/lib/jmap/types';
+
+const contact: ContactCard = {
+  id: 'c1',
+  addressBookIds: {},
+  name: {
+    components: [
+      { kind: 'given', value: 'Alice' },
+      { kind: 'surname', value: 'Smith' },
+    ],
+    isOrdered: true,
+  },
+  emails: { e0: { address: 'alice@example.com' } },
+};
+
+const unknownEmail = 'unknown@example.com';
+
+describe('ContactSidebarPanel', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('shows Edit button when contact is known and onEditContact is provided', () => {
+    render(
+      <ContactSidebarPanel
+        email="alice@example.com"
+        contact={contact}
+        onClose={vi.fn()}
+        onEditContact={vi.fn()}
+      />,
+    );
+    // useTranslations mock returns the key, so we look for the common.edit key
+    expect(screen.getByTitle('contact_sidebar.action_edit_title')).toBeInTheDocument();
+    expect(screen.getByText('edit')).toBeInTheDocument();
+  });
+
+  it('calls onEditContact when Edit button is clicked', () => {
+    const onEditContact = vi.fn();
+    render(
+      <ContactSidebarPanel
+        email="alice@example.com"
+        contact={contact}
+        onClose={vi.fn()}
+        onEditContact={onEditContact}
+      />,
+    );
+    fireEvent.click(screen.getByTitle('contact_sidebar.action_edit_title'));
+    expect(onEditContact).toHaveBeenCalledOnce();
+  });
+
+  it('does not show Edit button when contact is null', () => {
+    render(
+      <ContactSidebarPanel
+        email={unknownEmail}
+        contact={null}
+        onClose={vi.fn()}
+        onEditContact={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTitle('contact_sidebar.action_edit_title')).not.toBeInTheDocument();
+  });
+
+  it('does not show Edit button when onEditContact is not provided', () => {
+    render(
+      <ContactSidebarPanel
+        email="alice@example.com"
+        contact={contact}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTitle('contact_sidebar.action_edit_title')).not.toBeInTheDocument();
+  });
+
+  it('shows "not in contacts" message and Add button for unknown email', () => {
+    const onAddToContacts = vi.fn();
+    render(
+      <ContactSidebarPanel
+        email={unknownEmail}
+        contact={null}
+        onClose={vi.fn()}
+        onAddToContacts={onAddToContacts}
+      />,
+    );
+    expect(screen.getByText('contact_sidebar.not_in_contacts')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('contact_sidebar.add_to_contacts'));
+    expect(onAddToContacts).toHaveBeenCalledWith(unknownEmail, undefined);
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <ContactSidebarPanel
+        email="alice@example.com"
+        contact={contact}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('contact_sidebar.close'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -609,19 +609,23 @@ function renderClickableRecipients(
 }
 
 // Contact sidebar panel that slides in from the right on desktop
-function ContactSidebarPanel({
+export function ContactSidebarPanel({
   email,
   contact,
   senderName,
   onClose,
   onAddToContacts,
+  onEditContact,
 }: {
   email: string;
   contact: ContactCard | null;
   senderName?: string;
   onClose: () => void;
   onAddToContacts?: (email: string, name?: string) => void;
+  onEditContact?: () => void;
 }) {
+  const t = useTranslations('email_viewer');
+  const tCommon = useTranslations('common');
   const name = contact ? getContactDisplayName(contact) : senderName || null;
   const primaryEmail = contact ? getContactPrimaryEmail(contact) : email;
   const emails = contact?.emails ? Object.values(contact.emails) : [];
@@ -633,9 +637,9 @@ function ContactSidebarPanel({
   const handleCopy = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
-      toast.success("Copied!");
+      toast.success(t('contact_sidebar.copied'));
     } catch {
-      toast.error("Failed to copy");
+      toast.error(t('contact_sidebar.copy_failed'));
     }
   };
 
@@ -643,11 +647,11 @@ function ContactSidebarPanel({
     <div className="w-[320px] shrink-0 border-l border-border bg-background flex flex-col h-full animate-in slide-in-from-right-5 duration-200">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border">
-        <h3 className="text-sm font-semibold text-foreground truncate">Contact</h3>
+        <h3 className="text-sm font-semibold text-foreground truncate">{t('contact_sidebar.title')}</h3>
         <button
           onClick={onClose}
           className="p-1 rounded hover:bg-muted transition-colors"
-          aria-label="Close sidebar"
+          aria-label={t('contact_sidebar.close')}
         >
           <PanelRightClose className="w-4 h-4 text-muted-foreground" />
         </button>
@@ -685,19 +689,29 @@ function ContactSidebarPanel({
           <a
             href={`mailto:${primaryEmail}`}
             className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground px-3 py-2 rounded-md hover:bg-muted transition-colors border border-border"
-            title="Send email"
+            title={t('contact_sidebar.action_email_title')}
           >
             <Send className="w-3.5 h-3.5" />
-            Email
+            {t('contact_sidebar.action_email')}
           </a>
           <button
             onClick={() => handleCopy(primaryEmail)}
             className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground px-3 py-2 rounded-md hover:bg-muted transition-colors border border-border"
-            title="Copy email"
+            title={t('contact_sidebar.action_copy_title')}
           >
             <Copy className="w-3.5 h-3.5" />
-            Copy
+            {t('contact_sidebar.action_copy')}
           </button>
+          {contact && onEditContact && (
+            <button
+              onClick={onEditContact}
+              className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground px-3 py-2 rounded-md hover:bg-muted transition-colors border border-border"
+              title={t('contact_sidebar.action_edit_title')}
+            >
+              <EditIcon className="w-3.5 h-3.5" />
+              {tCommon('edit')}
+            </button>
+          )}
         </div>
 
         {/* Details sections */}
@@ -705,7 +719,7 @@ function ContactSidebarPanel({
           <div className="px-4 pb-4 space-y-4">
             {/* Emails */}
             {emails.length > 0 && (
-              <SidebarSection icon={Mail} title="Emails">
+              <SidebarSection icon={Mail} title={t('contact_sidebar.section_emails')}>
                 {emails.map((e, i) => (
                   <div key={i} className="flex items-center gap-2 group">
                     <a href={`mailto:${e.address}`} className="text-sm text-primary hover:underline truncate">
@@ -725,7 +739,7 @@ function ContactSidebarPanel({
 
             {/* Phones */}
             {phones.length > 0 && (
-              <SidebarSection icon={Phone} title="Phones">
+              <SidebarSection icon={Phone} title={t('contact_sidebar.section_phones')}>
                 {phones.map((p, i) => (
                   <div key={i} className="flex items-center gap-2 group">
                     <a href={`tel:${p.number}`} className="text-sm text-primary hover:underline">
@@ -745,7 +759,7 @@ function ContactSidebarPanel({
 
             {/* Organizations */}
             {orgs.length > 1 && (
-              <SidebarSection icon={Building} title="Organizations">
+              <SidebarSection icon={Building} title={t('contact_sidebar.section_organizations')}>
                 {orgs.map((o, i) => (
                   <div key={i} className="text-sm">
                     {o.name}
@@ -759,7 +773,7 @@ function ContactSidebarPanel({
 
             {/* Addresses */}
             {addresses.length > 0 && (
-              <SidebarSection icon={MapPin} title="Addresses">
+              <SidebarSection icon={MapPin} title={t('contact_sidebar.section_addresses')}>
                 {addresses.map((a, i) => (
                   <div key={i} className="text-sm text-muted-foreground">
                     {a.full || a.fullAddress
@@ -774,7 +788,7 @@ function ContactSidebarPanel({
 
             {/* Notes */}
             {notes.length > 0 && (
-              <SidebarSection icon={StickyNote} title="Notes">
+              <SidebarSection icon={StickyNote} title={t('contact_sidebar.section_notes')}>
                 {notes.map((n, i) => (
                   <p key={i} className="text-sm text-muted-foreground whitespace-pre-wrap">{n.note}</p>
                 ))}
@@ -787,7 +801,7 @@ function ContactSidebarPanel({
         {!contact && (
           <div className="px-4 pb-4 text-center space-y-3">
             <p className="text-xs text-muted-foreground">
-              Not in your contacts
+              {t('contact_sidebar.not_in_contacts')}
             </p>
             {onAddToContacts && (
               <button
@@ -795,7 +809,7 @@ function ContactSidebarPanel({
                 className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:text-primary/80 px-3 py-2 rounded-md hover:bg-muted transition-colors border border-border"
               >
                 <Mail className="w-3.5 h-3.5" />
-                Add to contacts
+                {t('contact_sidebar.add_to_contacts')}
               </button>
             )}
           </div>
@@ -5840,6 +5854,10 @@ export function EmailViewer({
           return allRecipients.find(r => r.email.toLowerCase() === contactSidebarEmail.toLowerCase())?.name;
         })()}
         onClose={() => setContactSidebarEmail(null)}
+        onEditContact={sidebarContact ? () => {
+          router.push(`/contacts?contactId=${sidebarContact.id}&view=edit`);
+          setContactSidebarEmail(null);
+        } : undefined}
         onAddToContacts={(addr, name) => {
           const { createContact, addLocalContact, supportsSync } = useContactStore.getState();
           const client = useAuthStore.getState().client;

--- a/locales/cs/common.json
+++ b/locales/cs/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Zadejte nové datum/čas, např. 2026-05-04T15:30",
     "scheduled_actions_only": "Zobrazení Naplánováno podporuje pouze akce plánování",
     "undo_send_scheduled": "Zpráva je naplánována k odeslání",
-    "undo_send": "Vrátit odeslání"
+    "undo_send": "Vrátit odeslání",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Vyžádáno potvrzení o přečtení (kliknutím vypnete)",

--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Indtast en ny dato/tid, f.eks. 2026-05-04T15:30",
     "scheduled_actions_only": "Planlagt-visningen understøtter kun planlagte handlinger",
     "undo_send_scheduled": "Besked planlagt til afsendelse",
-    "undo_send": "Fortryd afsendelse"
+    "undo_send": "Fortryd afsendelse",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Læsekvittering anmodet (klik for at deaktivere)",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Neues Datum/Uhrzeit eingeben, z. B. 2026-05-04T15:30",
     "scheduled_actions_only": "Die Geplant-Ansicht unterstützt nur Planungsaktionen",
     "undo_send_scheduled": "Nachricht ist zum Senden geplant",
-    "undo_send": "Senden rückgängig"
+    "undo_send": "Senden rückgängig",
+    "contact_sidebar": {
+      "title": "Kontakt",
+      "close": "Seitenleiste schließen",
+      "action_email": "E-Mail",
+      "action_email_title": "E-Mail senden",
+      "action_copy": "Kopieren",
+      "action_copy_title": "E-Mail-Adresse kopieren",
+      "action_edit_title": "Kontakt bearbeiten",
+      "section_emails": "E-Mail-Adressen",
+      "section_phones": "Telefonnummern",
+      "section_organizations": "Organisationen",
+      "section_addresses": "Adressen",
+      "section_notes": "Notizen",
+      "not_in_contacts": "Nicht in Ihren Kontakten",
+      "add_to_contacts": "Zu Kontakten hinzufügen",
+      "copied": "Kopiert!",
+      "copy_failed": "Kopieren fehlgeschlagen"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Lesebestätigung angefordert (klicken zum Deaktivieren)",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Enter a new date/time, e.g. 2026-05-04T15:30",
     "scheduled_actions_only": "Scheduled view supports scheduled actions only",
     "undo_send_scheduled": "Message scheduled for sending",
-    "undo_send": "Undo send"
+    "undo_send": "Undo send",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Read receipt requested (click to disable)",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Introduce una nueva fecha/hora, p. ej. 2026-05-04T15:30",
     "scheduled_actions_only": "La vista Programados solo admite acciones de programación",
     "undo_send_scheduled": "Mensaje programado para envío",
-    "undo_send": "Deshacer envío"
+    "undo_send": "Deshacer envío",
+    "contact_sidebar": {
+      "title": "Contacto",
+      "close": "Cerrar panel",
+      "action_email": "Correo",
+      "action_email_title": "Enviar correo",
+      "action_copy": "Copiar",
+      "action_copy_title": "Copiar correo electrónico",
+      "action_edit_title": "Editar contacto",
+      "section_emails": "Correos electrónicos",
+      "section_phones": "Teléfonos",
+      "section_organizations": "Organizaciones",
+      "section_addresses": "Direcciones",
+      "section_notes": "Notas",
+      "not_in_contacts": "No está en sus contactos",
+      "add_to_contacts": "Añadir a contactos",
+      "copied": "¡Copiado!",
+      "copy_failed": "Error al copiar"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Confirmación de lectura solicitada (haz clic para desactivar)",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Saisissez une nouvelle date/heure, p. ex. 2026-05-04T15:30",
     "scheduled_actions_only": "La vue Planifiés prend uniquement en charge les actions de planification",
     "undo_send_scheduled": "Message planifié pour envoi",
-    "undo_send": "Annuler l’envoi"
+    "undo_send": "Annuler l’envoi",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Fermer le panneau",
+      "action_email": "E-mail",
+      "action_email_title": "Envoyer un e-mail",
+      "action_copy": "Copier",
+      "action_copy_title": "Copier l'adresse e-mail",
+      "action_edit_title": "Modifier le contact",
+      "section_emails": "E-mails",
+      "section_phones": "Téléphones",
+      "section_organizations": "Organisations",
+      "section_addresses": "Adresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Pas dans vos contacts",
+      "add_to_contacts": "Ajouter aux contacts",
+      "copied": "Copié !",
+      "copy_failed": "Échec de la copie"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Accusé de lecture demandé (cliquez pour désactiver)",

--- a/locales/hu/common.json
+++ b/locales/hu/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Adj meg egy új dátumot/időpontot, pl. 2026-05-04T15:30",
     "scheduled_actions_only": "Az ütemezett nézet csak ütemezett műveleteket támogat",
     "undo_send_scheduled": "Üzenet ütemezve a küldéshez",
-    "undo_send": "Küldés visszavonása"
+    "undo_send": "Küldés visszavonása",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Olvasási visszaigazolás kérve (kattints a letiltáshoz)",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Inserisci una nuova data/ora, ad es. 2026-05-04T15:30",
     "scheduled_actions_only": "La vista Programmate supporta solo azioni di programmazione",
     "undo_send_scheduled": "Messaggio programmato per l’invio",
-    "undo_send": "Annulla invio"
+    "undo_send": "Annulla invio",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Conferma di lettura richiesta (clicca per disattivare)",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "新しい日時を入力してください。例: 2026-05-04T15:30",
     "scheduled_actions_only": "予約済みビューでは予約アクションのみ利用できます",
     "undo_send_scheduled": "メッセージは送信予約されています",
-    "undo_send": "送信を取り消す"
+    "undo_send": "送信を取り消す",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "開封確認を要求中（クリックで無効化）",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "새 날짜/시간을 입력하세요. 예: 2026-05-04T15:30",
     "scheduled_actions_only": "예약됨 보기에서는 예약 작업만 사용할 수 있습니다",
     "undo_send_scheduled": "메시지가 보내기로 예약되었습니다",
-    "undo_send": "보내기 실행 취소"
+    "undo_send": "보내기 실행 취소",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "읽음 확인 요청됨 (클릭하여 해제)",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Ievadiet jaunu datumu/laiku, piem. 2026-05-04T15:30",
     "scheduled_actions_only": "Ieplānoto skatā ir pieejamas tikai ieplānošanas darbības",
     "undo_send_scheduled": "Ziņojums ir ieplānots nosūtīšanai",
-    "undo_send": "Atsaukt sūtīšanu"
+    "undo_send": "Atsaukt sūtīšanu",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Pieprasīts lasīšanas apstiprinājums (noklikšķiniet, lai atspējotu)",

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Voer een nieuwe datum/tijd in, bijv. 2026-05-04T15:30",
     "scheduled_actions_only": "De geplande weergave ondersteunt alleen geplande acties",
     "undo_send_scheduled": "Bericht gepland voor verzending",
-    "undo_send": "Verzenden ongedaan maken"
+    "undo_send": "Verzenden ongedaan maken",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Leesbevestiging aangevraagd (klik om uit te schakelen)",

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Wprowadź nową datę/godzinę, np. 2026-05-04T15:30",
     "scheduled_actions_only": "Widok Zaplanowane obsługuje tylko akcje planowania",
     "undo_send_scheduled": "Wiadomość zaplanowana do wysłania",
-    "undo_send": "Cofnij wysyłkę"
+    "undo_send": "Cofnij wysyłkę",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Zażądano potwierdzenia przeczytania (kliknij, aby wyłączyć)",

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Informe uma nova data/hora, ex. 2026-05-04T15:30",
     "scheduled_actions_only": "A visualização Agendados permite apenas ações de agendamento",
     "undo_send_scheduled": "Mensagem agendada para envio",
-    "undo_send": "Desfazer envio"
+    "undo_send": "Desfazer envio",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Confirmação de leitura solicitada (clique para desativar)",

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Введите новую дату/время, например 2026-05-04T15:30",
     "scheduled_actions_only": "В представлении запланированных доступны только действия планирования",
     "undo_send_scheduled": "Сообщение запланировано к отправке",
-    "undo_send": "Отменить отправку"
+    "undo_send": "Отменить отправку",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Запрошено уведомление о прочтении (нажмите, чтобы отключить)",

--- a/locales/tr/common.json
+++ b/locales/tr/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Yeni tarih/saat girin, ör. 2026-05-04T15:30",
     "scheduled_actions_only": "Zamanlandı görünümü yalnızca zamanlama işlemlerini destekler",
     "undo_send_scheduled": "İleti gönderim için zamanlandı",
-    "undo_send": "Göndermeyi geri al"
+    "undo_send": "Göndermeyi geri al",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Okundu bilgisi istendi (devre dışı bırakmak için tıklayın)",

--- a/locales/uk/common.json
+++ b/locales/uk/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "Введіть нову дату/час, напр. 2026-05-04T15:30",
     "scheduled_actions_only": "У поданні Заплановано доступні лише дії планування",
     "undo_send_scheduled": "Повідомлення заплановано до надсилання",
-    "undo_send": "Скасувати надсилання"
+    "undo_send": "Скасувати надсилання",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "Запитано сповіщення про прочитання (натисніть, щоб вимкнути)",

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -544,7 +544,25 @@
     "reschedule_prompt": "输入新的日期/时间，例如 2026-05-04T15:30",
     "scheduled_actions_only": "计划发送视图仅支持计划操作",
     "undo_send_scheduled": "邮件已计划发送",
-    "undo_send": "撤销发送"
+    "undo_send": "撤销发送",
+    "contact_sidebar": {
+      "title": "Contact",
+      "close": "Close sidebar",
+      "action_email": "Email",
+      "action_email_title": "Send email",
+      "action_copy": "Copy",
+      "action_copy_title": "Copy email",
+      "action_edit_title": "Edit contact",
+      "section_emails": "Emails",
+      "section_phones": "Phones",
+      "section_organizations": "Organizations",
+      "section_addresses": "Addresses",
+      "section_notes": "Notes",
+      "not_in_contacts": "Not in your contacts",
+      "add_to_contacts": "Add to contacts",
+      "copied": "Copied!",
+      "copy_failed": "Failed to copy"
+    }
   },
   "email_composer": {
     "read_receipt_on": "已请求已读回执（点击以关闭）",


### PR DESCRIPTION
Clicking an email address in the viewer already shows a contact detail sidebar. An "Edit" button now appears there (for known contacts) that navigates directly to the contact edit form via the existing URL-param intent system (?contactId=…&view=edit), removing the need to open the Contacts page manually and search for the contact.

## Summary

Adds a direct path from the email viewer to the contact edit form. Previously the user had to open the Contacts page separately and find the contact manually.

## Changes

- components/email/email-viewer.tsx — Exports ContactSidebarPanel and adds an Edit button (visible for known contacts) that navigates to /contacts?contactId=…&view=edit and closes the sidebar. All 16 previously hardcoded UI strings replaced
  with useTranslations.
  - app/(main)/[locale]/contacts/page.tsx — URL-param intent handler extended to read view=edit, opening the edit form directly instead of the detail view.
  - locales/*/common.json — New contact_sidebar namespace added to email_viewer in all 18 locale files (EN/DE/FR/ES translated, remaining locales carry English as fallback).
  - components/email/__tests__/contact-sidebar-edit.test.tsx — 6 integration tests covering Edit button visibility, click behaviour, close action, and the unknown-contact path.

- 

## Related Issues
-

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

[screen-capture-navigation.webm](https://github.com/user-attachments/assets/361f8e76-055b-464f-a43c-838182bc4edc)

## Notes for Reviewers

