### PR TITLE
fix(mail-list): space between the unread dot and the avatar

### DIFF
--- a/components/email/email-list-item.tsx
+++ b/components/email/email-list-item.tsx
@@ -162,7 +162,7 @@ export function EmailListItem({ email, selected, onClick, onDoubleClick, onConte
 
         {/* Unread indicator */}
         {isUnread && (
-          <div className="absolute left-1 top-1/2 -translate-y-1/2">
+          <div className="absolute left-0.5 top-1/2 -translate-y-1/2">
             <Circle className="w-2 h-2 fill-unread text-unread" />
           </div>
         )}

--- a/components/email/thread-list-item.tsx
+++ b/components/email/thread-list-item.tsx
@@ -188,7 +188,7 @@ const SingleEmailItem = React.forwardRef<HTMLDivElement, SingleEmailItemProps>(
           )}
 
           {isUnread && (
-            <div className="absolute left-1 top-1/2 -translate-y-1/2">
+            <div className="absolute left-0.5 top-1/2 -translate-y-1/2">
               <Circle className="w-2 h-2 fill-unread text-unread" />
             </div>
           )}
@@ -585,7 +585,7 @@ export const ThreadListItem = React.forwardRef<HTMLDivElement, ThreadListItemPro
             )}
 
             {hasUnread && (
-              <div className="absolute left-1 top-1/2 -translate-y-1/2">
+              <div className="absolute left-0.5 top-1/2 -translate-y-1/2">
                 <Circle className="w-2 h-2 fill-unread text-unread" />
               </div>
             )}


### PR DESCRIPTION
## Issue

The unread-indicator blue dot sits flush against the avatar — there's no
visible breathing room between them.

## Cause

The dot is absolutely positioned at `left-1` (4px). The avatar starts at the
row's `px-4` gutter (16px), so the dot's right edge (12px) ends only **4px**
before the avatar — too tight, so it reads as touching.

## Fix

Move the dot to `left-0.5` (2px from the panel edge). This sits the dot nearer
the left edge (the convention in most mail clients) and opens the dot-to-avatar
gap from 4px to **6px**, without shifting any row content. Applied to all three
absolute-positioned dot instances (`email-list-item` ×1, `thread-list-item` ×2).

| | edge gap | dot → avatar gap |
|---|---|---|
| before (`left-1`) | 4px | 4px |
| after (`left-0.5`) | 2px | 6px |

## Verification

- [x] `npm run typecheck`, `npm run build` — green
- CSS-only change (one class per dot); no logic changes.
