### PR TITLE
fix: fix directory fetching display names.

### DIFF
--- a/stores/contact-store.ts
+++ b/stores/contact-store.ts
@@ -289,7 +289,7 @@ export const useContactStore = create<ContactStore>()(
             const email = p.email?.trim();
             if (!email) continue;
             entries.push({
-              name: p.name || email,
+              name: p.description || p.name || email,
               email,
               description: p.description ?? undefined,
             });
@@ -556,9 +556,20 @@ export const useContactStore = create<ContactStore>()(
           for (const p of directoryPrincipals) {
             if (results.length >= 10) break;
             const addr = p.email.toLowerCase();
-            if (seen.has(addr)) continue;
-            if (p.name.toLowerCase().includes(lower) || addr.includes(lower)) {
-              results.push({ name: p.name, email: p.email });
+            if (seen.has(addr)) {
+              const betterName = p.description || p.name;
+              if (betterName && betterName !== p.email) {
+                const existing = results.find(r => r.email.toLowerCase() === addr);
+                if (existing && (!existing.name || existing.name === existing.email)) {
+                  existing.name = betterName;
+                }
+              }
+              continue;
+            }
+            if (p.name.toLowerCase().includes(lower) || addr.includes(lower) || (p.description && p.description.toLowerCase().includes(lower))) {
+              const displayName = p.description || p.name;
+              const name = displayName !== p.email ? displayName : '';
+              results.push({ name, email: p.email });
               seen.add(addr);
             }
           }


### PR DESCRIPTION
## Summary

Fix #429 

## Changes

- fetchDirectory: changed name: p.name || email → name: p.description || p.name || email so Stalwart's description field (which holds the real display name) is used as the stored name
- getAutocomplete: when a directory principal's email is already in results (from contacts with no display name), seen.has(addr) now checks if the existing result has only an email-as-name and upgrades it with the directory's real name from description instead of silently skipping

## Related Issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Fix #429


## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

<img width="1182" height="148" alt="image" src="https://github.com/user-attachments/assets/00bd02b4-95d7-4f11-be56-dd407d6fd48b" />


## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
