### PR TITLE
fix(mail-list): truncate long subjects so they don't overlap the timestamp

### DIFF
--- a/components/email/email-list-item.tsx
+++ b/components/email/email-list-item.tsx
@@ -191,13 +191,13 @@ export function EmailListItem({ email, selected, onClick, onDoubleClick, onConte
                 </span>
                 <div className="flex min-w-0 flex-1 items-center gap-2 text-sm">
                   <span className={cn(
-                    'shrink-0 truncate',
+                    'min-w-0 truncate',
                     isUnread ? 'font-semibold text-foreground' : 'text-foreground/90'
                   )}>
                     {email.subject || t('no_subject')}
                   </span>
                   {inlinePreview && (
-                    <span className="min-w-0 truncate text-muted-foreground">{inlinePreview}</span>
+                    <span className="min-w-0 shrink-[9999] truncate text-muted-foreground">{inlinePreview}</span>
                   )}
                 </div>
               </div>

--- a/components/email/thread-list-item.tsx
+++ b/components/email/thread-list-item.tsx
@@ -222,13 +222,13 @@ const SingleEmailItem = React.forwardRef<HTMLDivElement, SingleEmailItemProps>(
                   </span>
                   <div className="flex min-w-0 flex-1 items-center gap-2 text-sm">
                     <span className={cn(
-                      'shrink-0 truncate',
+                      'min-w-0 truncate',
                       isUnread ? 'font-semibold text-foreground' : 'text-foreground/90'
                     )}>
                       {email.subject || '(no subject)'}
                     </span>
                     {inlinePreview && (
-                      <span className="min-w-0 truncate text-muted-foreground">{inlinePreview}</span>
+                      <span className="min-w-0 shrink-[9999] truncate text-muted-foreground">{inlinePreview}</span>
                     )}
                   </div>
                 </div>
@@ -658,13 +658,13 @@ export const ThreadListItem = React.forwardRef<HTMLDivElement, ThreadListItemPro
                     </span>
                     <div className="flex min-w-0 flex-1 items-center gap-2 text-sm">
                       <span className={cn(
-                        'shrink-0 truncate',
+                        'min-w-0 truncate',
                         hasUnread ? 'font-semibold text-foreground' : 'text-foreground/90'
                       )}>
                         {latestEmail.subject || '(no subject)'}
                       </span>
                       {inlinePreview && (
-                        <span className="min-w-0 truncate text-muted-foreground">{inlinePreview}</span>
+                        <span className="min-w-0 shrink-[9999] truncate text-muted-foreground">{inlinePreview}</span>
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
## Bug

In the single-line (focused) message-list layout, a long subject overflows its
column and renders **on top of the timestamp**, hiding the time (e.g. a backup
"…completed successfully" subject runs straight through "11:05").

## Cause

The subject span used `shrink-0`. With `flex-shrink: 0`, `truncate` can't
engage — the span sizes to its full content width and overflows the bounded
subject/preview group, spilling over the time on the right.

## Fix

- Subject `shrink-0` → `min-w-0` so it can shrink and `truncate` with an ellipsis.
- Inline preview gets `shrink-[9999]` so it collapses **first** — the subject
  stays fully visible while there's room and only truncates once the preview is
  gone, so the prominence ordering (subject > preview) is preserved and the
  subject never collides with the time.

Applied to both `email-list-item` and `thread-list-item` (single-email and
thread-aggregate rows — both had the identical pattern).

## Verification

Measured in a faithful repro of the exact flex structure:

| | subject right edge | time left edge | result |
|---|---|---|---|
| before | 1210px | 628px | **overlaps by 582px**, not truncated |
| after | 608px | 628px | clear of the time, **truncated** (scrollWidth 999 → clientWidth 397) |

- [x] `npm run typecheck`, `npm run lint`, `npm run build` — green
- [x] `email-list-item` tests — 8/8 pass
- CSS-only change (two className tweaks per file); no behavior/logic changes.
