### PR TITLE
fix: toolbar re-renders when opening message. 

### DIFF
--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -2230,11 +2230,10 @@ export default function Home() {
       setShowComposer(false);
     }
 
-    // waiting for the body fetch - avoids the loading flicker.
+    // Find the list-level email for metadata (accountId, scheduled flags, etc.)
+    // but don't select it yet — wait for the full fetch to avoid a toolbar flash
+    // caused by rendering with the stub (no bodyValues) then re-rendering with the full email.
     const listEmail = activeEmails.find(e => e.id === email.id);
-    if (listEmail) {
-      selectEmail(listEmail);
-    }
 
     setLoadingEmail(true);
 

--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -3831,19 +3831,22 @@ export function EmailViewer({
         </Button>
 
         {/* Dark/light mode toggle for HTML emails */}
-        {effectiveEmailContent.isHtml && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setEmailViewDarkOverride(prev => prev === null ? !(resolvedTheme === 'dark') : !prev)}
-            data-overflow-item
-            data-overflow-priority="11"
-            className="hidden sm:inline-flex h-8 gap-1.5"
-            title={isDark ? 'View in light mode' : 'View in dark mode'}
-          >
-            {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
-          </Button>
-        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setEmailViewDarkOverride(prev => prev === null ? !(resolvedTheme === 'dark') : !prev)}
+          data-overflow-item
+          data-overflow-priority="11"
+          className={cn(
+            "hidden sm:inline-flex h-8 gap-1.5",
+            !effectiveEmailContent.isHtml && "invisible pointer-events-none"
+          )}
+          title={isDark ? 'View in light mode' : 'View in dark mode'}
+          tabIndex={effectiveEmailContent.isHtml ? 0 : -1}
+          aria-hidden={!effectiveEmailContent.isHtml}
+        >
+          {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+        </Button>
 
         {/* More menu - click-based */}
         <div ref={moreMenuRef} className="relative">
@@ -4084,9 +4087,8 @@ export function EmailViewer({
 
   return (
     <div
-      key={email.id}
       data-tour="email-viewer"
-      className={cn("flex-1 flex flex-row h-full bg-background overflow-hidden animate-in fade-in duration-300 relative", className)}
+      className={cn("flex-1 flex flex-row h-full bg-background overflow-hidden relative", className)}
     >
     {/* Mobile More menu sidebar overlay */}
     {!isScheduled && isMobile && moreMenuOpen && (

--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -3831,22 +3831,19 @@ export function EmailViewer({
         </Button>
 
         {/* Dark/light mode toggle for HTML emails */}
+        {effectiveEmailContent.isHtml && (
         <Button
           variant="ghost"
           size="sm"
           onClick={() => setEmailViewDarkOverride(prev => prev === null ? !(resolvedTheme === 'dark') : !prev)}
           data-overflow-item
           data-overflow-priority="11"
-          className={cn(
-            "hidden sm:inline-flex h-8 gap-1.5",
-            !effectiveEmailContent.isHtml && "invisible pointer-events-none"
-          )}
+          className="hidden sm:inline-flex h-8 gap-1.5"
           title={isDark ? 'View in light mode' : 'View in dark mode'}
-          tabIndex={effectiveEmailContent.isHtml ? 0 : -1}
-          aria-hidden={!effectiveEmailContent.isHtml}
         >
           {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
         </Button>
+        )}
 
         {/* More menu - click-based */}
         <div ref={moreMenuRef} className="relative">


### PR DESCRIPTION
## Summary

<!-- A brief, one-paragraph description of what this PR does and why. -->
Fixes the toolbar flickering/re-rendering when opening a new message from the list. 

## Changes

<!-- A bulleted list of the key changes made. -->

- page.tsx — Removed premature selectEmail(listEmail) call before the full email body fetch, preventing toolbar flash from rendering with stub data then re-rendering with the full email.
- email-viewer.tsx — Changed dark/light toggle from conditional rendering to invisible pointer-events-none to keep DOM stability during re-renders.  Removed key={email.id} from the email viewer root div to prevent full component remount on email switch. Removed animate-in fade-in duration-300 animation classes from the email viewer.


## Related Issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
