### PR TITLE
feat(avatar): Libravatar avatars for senders and recipients

### DIFF
--- a/app/api/libravatar/route.ts
+++ b/app/api/libravatar/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { resolveSrv } from 'node:dns/promises';
+import {
+  EMAIL_RE,
+  emailHash,
+  emailDomain,
+  clampSize,
+  isPublicHost,
+  buildAvatarUrl,
+  type SrvTarget,
+} from '@/lib/libravatar';
+
+// Libravatar avatar resolver (https://www.libravatar.org/).
+//
+// Federated, privacy-friendly Gravatar alternative. For an email address we:
+//   1. hash the normalised address (SHA-256, per the Libravatar spec),
+//   2. look up the domain's `_avatars-sec._tcp.<domain>` (https) SRV record;
+//      if a federated server is published we fetch the avatar from THERE
+//      (so self-hosted mail servers serve their own users' photos),
+//   3. otherwise fall back to the central seccdn.libravatar.org.
+// `d=404` means "no image → 404" so the <Avatar> component can fall back to
+// the sender favicon / initials instead of a default silhouette.
+//
+// All fetches happen server-side (DNS SRV isn't available in the browser),
+// behind the same SSRF guards + LRU cache as the favicon proxy.
+
+const CACHE_MAX_SIZE = 2000;
+const CACHE_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 2 weeks
+const NEGATIVE_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 1 day
+const NEGATIVE_CACHE_MAX_SIZE = 4000;
+const SRV_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+const FETCH_TIMEOUT_MS = 5000;
+const MAX_BYTES = 256 * 1024; // avatars are small; bound memory
+
+interface CacheEntry {
+  data: ArrayBuffer;
+  contentType: string;
+  fetchedAt: number;
+}
+const cache = new Map<string, CacheEntry>();
+const negativeCache = new Map<string, { fetchedAt: number }>();
+const srvCache = new Map<string, { target: SrvTarget | null; fetchedAt: number }>();
+
+function pruneCache<T>(map: Map<string, T>, max: number) {
+  if (map.size <= max) return;
+  const drop = Math.ceil(max * 0.1);
+  let i = 0;
+  for (const k of map.keys()) {
+    map.delete(k);
+    if (++i >= drop) break;
+  }
+}
+
+// Resolve the Libravatar federation target for a domain via the
+// `_avatars-sec._tcp.<domain>` (https) SRV record. null → use the central CDN.
+async function resolveFederatedTarget(domain: string): Promise<SrvTarget | null> {
+  const cached = srvCache.get(domain);
+  if (cached && Date.now() - cached.fetchedAt < SRV_CACHE_TTL_MS) return cached.target;
+  let target: SrvTarget | null = null;
+  try {
+    const records = await resolveSrv(`_avatars-sec._tcp.${domain}`);
+    const usable = records
+      .filter((r) => r.name && isPublicHost(r.name) && r.port > 0 && r.port <= 65535)
+      .sort((a, b) => a.priority - b.priority || b.weight - a.weight);
+    if (usable.length > 0) target = { host: usable[0].name, port: usable[0].port };
+  } catch {
+    target = null;
+  }
+  if (srvCache.size >= 1000) srvCache.clear();
+  srvCache.set(domain, { target, fetchedAt: Date.now() });
+  return target;
+}
+
+export async function GET(req: NextRequest) {
+  const email = req.nextUrl.searchParams.get('email');
+  const size = clampSize(req.nextUrl.searchParams.get('s'));
+
+  if (!email) return new NextResponse('Missing email', { status: 400 });
+  if (!EMAIL_RE.test(email)) return new NextResponse('Invalid email', { status: 400 });
+
+  const domain = emailDomain(email)!;
+  const hash = emailHash(email);
+  const cacheKey = `${hash}:${size}`;
+
+  const neg = negativeCache.get(cacheKey);
+  if (neg && Date.now() - neg.fetchedAt < NEGATIVE_CACHE_TTL_MS) {
+    return new NextResponse(null, { status: 404 });
+  }
+  const hit = cache.get(cacheKey);
+  if (hit && Date.now() - hit.fetchedAt < CACHE_TTL_MS) {
+    return new NextResponse(hit.data, {
+      status: 200,
+      headers: { 'Content-Type': hit.contentType, 'Cache-Control': 'public, max-age=86400' },
+    });
+  }
+
+  const target = await resolveFederatedTarget(domain);
+  const url = buildAvatarUrl(target, hash, size);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const upstream = await fetch(url, {
+      signal: controller.signal,
+      redirect: 'follow',
+      headers: { Accept: 'image/*' },
+    });
+    const contentType = upstream.headers.get('content-type') || '';
+    if (!upstream.ok || !contentType.startsWith('image/')) {
+      negativeCache.set(cacheKey, { fetchedAt: Date.now() });
+      pruneCache(negativeCache, NEGATIVE_CACHE_MAX_SIZE);
+      return new NextResponse(null, { status: 404 });
+    }
+    const buf = await upstream.arrayBuffer();
+    if (buf.byteLength === 0 || buf.byteLength > MAX_BYTES) {
+      negativeCache.set(cacheKey, { fetchedAt: Date.now() });
+      return new NextResponse(null, { status: 404 });
+    }
+    cache.set(cacheKey, { data: buf, contentType, fetchedAt: Date.now() });
+    pruneCache(cache, CACHE_MAX_SIZE);
+    return new NextResponse(buf, {
+      status: 200,
+      headers: { 'Content-Type': contentType, 'Cache-Control': 'public, max-age=86400' },
+    });
+  } catch {
+    negativeCache.set(cacheKey, { fetchedAt: Date.now() });
+    pruneCache(negativeCache, NEGATIVE_CACHE_MAX_SIZE);
+    return new NextResponse(null, { status: 404 });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/components/settings/advanced-settings.tsx
+++ b/components/settings/advanced-settings.tsx
@@ -17,7 +17,7 @@ const GIT_COMMIT = process.env.NEXT_PUBLIC_GIT_COMMIT || "unknown";
 export function AdvancedSettings() {
   const t = useTranslations('settings.advanced');
   const tCommon = useTranslations('common');
-  const { debugMode, debugCategories, senderFavicons, settingsSyncDisabled, updateSetting, resetToDefaults, exportSettings, importSettings } =
+  const { debugMode, debugCategories, senderFavicons, senderAvatars, settingsSyncDisabled, updateSetting, resetToDefaults, exportSettings, importSettings } =
     useSettingsStore();
   const { settingsSyncEnabled } = useConfig();
   const [showResetConfirm, setShowResetConfirm] = useState(false);
@@ -164,6 +164,11 @@ export function AdvancedSettings() {
       {/* Sender Favicons (Experimental) */}
       <SettingItem label={t('sender_favicons.label')} description={t('sender_favicons.description')}>
         <ToggleSwitch checked={senderFavicons} onChange={(checked) => updateSetting('senderFavicons', checked)} />
+      </SettingItem>
+
+      {/* Sender Avatars / Libravatar (Experimental) */}
+      <SettingItem label={t('sender_avatars.label')} description={t('sender_avatars.description')}>
+        <ToggleSwitch checked={senderAvatars} onChange={(checked) => updateSetting('senderAvatars', checked)} />
       </SettingItem>
 
       {/* Export Settings */}

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -63,6 +63,8 @@ function getRootDomain(domain: string): string {
 // Module-level cache of domains whose favicons failed to load.
 // Shared across all Avatar instances to avoid re-requesting known-bad domains.
 const failedFaviconDomains = new Set<string>();
+// Emails whose Libravatar lookup 404'd this session — don't retry.
+const failedAvatarEmails = new Set<string>();
 // Personal email domains where the favicon is the mail provider logo, not the sender
 const PERSONAL_DOMAINS = new Set([
   "gmail.com", "googlemail.com", "outlook.com", "hotmail.com", "live.com",
@@ -144,6 +146,7 @@ interface AvatarProps {
 export function Avatar({ name, email, contactPhotoUri, size = "md", className }: AvatarProps) {
   const [imgError, setImgError] = useState(false);
   const senderFavicons = useSettingsStore((s) => s.senderFavicons);
+  const senderAvatars = useSettingsStore((s) => s.senderAvatars);
   const contacts = useContactStore((s) => s.contacts);
   const { devMode } = useConfig();
 
@@ -199,22 +202,36 @@ export function Avatar({ name, email, contactPhotoUri, size = "md", className }:
   };
 
   const profilePic = email && domain ? getProfilePictureUrl(email, domain, devMode, name) : null;
+  const avatarPx = size === "lg" ? 96 : size === "sm" ? 64 : 80;
+  const avatarFailed = email ? failedAvatarEmails.has(email.toLowerCase()) : false;
+  // Libravatar (federated, privacy-friendly) avatar for any address, resolved
+  // server-side via /api/libravatar (SRV federation + central fallback).
+  const libravatarSrc =
+    senderAvatars && email && !avatarFailed && !imgError && !domainFailed
+      ? `/api/libravatar?email=${encodeURIComponent(email)}&s=${avatarPx}`
+      : null;
   const showFavicon =
     senderFavicons && faviconDomain && !PERSONAL_DOMAINS.has(faviconDomain) && !imgError && !domainFailed;
 
   // Priority: contact photo > custom avatar > profile picture > company favicon > initials
   const customAvatar = devMode && email ? CUSTOM_AVATARS[email.toLowerCase()] : null;
   const imgSrc = !imgError && !domainFailed
-    ? resolvedContactPhoto || customAvatar || profilePic || (showFavicon ? `/api/favicon?domain=${encodeURIComponent(faviconDomain!)}` : null)
+    ? resolvedContactPhoto || customAvatar || profilePic || libravatarSrc || (showFavicon ? `/api/favicon?domain=${encodeURIComponent(faviconDomain!)}` : null)
     : (resolvedContactPhoto || customAvatar || profilePic || null);
 
   const handleImgError = useCallback(() => {
+    // A failed Libravatar lookup shouldn't poison the favicon domain — record
+    // it separately so the next render falls through to favicon/initials.
+    if (libravatarSrc && imgSrc === libravatarSrc && email) {
+      failedAvatarEmails.add(email.toLowerCase());
+    }
     setImgError(true);
-    // If this was a favicon URL (not a contact photo, custom avatar or profile pic), remember the domain
-    if (faviconDomain && !resolvedContactPhoto && !customAvatar && !profilePic) {
+    // If this was a favicon URL (not a contact photo, custom avatar, profile
+    // pic or libravatar), remember the domain.
+    if (faviconDomain && !resolvedContactPhoto && !customAvatar && !profilePic && !libravatarSrc) {
       failedFaviconDomains.add(faviconDomain);
     }
-  }, [faviconDomain, resolvedContactPhoto, customAvatar, profilePic]);
+  }, [faviconDomain, resolvedContactPhoto, customAvatar, profilePic, libravatarSrc, imgSrc, email]);
 
   return (
     <div

--- a/lib/__tests__/libravatar.test.ts
+++ b/lib/__tests__/libravatar.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normaliseEmail,
+  emailHash,
+  emailDomain,
+  clampSize,
+  isPublicHost,
+  buildAvatarUrl,
+  AVATAR_SIZE_DEFAULT,
+  AVATAR_SIZE_MAX,
+  AVATAR_SIZE_MIN,
+  LIBRAVATAR_CENTRAL_HOST,
+} from '@/lib/libravatar';
+
+describe('libravatar helpers', () => {
+  it('normalises email (trim + lowercase)', () => {
+    expect(normaliseEmail('  User@Example.COM ')).toBe('user@example.com');
+  });
+
+  it('hashes case-insensitively to 64 hex chars (sha256)', () => {
+    const a = emailHash('User@Example.com');
+    const b = emailHash('user@example.com');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+    expect(emailHash('other@example.com')).not.toBe(a);
+  });
+
+  it('extracts the domain for valid addresses, null otherwise', () => {
+    expect(emailDomain('jane@sub.example.co.uk')).toBe('sub.example.co.uk');
+    expect(emailDomain('not-an-email')).toBeNull();
+    expect(emailDomain('a@b')).toBeNull(); // no TLD
+  });
+
+  it('clamps avatar size', () => {
+    expect(clampSize(null)).toBe(AVATAR_SIZE_DEFAULT);
+    expect(clampSize('abc')).toBe(AVATAR_SIZE_DEFAULT);
+    expect(clampSize('1')).toBe(AVATAR_SIZE_MIN);
+    expect(clampSize('99999')).toBe(AVATAR_SIZE_MAX);
+    expect(clampSize('128')).toBe(128);
+  });
+
+  it('rejects non-public SRV targets (SSRF guard)', () => {
+    expect(isPublicHost('avatars.example.com')).toBe(true);
+    expect(isPublicHost('localhost')).toBe(false);
+    expect(isPublicHost('mail.internal')).toBe(false);
+    expect(isPublicHost('foo.local')).toBe(false);
+    expect(isPublicHost('10.0.0.5')).toBe(false);
+    expect(isPublicHost('')).toBe(false);
+  });
+
+  it('builds federated vs central avatar URLs', () => {
+    const hash = 'a'.repeat(64);
+    expect(buildAvatarUrl(null, hash, 80)).toBe(
+      `https://${LIBRAVATAR_CENTRAL_HOST}/avatar/${hash}?s=80&d=404`,
+    );
+    expect(buildAvatarUrl({ host: 'av.example.com', port: 443 }, hash, 80)).toBe(
+      `https://av.example.com/avatar/${hash}?s=80&d=404`,
+    );
+    expect(buildAvatarUrl({ host: 'av.example.com', port: 8443 }, hash, 96)).toBe(
+      `https://av.example.com:8443/avatar/${hash}?s=96&d=404`,
+    );
+  });
+});

--- a/lib/libravatar.ts
+++ b/lib/libravatar.ts
@@ -1,0 +1,76 @@
+import { createHash } from 'node:crypto';
+
+// Pure helpers for the Libravatar resolver (app/api/libravatar/route.ts).
+// Kept separate so they can be unit-tested without spinning up the route.
+
+export const LIBRAVATAR_CENTRAL_HOST = 'seccdn.libravatar.org';
+
+export const AVATAR_SIZE_MIN = 16;
+export const AVATAR_SIZE_MAX = 512;
+export const AVATAR_SIZE_DEFAULT = 80;
+
+export const EMAIL_RE =
+  /^[^\s@]+@([a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+)$/i;
+
+const HOST_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
+
+export interface SrvTarget {
+  host: string;
+  port: number;
+}
+
+/** Lower-case + trim, per the Libravatar hashing spec. */
+export function normaliseEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/** SHA-256 hex of the normalised address (Libravatar's recommended hash). */
+export function emailHash(email: string): string {
+  return createHash('sha256').update(normaliseEmail(email)).digest('hex');
+}
+
+/** Returns the domain for a valid address, else null. */
+export function emailDomain(email: string): string | null {
+  const m = EMAIL_RE.exec(email);
+  return m ? m[1].toLowerCase() : null;
+}
+
+export function clampSize(raw: string | null | undefined): number {
+  const n = raw ? parseInt(raw, 10) : AVATAR_SIZE_DEFAULT;
+  if (Number.isNaN(n)) return AVATAR_SIZE_DEFAULT;
+  return Math.min(AVATAR_SIZE_MAX, Math.max(AVATAR_SIZE_MIN, n));
+}
+
+/**
+ * SSRF guard for a federation target resolved from an SRV record: must be a
+ * public hostname (not localhost / *.local / *.internal / a bare IP).
+ */
+export function isPublicHost(host: string): boolean {
+  if (!host || host.length > 253 || !HOST_RE.test(host)) return false;
+  const lower = host.toLowerCase();
+  if (
+    lower === 'localhost' ||
+    lower.endsWith('.local') ||
+    lower.endsWith('.internal') ||
+    lower.endsWith('.arpa') ||
+    lower.endsWith('.localhost')
+  ) {
+    return false;
+  }
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(lower)) return false;
+  return true;
+}
+
+/**
+ * Build the avatar URL. With a federated SRV target, query that server;
+ * otherwise the central Libravatar CDN. `d=404` so a miss returns 404 and the
+ * caller can fall back to a favicon / initials.
+ */
+export function buildAvatarUrl(target: SrvTarget | null, hash: string, size: number): string {
+  const path = `/avatar/${hash}?s=${size}&d=404`;
+  if (target) {
+    const portPart = target.port === 443 ? '' : `:${target.port}`;
+    return `https://${target.host}${portPart}${path}`;
+  }
+  return `https://${LIBRAVATAR_CENTRAL_HOST}${path}`;
+}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1192,6 +1192,10 @@
         "label": "Sender Favicons (Experimental)",
         "description": "Show website icons as profile pictures for business senders"
       },
+      "sender_avatars": {
+        "label": "Sender Avatars (Experimental)",
+        "description": "Show Libravatar profile pictures for senders and recipients (federated, privacy-friendly)"
+      },
       "keyboard_shortcuts": {
         "label": "Keyboard Shortcuts",
         "description": "View available keyboard shortcuts",

--- a/stores/settings-store.ts
+++ b/stores/settings-store.ts
@@ -178,6 +178,7 @@ interface SettingsState {
 
   // Experimental
   senderFavicons: boolean;
+  senderAvatars: boolean;
 
   // Folders
   folderIcons: Record<string, string>; // mailboxId -> icon name
@@ -307,6 +308,7 @@ const DEFAULT_SETTINGS = {
 
   // Experimental
   senderFavicons: true,
+  senderAvatars: true,
 
   // Folders
   folderIcons: {} as Record<string, string>,
@@ -410,6 +412,7 @@ export const useSettingsStore = create<SettingsState>()(
           hideAccountSwitcher: state.hideAccountSwitcher,
           showRailAccountList: state.showRailAccountList,
           senderFavicons: state.senderFavicons,
+          senderAvatars: state.senderAvatars,
           folderIcons: state.folderIcons,
           emailKeywords: state.emailKeywords,
           sidebarApps: state.sidebarApps,


### PR DESCRIPTION
Adds federated, privacy-friendly avatar resolution ([Libravatar](https://www.libravatar.org/) — the self-hostable Gravatar alternative), so senders and recipients show a real profile photo instead of initials when there's no contact photo.

### How
- **`app/api/libravatar`** — server-side resolver: SHA-256 the normalised address, look up the domain's `_avatars-sec._tcp.<domain>` SRV record and fetch the avatar from the **federated** server if one is published (so self-hosted mail servers serve their own users' photos), otherwise the central `seccdn.libravatar.org`. `d=404` means a miss returns 404 so the `<Avatar>` falls through to the sender favicon / initials. Reuses the favicon proxy's SSRF guards + LRU (positive/negative) caching; SRV results cached for 1h.
- **`lib/libravatar`** — pure helpers (hash, domain extraction, size clamp, SSRF host check, URL builder) + unit tests.
- **`components/ui/avatar`** — new `libravatarSrc` slot in the existing priority chain (contact photo > custom > profile > **libravatar** > favicon > initials). A failed lookup is remembered per-address so it doesn't poison the favicon domain.
- **Settings** — new **"Sender Avatars (Experimental)"** toggle (`senderAvatars`, default on), mirroring the existing Sender Favicons toggle; persisted; `en` locale string added.

### Notes
- DNS SRV lookups aren't available in the browser, so resolution runs server-side via the API route (same model as the favicon proxy).
- The central `seccdn.libravatar.org` resolves the SHA-256 hash (verified against a real address), so Gravatar-backed users resolve too — while self-hosted domains can serve their own via the SRV record.
- No new dependencies. `typecheck`, `eslint`, and the new unit tests pass.

### Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run lib/__tests__/libravatar.test.ts` (6 tests)
- [x] `eslint` clean on changed files
- [x] Verified `seccdn.libravatar.org/avatar/<sha256>?s=80&d=404` returns the image for an address with an avatar, and 404 for an unknown address
- [ ] Maintainer: toggle **Settings → Advanced → Sender Avatars** and confirm avatars render for known senders
