### PR TITLE
feat(oauth): add OAUTH_AUTHORIZE_URL to override authorize endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,11 @@ JMAP_SERVER_URL=https://your-jmap-server.com
 # OpenID Connect issuer URL for discovery
 # OAUTH_ISSUER_URL=https://your-idp.example.com
 
+# Overrides only the user-facing authorize endpoint (e.g. a per-brand login
+# host). Discovery, token exchange and refresh keep using OAUTH_ISSUER_URL.
+# Leave unset to use the authorization_endpoint from discovery.
+# OAUTH_AUTHORIZE_URL=https://login.your-brand.example.com/application/o/authorize/
+
 # Allow OAuth discovery to resolve to private (RFC-1918 / loopback) addresses.
 # Off by default as an SSRF guard. Enable for split-DNS deployments where the
 # OAuth issuer's public hostname resolves to an internal IP from this server.

--- a/app/api/auth/sso/start/route.ts
+++ b/app/api/auth/sso/start/route.ts
@@ -8,6 +8,7 @@ import { discoverOAuth } from '@/lib/oauth/discovery';
 import { getOauthScopes } from '@/lib/oauth/tokens';
 import { getCookieOptions } from '@/lib/oauth/cookie-config';
 import { hasSessionSecret } from '@/lib/auth/session-secret';
+import { configManager } from '@/lib/admin/config-manager';
 
 const SSO_PENDING_COOKIE = 'sso_pending';
 const SSO_PENDING_MAX_AGE = 300; // 5 minutes
@@ -102,8 +103,12 @@ export async function POST(request: NextRequest) {
       maxAge: SSO_PENDING_MAX_AGE,
     });
 
-    // Build authorize URL
-    const authUrl = new URL(metadata.authorization_endpoint);
+    // Build authorize URL. OAUTH_AUTHORIZE_URL, when set, overrides only the
+    // user-facing authorize endpoint (e.g. a per-brand login host). Discovery,
+    // token exchange and refresh keep using the canonical discovered endpoints.
+    const authorizeOverride =
+      configManager.get<string>('oauthAuthorizeUrl', '') || process.env.OAUTH_AUTHORIZE_URL;
+    const authUrl = new URL(authorizeOverride?.trim() || metadata.authorization_endpoint);
     authUrl.searchParams.set('response_type', 'code');
     authUrl.searchParams.set('client_id', clientId);
     authUrl.searchParams.set('redirect_uri', redirect_uri);

--- a/lib/admin/types.ts
+++ b/lib/admin/types.ts
@@ -163,6 +163,11 @@ export const CONFIG_ENV_MAP: Record<string, { envVar: string; fileEnvVar?: strin
   oauthClientId: { envVar: 'OAUTH_CLIENT_ID', type: 'string', defaultValue: '' },
   oauthClientSecret: { envVar: 'OAUTH_CLIENT_SECRET', fileEnvVar: 'OAUTH_CLIENT_SECRET_FILE', type: 'string', defaultValue: '' },
   oauthIssuerUrl: { envVar: 'OAUTH_ISSUER_URL', type: 'url', defaultValue: '' },
+  // Overrides only the user-facing authorize endpoint. Discovery, token exchange
+  // and refresh continue to use the canonical OAUTH_ISSUER_URL. Lets a per-brand
+  // authorize host front a single canonical issuer. Empty = use the discovered
+  // authorization_endpoint.
+  oauthAuthorizeUrl: { envVar: 'OAUTH_AUTHORIZE_URL', type: 'url', defaultValue: '' },
   oauthScopes: { envVar: 'OAUTH_SCOPES', type: 'string', defaultValue: '' },
   oauthExtraScopes: { envVar: 'OAUTH_EXTRA_SCOPES', type: 'string', defaultValue: '' },
   oauthAllowPrivateEndpoints: { envVar: 'OAUTH_ALLOW_PRIVATE_ENDPOINTS', type: 'boolean', defaultValue: false },


### PR DESCRIPTION
## Summary

Adds an optional `OAUTH_AUTHORIZE_URL` env var that overrides **only** the OIDC authorize endpoint, while OIDC discovery, token exchange, and refresh continue to use `OAUTH_ISSUER_URL`. This lets a multi-tenant deployment put a per-brand, branded login host in front of a single canonical issuer, so the access token's `iss` stays constant for downstream resource servers (e.g. Stalwart, which validates `iss` against one configured issuer). Fully backward compatible — when the var is unset, behavior is unchanged.

## Changes

- Add `oauthAuthorizeUrl` (`OAUTH_AUTHORIZE_URL`) to the admin config types in `lib/admin/types.ts`, mirroring the existing `oauthIssuerUrl` entry.
- Apply the override at the single authorize-URL build site in `app/api/auth/sso/start/route.ts`; fall back to the discovered `authorization_endpoint` when unset.
- Document the new variable in `.env.example`.

## Related Issues

Closes #444

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [ ] N/A — no user-facing text changed (translations not affected)
- [ ] N/A — no UI changes (no screenshots)

## Screenshots / Demo

N/A — backend OIDC redirect behavior only, no UI change.

## Notes for Reviewers

- The change is intentionally minimal: one new documented env var, applied at a single site. Token exchange and refresh are deliberately left on the discovered canonical endpoint so the validated `iss` is deterministic.
- This relies on the IdP not binding the authorization code to the originating host. Verified with Authentik: auth codes carry no host binding, and `iss` is stamped from the token-request host at redemption — so a code minted at `auth.brand-a.example/authorize` redeems fine at the canonical token endpoint and yields the canonical `iss`.
- Running in production across three brands.