### PR TITLE
Fix/download filename token cap

### DIFF
--- a/lib/__tests__/download-filename.test.ts
+++ b/lib/__tests__/download-filename.test.ts
@@ -41,11 +41,11 @@ describe('emailExportFilename', () => {
     expect(emailExportFilename(makeEmail({}), '{unknown_token}')).toBe('email.eml');
   });
 
-  it('CHARACTERISATION: per-token sanitise caps each value at 80 chars', () => {
-    // sanitizePart defaults to maxLen=80, applied per {token} during render —
-    // so a single long {subject} is truncated to 80 well before the 200 cap.
+  it('lets a single long token reach the 200-char filename cap', () => {
+    // Each {token} is now capped at FILENAME_MAX_LEN (200), so the overall
+    // filename limit governs instead of an earlier 80-char per-token cap.
     const out = emailExportFilename(makeEmail({ subject: 'a'.repeat(300) }), '{subject}');
-    expect(out).toBe('a'.repeat(80) + '.eml');
+    expect(out).toBe('a'.repeat(200) + '.eml');
   });
 });
 

--- a/lib/download-filename.ts
+++ b/lib/download-filename.ts
@@ -64,6 +64,11 @@ export const BUNDLE_TOKENS: { token: string; description: string }[] = [
   { token: "day", description: "2-digit day" },
 ];
 
+// Overall cap for a generated filename stem. Also used as the per-token cap so
+// a single long token (e.g. {subject}) isn't truncated earlier than the final
+// filename would be.
+const FILENAME_MAX_LEN = 200;
+
 function sanitizePart(input: string, maxLen = 80): string {
   const cleaned = input
     .replace(SAFE_CHARS, "_")
@@ -173,7 +178,7 @@ function renderRaw(template: string, vars: Record<string, string>): string {
   return template.replace(/\{(\w+)\}/g, (_, key: string) => {
     const value = vars[key];
     if (value === undefined) return "";
-    return sanitizePart(value);
+    return sanitizePart(value, FILENAME_MAX_LEN);
   });
 }
 
@@ -184,9 +189,9 @@ export function emailExportFilename(
   const opts = typeof options === "string" ? { template: options } : options;
   const template = opts.template ?? DEFAULT_EMAIL_TEMPLATE;
   const rendered = renderRaw(template, emailVars(email));
-  const cleaned = sanitizePart(rendered, 200);
+  const cleaned = sanitizePart(rendered, FILENAME_MAX_LEN);
   const transformed = applyTransforms(cleaned, opts);
-  const stem = transformed.slice(0, 200) || "email";
+  const stem = transformed.slice(0, FILENAME_MAX_LEN) || "email";
   return `${stem}.eml`;
 }
 
@@ -199,7 +204,7 @@ export function attachmentDownloadFilename(
   const template = opts.template ?? DEFAULT_ATTACHMENT_TEMPLATE;
   if (!email) {
     const filename = (attachment.name || "attachment").trim();
-    const cleaned = sanitizePart(filename, 200) || "attachment";
+    const cleaned = sanitizePart(filename, FILENAME_MAX_LEN) || "attachment";
     return applyTransforms(cleaned, opts) || cleaned;
   }
   const vars = attachmentVars(email, attachment);
@@ -208,10 +213,10 @@ export function attachmentDownloadFilename(
     if (value === undefined) return "";
     // Preserve dots in {filename} so the original extension survives the
     // sanitiser (it strips trailing dots otherwise).
-    return key === "filename" ? value.replace(SAFE_CHARS, "_") : sanitizePart(value);
+    return key === "filename" ? value.replace(SAFE_CHARS, "_") : sanitizePart(value, FILENAME_MAX_LEN);
   });
   const templateMentionsExt = /\{(ext|filename)\}/.test(template);
-  const cleaned = sanitizePart(rendered, 200) || "attachment";
+  const cleaned = sanitizePart(rendered, FILENAME_MAX_LEN) || "attachment";
   if (templateMentionsExt) {
     return applyTransforms(cleaned, opts) || cleaned;
   }
@@ -235,9 +240,9 @@ export function bundleExportFilename(
   const opts = typeof options === "string" ? { template: options } : options;
   const template = opts.template ?? DEFAULT_BUNDLE_TEMPLATE;
   const rendered = renderRaw(template, bundleVars(count, iso));
-  const cleaned = sanitizePart(rendered, 200);
+  const cleaned = sanitizePart(rendered, FILENAME_MAX_LEN);
   const transformed = applyTransforms(cleaned, opts);
-  const stem = transformed.slice(0, 200) || "emails";
+  const stem = transformed.slice(0, FILENAME_MAX_LEN) || "emails";
   return `${stem}.zip`;
 }
 


### PR DESCRIPTION
## Summary

Fixes one issue spotted in MR #451 

When building download filenames from a template, each {token} was sanitised
with sanitizePart's default 80-char cap. A single long token such as
{subject} was therefore truncated to 80 characters — well before the
documented 200-char filename limit, which was effectively unreachable per
token.

## Changes

lib/download-filename.ts:
- Introduce a FILENAME_MAX_LEN (200) constant and use it as the per-token cap
  in renderRaw and the attachment-template renderer, so the overall 200-char
  limit governs. The existing 200-literal caps now reference the constant too.

Tests:
- lib/__tests__/download-filename.test.ts — a single long {subject} reaches
  200 chars; a long attachment {name} reaches 200 before the appended
  extension; short values and {filename} extension preservation unchanged.

## Related Issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #

## Type of Change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
