### PR TITLE
fix: guard compose Send against double-submit

### DIFF
--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -1490,7 +1490,16 @@ export function EmailComposer({
     };
   };
 
+  // Guard against double-submit. Rapid Send clicks (or a click racing the
+  // keyboard shortcut) used to invoke handleSend once per click before the
+  // first submission resolved, sending the message multiple times. The ref is
+  // a synchronous re-entry guard - state updates are async and wouldn't block a
+  // second click in the same tick - and isSending drives button disabling.
+  const [isSending, setIsSending] = useState(false);
+  const isSendingRef = useRef(false);
+
   const handleSend = async (skipAttachmentCheck = false, delayedUntil?: string) => {
+    if (isSendingRef.current) return;
     const ccAddresses = withInput(cc, ccInput);
     const bccAddresses = withInput(bcc, bccInput);
 
@@ -1524,6 +1533,11 @@ export function EmailComposer({
         }
       }
     }
+
+    // Past every "don't send" early return - mark the send in flight so a
+    // second click is a no-op until this resolves (reset in the finally below).
+    isSendingRef.current = true;
+    setIsSending(true);
 
     // Resolve the freshest draftId we can. Two cases:
     //   1. An autosave is currently in flight - wait for it; don't issue a
@@ -1855,6 +1869,9 @@ export function EmailComposer({
     } catch (err) {
       debug.error('Failed to send email:', err);
       toast.error(err instanceof Error ? err.message : t('send_failed'));
+    } finally {
+      isSendingRef.current = false;
+      setIsSending(false);
     }
   };
 
@@ -2034,7 +2051,7 @@ export function EmailComposer({
         {/* Mobile: send button in header */}
         <Button
           onClick={() => handleSend()}
-          disabled={!canSend}
+          disabled={!canSend || isSending}
           title={getSendTooltip()}
           size="sm"
           className="md:hidden h-9 px-4"
@@ -2541,7 +2558,7 @@ export function EmailComposer({
               <div ref={sendMenuRef} className="relative hidden md:inline-flex">
                 <Button
                   onClick={() => handleSend()}
-                  disabled={!canSend}
+                  disabled={!canSend || isSending}
                   title={getSendTooltip()}
                   className="rounded-r-none border-r border-primary-foreground/20"
                 >
@@ -2551,7 +2568,7 @@ export function EmailComposer({
                 <Button
                   type="button"
                   onClick={() => setShowSendMenu((open) => !open)}
-                  disabled={!canSend}
+                  disabled={!canSend || isSending}
                   title={t('schedule_send')}
                   className="rounded-l-none px-2"
                   aria-haspopup="menu"
@@ -2579,7 +2596,7 @@ export function EmailComposer({
             ) : (
               <Button
                 onClick={() => handleSend()}
-                disabled={!canSend}
+                disabled={!canSend || isSending}
                 title={getSendTooltip()}
                 className="hidden md:inline-flex"
               >
@@ -2642,7 +2659,7 @@ export function EmailComposer({
             {scheduleError && <p className="mt-2 text-sm text-destructive">{scheduleError}</p>}
             <div className="mt-5 flex justify-end gap-2">
               <Button variant="ghost" onClick={() => setShowScheduleDialog(false)}>{tCommon('cancel')}</Button>
-              <Button onClick={handleScheduleSend} disabled={!canSend}>{t('schedule_send')}</Button>
+              <Button onClick={handleScheduleSend} disabled={!canSend || isSending}>{t('schedule_send')}</Button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Problem

Every Send control in the composer is disabled only by `canSend`, which reflects **validity** (recipient/subject/body present) and never an in-flight submission. The composer stays interactive during the JMAP send round-trip, so clicking **Send** quickly more than once — or a click racing the keyboard send shortcut — invokes `handleSend` once per click and sends the message **multiple times**: the recipient gets duplicates and duplicate copies land in Sent.

It's easy to reproduce on a higher-latency connection, where the gap between click and the composer closing is long enough to "click again because nothing happened yet."

### Steps to reproduce
1. Compose a message with a recipient.
2. (Optional, makes it reliable) throttle the network to add latency.
3. Click **Send** two or three times in quick succession.
4. Observe two or three identical deliveries and two or three copies in Sent.

> Note: the existing scheduled-send / send-delay feature doesn't help here — it defers *when* the message goes out, but rapid clicks before the deferral is registered still enqueue multiple sends.

## Fix

Add a re-entry guard around `handleSend` in `components/email/email-composer.tsx`:

- **`isSendingRef` (a `ref`, not state)** — a *synchronous* guard, because state updates are async and wouldn't block a second click in the same tick. Checked at the top of `handleSend`; set `true` only **after** the "don't send" early returns (validation + attachment reminder), so the attachment-warning confirm path still re-enters correctly; cleared in a new `finally`.
- **`isSending` state** — drives `disabled={!canSend || isSending}` on every Send control.

This covers all send entry points: the three Send buttons, the keyboard shortcut, the schedule dialog, and the attachment-warning confirm. Exactly one message is sent regardless of how many times Send is activated.

## Notes

- No user-facing strings added, so no i18n changes.
- `npm run typecheck` and `npm run lint` both pass.
- UI-only behaviour change (a momentarily-disabled button); no screenshot adds much, but happy to add a short clip if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)