### PR TITLE
feat: split a pasted address list into recipient chips

### DIFF
--- a/components/email/__tests__/recipient-paste.test.tsx
+++ b/components/email/__tests__/recipient-paste.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { fireEvent } from '@testing-library/dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
 import { EmailComposer } from '../email-composer';
 
-// ─── Heavy component mocks ────────────────────────────────────────────────────
+// ─── Heavy component mocks (mirrors recipient-chip-drag.test.tsx) ──────────────
 
 vi.mock('@/components/email/rich-text-editor', () => ({
   RichTextEditor: ({ onChange }: { onChange?: (html: string) => void }) => (
@@ -26,7 +26,6 @@ vi.mock('@/hooks/use-pro-multi-account-identities', () => ({
 }));
 
 // ─── Store mocks ──────────────────────────────────────────────────────────────
-// vi.mock factories are hoisted, so all values must be defined inline.
 
 vi.mock('@/stores/auth-store', () => {
   const state = {
@@ -185,33 +184,10 @@ vi.mock('@/components/email/quoted-html', () => ({
 }));
 vi.mock('@/lib/template-utils', () => ({ substitutePlaceholders: (s: string) => s }));
 
-// ─── DataTransfer polyfill ────────────────────────────────────────────────────
-
-/** jsdom's built-in DataTransfer doesn't fully support setData/getData in synthetic drag events. */
-class MockDataTransfer {
-  private _data: Record<string, string> = {};
-  types: string[] = [];
-  effectAllowed = '';
-  dropEffect = '';
-
-  setData(type: string, data: string) {
-    this._data[type] = data;
-    if (!this.types.includes(type)) this.types.push(type);
-  }
-
-  getData(type: string): string {
-    return this._data[type] ?? '';
-  }
-
-  setDragImage(_image: Element, _x: number, _y: number) {
-    // no-op: jsdom has no rendering, but the chip drag handler calls this.
-  }
-}
-
 // ─── Shared test data ─────────────────────────────────────────────────────────
 
-const BASE_DATA = {
-  to: 'alice@example.com, ',
+const EMPTY_DATA = {
+  to: '',
   cc: '',
   bcc: '',
   subject: '',
@@ -224,141 +200,118 @@ const BASE_DATA = {
   draftId: null,
 };
 
+/** next-intl is mocked to return the key, so the To placeholder is "to_placeholder". */
+const toInput = () => screen.getByPlaceholderText('to_placeholder') as HTMLInputElement;
+const ccInput = () => screen.getByPlaceholderText('cc_placeholder') as HTMLInputElement;
+
+const paste = (input: HTMLElement, text: string) =>
+  fireEvent.paste(input, { clipboardData: { getData: () => text } });
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
-describe('RecipientChipInput drag and drop', () => {
+describe('RecipientChipInput paste', () => {
   beforeEach(() => { vi.clearAllMocks(); });
 
-  it('renders recipient chips with draggable="true"', async () => {
-    render(<EmailComposer initialData={BASE_DATA} />);
+  it('splits a pasted list (comma / semicolon / whitespace) into one chip per address', () => {
+    render(<EmailComposer initialData={EMPTY_DATA} />);
+    const input = toInput(); // capture once — placeholder disappears once chips exist
+    paste(input, 'a@x.com b@y.com; c@z.com');
 
-    const chipText = await screen.findByText('alice@example.com');
-    const chipSpan = chipText.closest('[draggable]');
-    expect(chipSpan).not.toBeNull();
-    expect(chipSpan).toHaveAttribute('draggable', 'true');
+    expect(screen.getByText('a@x.com')).toBeInTheDocument();
+    expect(screen.getByText('b@y.com')).toBeInTheDocument();
+    expect(screen.getByText('c@z.com')).toBeInTheDocument();
+    // all consumed → input cleared
+    expect(input.value).toBe('');
   });
 
-  it('onDragStart encodes the recipient and source field into dataTransfer', async () => {
-    render(<EmailComposer initialData={BASE_DATA} />);
+  it('chips the valid addresses and leaves invalid text in the input', () => {
+    render(<EmailComposer initialData={EMPTY_DATA} />);
+    const input = toInput();
+    paste(input, 'foo bar a@x.com');
 
-    const chipText = await screen.findByText('alice@example.com');
-    const chipSpan = chipText.closest('[draggable]') as HTMLElement;
-
-    const dt = new MockDataTransfer();
-    fireEvent.dragStart(chipSpan, { dataTransfer: dt });
-
-    const payload = JSON.parse(dt.getData('application/x-recipient-chip'));
-    expect(payload).toEqual({ recipient: { email: 'alice@example.com' }, fromField: 'to' });
+    expect(screen.getByText('a@x.com')).toBeInTheDocument();
+    expect(input.value).toBe('foo bar');
   });
 
-  it('keeps a display name with a comma in a single chip (array model)', async () => {
-    render(<EmailComposer initialData={{ ...BASE_DATA, to: '"Doo, John" <john@doo.org>, ' }} />);
+  it('does not pre-empt a single-address paste (no delimiter → normal editing)', () => {
+    render(<EmailComposer initialData={EMPTY_DATA} />);
+    paste(toInput(), 'single@x.com');
 
-    // One chip, displayed as "Doo, John (john@doo.org)" — not split on the comma.
-    const chip = await screen.findByText('Doo, John (john@doo.org)');
-    const chipSpan = chip.closest('[draggable]') as HTMLElement;
-    expect(chipSpan).not.toBeNull();
-
-    const dt = new MockDataTransfer();
-    fireEvent.dragStart(chipSpan, { dataTransfer: dt });
-    const payload = JSON.parse(dt.getData('application/x-recipient-chip'));
-    expect(payload).toEqual({ recipient: { name: 'Doo, John', email: 'john@doo.org' }, fromField: 'to' });
+    // The handler bailed out, so no chip was created from the single token.
+    expect(screen.queryByText('single@x.com')).not.toBeInTheDocument();
   });
 
-  it('onDragEnd clears the opacity class on the chip', async () => {
-    render(<EmailComposer initialData={BASE_DATA} />);
+  it('keeps display names from a fully-quoted "Name <email>" list', () => {
+    render(<EmailComposer initialData={EMPTY_DATA} />);
+    const input = toInput();
+    paste(input, '"Alice Smith <alice@x.com>", "Alex Smith <alex@x.com>"');
 
-    const chipText = await screen.findByText('alice@example.com');
-    const chipSpan = chipText.closest('[draggable]') as HTMLElement;
-
-    fireEvent.dragStart(chipSpan, { dataTransfer: new MockDataTransfer() });
-    expect(chipSpan.className).toContain('opacity-50');
-
-    fireEvent.dragEnd(chipSpan);
-    expect(chipSpan.className).not.toContain('opacity-50');
+    // Chips render as "Name (email)" when a display name is present.
+    expect(screen.getByText('Alice Smith (alice@x.com)')).toBeInTheDocument();
+    expect(screen.getByText('Alex Smith (alex@x.com)')).toBeInTheDocument();
+    expect(input.value).toBe('');
   });
 
-  it('dragOver on a different field container adds ring indicator; dragLeave removes it', async () => {
-    render(<EmailComposer initialData={BASE_DATA} />);
+  it('keeps a `Name <email>` pair as a single named chip', () => {
+    render(<EmailComposer initialData={EMPTY_DATA} />);
+    const input = toInput();
+    paste(input, 'John Doe <j@x.com>, jane@y.com');
 
-    await screen.findByText('alice@example.com');
-
-    // The flex-wrap containers are the actual drop zones
-    const allContainers = Array.from(document.querySelectorAll('[class*="flex-wrap"]'));
-    // To-container has the draggable chip; cc-container doesn't
-    const toContainer = allContainers.find(el => el.querySelector('[draggable]')) as HTMLElement;
-    const ccContainer = allContainers.find(el => el !== toContainer) as HTMLElement;
-
-    if (!ccContainer) return;
-
-    const dt = new MockDataTransfer();
-    dt.setData('application/x-recipient-chip', JSON.stringify({ recipient: { email: 'alice@example.com' }, fromField: 'to' }));
-
-    fireEvent.dragOver(ccContainer, { dataTransfer: dt });
-    expect(ccContainer.className).toContain('ring-primary');
-
-    fireEvent.dragLeave(ccContainer, { relatedTarget: null });
-    expect(ccContainer.className).not.toContain('ring-primary');
+    expect(screen.getByText('John Doe (j@x.com)')).toBeInTheDocument();
+    expect(screen.getByText('jane@y.com')).toBeInTheDocument();
+    expect(input.value).toBe('');
   });
 
-  it('drop on a different field container moves the chip', async () => {
-    render(<EmailComposer initialData={BASE_DATA} />);
-    await screen.findByText('alice@example.com');
+  it('keeps a comma inside a quoted display name intact', () => {
+    render(<EmailComposer initialData={EMPTY_DATA} />);
+    const input = toInput();
+    paste(input, '"Doe, John" <j@x.com>; bob@z.com');
 
-    const allContainers = Array.from(document.querySelectorAll('[class*="flex-wrap"]'));
-    const toContainer = allContainers.find(el => el.querySelector('[draggable]')) as HTMLElement;
-    const ccContainer = allContainers.find(el => el !== toContainer) as HTMLElement;
-
-    if (!toContainer || !ccContainer) return;
-
-    const dt = new MockDataTransfer();
-    dt.setData('application/x-recipient-chip', JSON.stringify({ recipient: { email: 'alice@example.com' }, fromField: 'to' }));
-    fireEvent.dragOver(ccContainer, { dataTransfer: dt });
-    act(() => {
-      fireEvent.drop(ccContainer, { dataTransfer: dt });
-    });
-
-    // Chip should still appear exactly once (moved, not duplicated or lost)
-    await screen.findByText('alice@example.com');
-    expect(screen.getAllByText('alice@example.com')).toHaveLength(1);
-
-    // The To container must now be empty
-    expect(toContainer.querySelectorAll('[draggable]')).toHaveLength(0);
+    expect(screen.getByText('Doe, John (j@x.com)')).toBeInTheDocument();
+    expect(screen.getByText('bob@z.com')).toBeInTheDocument();
+    expect(input.value).toBe('');
   });
 
-  it('drop on the same field container is a no-op', async () => {
-    render(<EmailComposer initialData={BASE_DATA} />);
-    await screen.findByText('alice@example.com');
+  it('splits a newline-separated block (e.g. a spreadsheet column)', () => {
+    render(<EmailComposer initialData={EMPTY_DATA} />);
+    const input = toInput();
+    paste(input, 'a@x.com\nb@y.com\nc@z.com');
 
-    const allContainers = Array.from(document.querySelectorAll('[class*="flex-wrap"]'));
-    const toContainer = allContainers.find(el => el.querySelector('[draggable]')) as HTMLElement;
-
-    const dt = new MockDataTransfer();
-    dt.setData('application/x-recipient-chip', JSON.stringify({ recipient: { email: 'alice@example.com' }, fromField: 'to' }));
-    fireEvent.dragOver(toContainer, { dataTransfer: dt });
-    act(() => {
-      fireEvent.drop(toContainer, { dataTransfer: dt });
-    });
-
-    // Chip stays present exactly once
-    expect(screen.getAllByText('alice@example.com')).toHaveLength(1);
+    expect(screen.getByText('a@x.com')).toBeInTheDocument();
+    expect(screen.getByText('b@y.com')).toBeInTheDocument();
+    expect(screen.getByText('c@z.com')).toBeInTheDocument();
+    expect(input.value).toBe('');
   });
 
-  it('dropping a chip onto the hidden Cc button shows the CC field', async () => {
-    render(<EmailComposer initialData={{ ...BASE_DATA, showCc: false, showBcc: false }} />);
-    await screen.findByText('alice@example.com');
+  it('dedupes case-insensitively within the paste and against existing chips', () => {
+    render(<EmailComposer initialData={EMPTY_DATA} />);
+    const input = toInput(); // DOM node persists across pastes (placeholder just clears)
+    paste(input, 'a@x.com, A@X.com, b@y.com'); // within-paste dup collapses
+    paste(input, 'A@X.COM, c@z.com'); // dup of an existing chip is dropped
 
-    const ccButton = screen.getByRole('button', { name: 'Cc' });
+    expect(screen.getByText('b@y.com')).toBeInTheDocument();
+    expect(screen.getByText('c@z.com')).toBeInTheDocument();
+    // a@x.com appears exactly once despite three case variants across two pastes.
+    expect(screen.getAllByText('a@x.com')).toHaveLength(1);
+    expect(screen.queryByText('A@X.COM')).not.toBeInTheDocument();
+    expect(input.value).toBe('');
+  });
 
-    const dt = new MockDataTransfer();
-    dt.setData('application/x-recipient-chip', JSON.stringify({ recipient: { email: 'alice@example.com' }, fromField: 'to' }));
-    fireEvent.dragOver(ccButton, { dataTransfer: dt });
-    act(() => {
-      fireEvent.drop(ccButton, { dataTransfer: dt });
-    });
+  it('chips the valid (named) entries and leaves a non-address token behind', () => {
+    render(<EmailComposer initialData={EMPTY_DATA} />);
+    const input = toInput();
+    paste(input, '"VIP" <vip@x.com>, not-an-email, b@y.com');
 
-    // cc_label is rendered by the mock translation as its key string
-    const ccLabel = await screen.findByText('cc_label');
-    expect(ccLabel).toBeInTheDocument();
+    expect(screen.getByText('VIP (vip@x.com)')).toBeInTheDocument();
+    expect(screen.getByText('b@y.com')).toBeInTheDocument();
+    expect(input.value).toBe('not-an-email');
+  });
+
+  it('works on the Cc field (shared handler)', () => {
+    render(<EmailComposer initialData={EMPTY_DATA} />);
+    paste(ccInput(), 'x@a.com; y@b.com');
+
+    expect(screen.getByText('x@a.com')).toBeInTheDocument();
+    expect(screen.getByText('y@b.com')).toBeInTheDocument();
   });
 });

--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -49,6 +49,7 @@ import {
   parseRecipient,
   parseRecipientList,
   formatRecipientList,
+  splitPastedRecipients,
   type Recipient,
 } from "@/lib/email-composer-utils";
 import { RichTextEditor } from "@/components/email/rich-text-editor";
@@ -2919,6 +2920,20 @@ function RecipientChipInput({
     }
   };
 
+  // Pasting a list of addresses (comma/semicolon/whitespace separated) splits
+  // into one chip per valid address; anything that isn't a valid address is
+  // left in the input for the user to fix. A single address with no separator
+  // falls through to the browser's normal paste so it stays editable.
+  const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    const text = e.clipboardData.getData('text');
+    if (!/[\s,;]/.test(text.trim())) return;
+    const { valid, invalid } = splitPastedRecipients(text, chips.map(c => c.email));
+    if (valid.length === 0) return;
+    e.preventDefault();
+    onChipsChange([...chips, ...valid]);
+    onInputChange([inputText.trim(), invalid.join(' ')].filter(Boolean).join(' '));
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (activeAutoField === field && autocompleteResults.length > 0) {
       if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Escape' ||
@@ -3113,6 +3128,7 @@ function RecipientChipInput({
             value={inputText}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             onBlur={handleBlur}
             className="flex-1 min-w-[120px] border-0 outline-none h-7 text-sm bg-transparent text-foreground placeholder:text-muted-foreground"
             role="combobox"

--- a/lib/__tests__/email-composer-utils.test.ts
+++ b/lib/__tests__/email-composer-utils.test.ts
@@ -9,6 +9,7 @@ import {
   parseRecipient,
   parseRecipientList,
   formatRecipientList,
+  splitPastedRecipients,
 } from "../email-composer-utils";
 
 describe("plainTextToComposerBody", () => {
@@ -150,6 +151,16 @@ describe("splitRecipients", () => {
   it("returns an empty array for an empty string", () => {
     expect(splitRecipients("")).toEqual([]);
   });
+
+  it("only splits on the given separators (default comma keeps semicolons/newlines literal)", () => {
+    expect(splitRecipients("a@x.com; b@y.com")).toEqual(["a@x.com; b@y.com"]);
+  });
+
+  it("splits on a wider separator set while keeping quotes/angles literal", () => {
+    expect(
+      splitRecipients('"Doo, John" <john@doo.org>; a@x.com\nb@y.com', ',;\n\r'),
+    ).toEqual(['"Doo, John" <john@doo.org>', "a@x.com", "b@y.com"]);
+  });
 });
 
 describe("formatRecipient / parseRecipient", () => {
@@ -196,5 +207,70 @@ describe("parseRecipientList / formatRecipientList", () => {
 
   it("parses an empty string to an empty array", () => {
     expect(parseRecipientList("")).toEqual([]);
+  });
+});
+
+describe("splitPastedRecipients", () => {
+  it("splits on commas, semicolons and whitespace (incl. newline/tab)", () => {
+    const { valid, invalid } = splitPastedRecipients(
+      "a@x.com, b@y.com; c@z.com\nd@w.com\te@v.com f@u.com",
+    );
+    expect(valid.map((r) => r.email)).toEqual([
+      "a@x.com", "b@y.com", "c@z.com", "d@w.com", "e@v.com", "f@u.com",
+    ]);
+    expect(invalid).toEqual([]);
+  });
+
+  it("collapses runs of mixed separators and drops empties", () => {
+    const { valid } = splitPastedRecipients("  a@x.com ,;  , b@y.com  ");
+    expect(valid.map((r) => r.email)).toEqual(["a@x.com", "b@y.com"]);
+  });
+
+  it("partitions invalid tokens into `invalid`, keeping valid as chips", () => {
+    const { valid, invalid } = splitPastedRecipients("a@x.com not-an-email b@y.com");
+    expect(valid.map((r) => r.email)).toEqual(["a@x.com", "b@y.com"]);
+    expect(invalid).toEqual(["not-an-email"]);
+  });
+
+  it("unwraps an angle-bracketed token before validating", () => {
+    const { valid } = splitPastedRecipients("<a@x.com>");
+    expect(valid).toEqual([{ email: "a@x.com" }]);
+  });
+
+  it("keeps a `Name <email>` pair as a single chip with its display name", () => {
+    const { valid, invalid } = splitPastedRecipients("John Doe <j@x.com>");
+    expect(valid).toEqual([{ name: "John Doe", email: "j@x.com" }]);
+    expect(invalid).toEqual([]);
+  });
+
+  it("keeps a fully-quoted `\"Name <email>\"` entry with its display name", () => {
+    const { valid, invalid } = splitPastedRecipients(
+      '"Alice Smith <alice@x.com>", "Alex Smith <alex@x.com>"',
+    );
+    expect(valid).toEqual([
+      { name: "Alice Smith", email: "alice@x.com" },
+      { name: "Alex Smith", email: "alex@x.com" },
+    ]);
+    expect(invalid).toEqual([]);
+  });
+
+  it("keeps a comma inside a quoted display name intact", () => {
+    const { valid } = splitPastedRecipients('"Doe, John" <j@x.com>; bob@z.com');
+    expect(valid).toEqual([
+      { name: "Doe, John", email: "j@x.com" },
+      { email: "bob@z.com" },
+    ]);
+  });
+
+  it("dedupes case-insensitively within the paste and against existing emails", () => {
+    const { valid } = splitPastedRecipients(
+      "a@x.com A@X.com b@y.com c@z.com",
+      ["B@Y.com"],
+    );
+    expect(valid.map((r) => r.email)).toEqual(["a@x.com", "c@z.com"]);
+  });
+
+  it("returns empty arrays for blank input", () => {
+    expect(splitPastedRecipients("   ")).toEqual({ valid: [], invalid: [] });
   });
 });

--- a/lib/email-composer-utils.ts
+++ b/lib/email-composer-utils.ts
@@ -1,3 +1,5 @@
+import { isValidEmail } from "@/lib/validation";
+
 const HTML_ESCAPE_MAP = {
   "&": "&amp;",
   "<": "&lt;",
@@ -56,13 +58,16 @@ export function rewriteCidImagesForEditor(html: string): string {
 export type Recipient = { name?: string; email: string };
 
 /**
- * Splits a comma-separated recipient string into individual entries. Commas
- * inside a quoted display name (`"Doo, John" <john@doo.org>`) or angle brackets
- * (`<a,b@x>`) are treated as literal, not separators. Only used at the
- * (de)serialization boundary — the live composer state is an array, so the UI
- * never round-trips through this. Trims each part and drops empties.
+ * Splits a recipient string into individual entries on any character in
+ * `separators`, treating those characters as literal when they sit inside a
+ * quoted display name (`"Doo, John" <john@doo.org>`) or angle brackets
+ * (`<a,b@x>`). Trims each part and drops empties.
+ *
+ * Defaults to comma-only, the (de)serialization boundary used by the composer
+ * state and mailto handling. Pasted lists pass a wider set (see
+ * {@link splitPasteEntries}) because they also use `;` and line breaks.
  */
-export function splitRecipients(value: string): string[] {
+export function splitRecipients(value: string, separators = ','): string[] {
   const result: string[] = [];
   let current = '';
   let inQuotes = false;
@@ -77,7 +82,7 @@ export function splitRecipients(value: string): string[] {
     } else if (ch === '>' && !inQuotes) {
       inAngle = false;
       current += ch;
-    } else if (ch === ',' && !inQuotes && !inAngle) {
+    } else if (separators.includes(ch) && !inQuotes && !inAngle) {
       const trimmed = current.trim();
       if (trimmed) result.push(trimmed);
       current = '';
@@ -138,6 +143,71 @@ export function parseRecipientList(value: string): Recipient[] {
 /** Serializes a recipient array into a comma-separated string. */
 export function formatRecipientList(recipients: Recipient[]): string {
   return recipients.map((r) => formatRecipient(r.name, r.email)).join(', ');
+}
+
+/**
+ * Top-level split of a pasted block into recipient entries on commas,
+ * semicolons and newlines (separators inside a quoted name or angle brackets
+ * stay literal). Broader than the comma-only default of {@link splitRecipients}
+ * because pasted lists also use `;` and line breaks as separators.
+ */
+function splitPasteEntries(value: string): string[] {
+  return splitRecipients(value, ',;\n\r');
+}
+
+/**
+ * Splits pasted text into recipient candidates and partitions them: valid email
+ * addresses become `Recipient`s (deduped case-insensitively against
+ * `existingEmails` and within the paste), and everything else is returned as
+ * `invalid` for the caller to drop back into the input field.
+ *
+ * Handles both structured and bare lists, preserving display names:
+ * - `"Name <email>"` (the whole recipient quoted), `Name <email>`, and
+ *   `"Doe, John" <email>` entries are kept intact with their display name.
+ * - Bare-address dumps (`a@x.com b@y.com`, spreadsheet columns, comma/space/
+ *   semicolon/newline separated) split into one chip per address.
+ * - A token wrapped in angle brackets (`<a@x.com>`) is unwrapped before
+ *   validating, so an `a <a@x.com>` fragment still yields the address.
+ */
+export function splitPastedRecipients(
+  text: string,
+  existingEmails: string[] = [],
+): { valid: Recipient[]; invalid: string[] } {
+  const seen = new Set(existingEmails.map((e) => e.toLowerCase()));
+  const valid: Recipient[] = [];
+  const invalid: string[] = [];
+
+  // Adds a recipient if its address is valid and unseen. Returns true when the
+  // entry is fully handled (valid or a known duplicate) so the caller can stop.
+  const tryAdd = (r: Recipient): boolean => {
+    if (!isValidEmail(r.email)) return false;
+    const key = r.email.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      valid.push(r.name ? { name: r.name, email: r.email } : { email: r.email });
+    }
+    return true;
+  };
+
+  // Split on commas, semicolons and newlines in a quote/angle-aware way so a
+  // `"Doe, John" <j@x.com>` or fully-quoted `"Name <email>"` entry stays a
+  // single recipient (separators inside the name or the address are literal).
+  for (const entry of splitPasteEntries(text)) {
+    // 1. Structured: `Name <email>`, a bare address, or the whole
+    //    `Name <email>` wrapped in quotes (unwrap once and retry).
+    if (tryAdd(parseRecipient(entry))) continue;
+    const unwrapped = unquoteName(entry);
+    if (unwrapped !== entry && tryAdd(parseRecipient(unwrapped))) continue;
+
+    // 2. Fallback: a bare-address run (`a@x.com b@y.com`) or a
+    //    `John Doe <j@x.com>` fragment where only the <addr> is valid.
+    //    Whitespace/semicolon-tokenize; leftover tokens stay behind.
+    for (const token of entry.split(/[\s;]+/).map((t) => t.trim()).filter(Boolean)) {
+      if (!tryAdd({ email: token.replace(/^<|>$/g, '') })) invalid.push(token);
+    }
+  }
+
+  return { valid, invalid };
 }
 
 /**


### PR DESCRIPTION
## Summary

Pasting a list of addresses into To/Cc/Bcc now creates one chip per address instead of dropping the whole blob in as a single invalid chip. A paste is split only when it actually contains a separator; a lone address falls through to normal editing.

- Separators: commas, semicolons, and any whitespace/newline - covers comma/space dumps, spreadsheet columns and Outlook-style `;` lists.
- Display names are preserved: `Name <email>`, a fully-quoted `"Name <email>"` entry, and `"Doe, John" <email>` (comma inside a quoted name) each stay a single chip with the name intact.
- Bare-address runs split per address; a `<addr>` token is unwrapped; tokens that aren't valid addresses are left behind in the input for the user to fix rather than becoming junk chips.
- Deduped case-insensitively within the paste and against existing chips.

Implemented as splitPastedRecipients in email-composer-utils, layered on the shared quote/angle-aware splitter: splitRecipients gains an optional `separators` argument so the composer/mailto serialization boundary (comma-only) and the paste path (`,;\n\r`) share one implementation. Wired into the recipient chip input's onPaste handler (To/Cc/Bcc).


## Changes

lib/email-composer-utils.ts:
- Add splitPastedRecipients(text, existingEmails): partitions a pasted block
  into { valid: Recipient[]; invalid: string[] }, deduped case-insensitively
  (within the paste and against existingEmails). Per top-level entry it tries
  parseRecipient (Name <email>, bare address, or a fully-quoted "Name <email>"
  unwrapped once), and otherwise falls back to whitespace/semicolon tokenizing
  for bare-address runs and "John Doe <j@x.com>" fragments. Imports isValidEmail
  from lib/validation (dependency-free, no cycle).
- Generalize the quote/angle-aware splitter rather than duplicate it:
  splitRecipients(value, separators = ',') gains an optional separator set so
  the comma-only (de)serialization boundary (composer state / mailto) and the
  paste path share one implementation. splitPasteEntries(text) is now just
  splitRecipients(text, ',;\n\r'); separators inside a quoted name or angle
  brackets stay literal.

components/email/email-composer.tsx:
- RecipientChipInput: add an onPaste handler on the recipient <input>. If the
  pasted text contains a separator and yields at least one valid address, it is
  split into chips (appended to the field), preventDefault is called, and the
  leftover invalid tokens are placed back in the input. Otherwise the paste is
  left to the browser. One handler covers To/Cc/Bcc (shared component).
- 

## Related Issues


## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [] I have added or updated documentation if needed
- [X] I have updated translations (`locales/`) if my changes affect user-facing text
- [X] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

[screen-capture-paste-email-list.webm](https://github.com/user-attachments/assets/28dc7d23-f8c2-45f7-a1d4-c52535652375)

## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
