### PR TITLE
Fix/subject prefix fullwidth colon

### DIFF
--- a/lib/__tests__/subject-prefix.test.ts
+++ b/lib/__tests__/subject-prefix.test.ts
@@ -10,10 +10,9 @@ describe('stripSubjectPrefixes', () => {
     expect(stripSubjectPrefixes('Re: AW: WG: foo')).toBe('foo');
   });
 
-  it('strips the Outlook [N] counter and Eudora *N counter', () => {
+  it('strips the Outlook [N] and Eudora *N counters', () => {
     expect(stripSubjectPrefixes('Re[2]: foo')).toBe('foo');
     expect(stripSubjectPrefixes('Re*3: foo')).toBe('foo');
-    expect(stripSubjectPrefixes('Re*: foo')).toBe('foo');
   });
 
   it('is case-insensitive and idempotent', () => {
@@ -21,47 +20,37 @@ describe('stripSubjectPrefixes', () => {
     expect(stripSubjectPrefixes(stripSubjectPrefixes('RE: Re: foo'))).toBe('foo');
   });
 
-  it('strips a Cyrillic reply token', () => {
+  it('strips a Cyrillic token and an ASCII-colon Chinese token', () => {
     expect(stripSubjectPrefixes('Ответ: foo')).toBe('foo');
-  });
-
-  it('strips a Chinese token followed by an ASCII colon', () => {
     expect(stripSubjectPrefixes('回复: foo')).toBe('foo');
   });
 
-  it('CHARACTERISATION: does NOT strip a token followed by a full-width colon', () => {
-    // The colon in the regex is ASCII ":"; a full-width "：" (U+FF1A), as some
-    // CJK mail clients emit, is left untouched. Likely a bug — see follow-ups.
-    expect(stripSubjectPrefixes('回复：foo')).toBe('回复：foo');
+  it('strips a token followed by a full-width colon (CJK clients)', () => {
+    expect(stripSubjectPrefixes('回复：foo')).toBe('foo');
+    expect(stripSubjectPrefixes('回覆：foo')).toBe('foo');
+    expect(stripSubjectPrefixes('Re：foo')).toBe('foo');
   });
 
-  it('does NOT strip a bare single-letter "R:" (would eat real subjects)', () => {
+  it('still does not strip a bare single-letter "R:"', () => {
     expect(stripSubjectPrefixes('R: budget 2024')).toBe('R: budget 2024');
   });
 
-  it('returns "" for empty / null / undefined', () => {
+  it('returns "" for empty / null / undefined and leaves clean subjects alone', () => {
     expect(stripSubjectPrefixes('')).toBe('');
     expect(stripSubjectPrefixes(null)).toBe('');
     expect(stripSubjectPrefixes(undefined)).toBe('');
-  });
-
-  it('leaves a prefix-free subject untouched', () => {
     expect(stripSubjectPrefixes('foo')).toBe('foo');
   });
 });
 
 describe('buildReplySubject / buildForwardSubject', () => {
-  it('replaces an existing prefix chain with the given prefix', () => {
-    expect(buildReplySubject('AW: WG: foo', 'Re:')).toBe('Re: foo');
+  it('replaces a prefix chain (incl. a full-width colon) with the given prefix', () => {
+    expect(buildReplySubject('回复：foo', 'Re:')).toBe('Re: foo');
     expect(buildForwardSubject('Re: foo', 'Fwd:')).toBe('Fwd: foo');
   });
 
-  it('prepends the prefix to a prefix-free subject', () => {
+  it('prepends to a clean subject and returns the bare prefix for empty input', () => {
     expect(buildReplySubject('foo', 'AW:')).toBe('AW: foo');
-  });
-
-  it('returns just the bare prefix for an empty subject', () => {
     expect(buildReplySubject('', 'AW:')).toBe('AW:');
-    expect(buildForwardSubject(null, 'Fwd:')).toBe('Fwd:');
   });
 });

--- a/lib/subject-prefix.ts
+++ b/lib/subject-prefix.ts
@@ -64,8 +64,10 @@ function buildPrefixRegex(tokens: string[]): RegExp {
   // Sort by length DESC so longer tokens (e.g. "Пересл") win over their
   // shorter prefixes (e.g. "Пер") during alternation matching.
   escaped.sort((a, b) => b.length - a.length);
+  // Accept both the ASCII colon and the full-width colon "：" (U+FF1A) that CJK
+  // mail clients emit after a localized prefix (e.g. "回复：foo").
   return new RegExp(
-    `^\\s*(?:${escaped.join("|")})(?:\\[\\d+\\]|\\*\\d*)?\\s*:\\s*`,
+    `^\\s*(?:${escaped.join("|")})(?:\\[\\d+\\]|\\*\\d*)?\\s*[:\\uFF1A]\\s*`,
     "i",
   );
 }


### PR DESCRIPTION
## Summary

Fixes on issue spotted in MR #451

Reply/forward subject prefixes from CJK mail clients use a full-width colon
("回复：foo", U+FF1A) rather than an ASCII ":". The prefix-stripping regex
matched only the ASCII colon, so such prefixes were left in place — and on
reply the user's own localized prefix was stacked on top, growing the subject
chain ("Re: 回复：foo") instead of replacing it.

## Changes


lib/subject-prefix.ts:
- buildPrefixRegex now accepts both ":" and the full-width "：" (U+FF1A) after
  the prefix token.

Tests:
- lib/__tests__/subject-prefix.test.ts — full-width colon cases ("回复：foo",
  "回覆：foo", "Re：foo") plus the existing ASCII / multilingual / counter /
  idempotency / bare-"R:" cases.

## Related Issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #

## Type of Change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
