### PR TITLE
chore: switch lint scripts from removed next lint to eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "next lint",
-    "lint:fix": "next lint --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "test:translations": "vitest run --no-isolate lib/__tests__/translations.test.ts",
     "prepare": "husky",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
## Summary

Next 16 removed the `next lint` subcommand. `npm run lint` therefore failed
immediately with:

    Invalid project directory provided, no such directory: <repo>/lint

(`next` treated the `lint` argument as a directory). Point the lint scripts at
ESLint directly. The repo already ships a flat config (eslint.config.mjs), so
no config migration is needed — only the npm script targets change.

No production code is touched.

## Changes

package.json:
- "lint":     "next lint"        ->  "eslint ."
- "lint:fix": "next lint --fix"  ->  "eslint . --fix"
- 
## Related Issues

## Type of Change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [ ] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
