### PR TITLE
feat(compose): auto-detect RTL text direction while writing

### DIFF
--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -2316,6 +2316,7 @@ export function EmailComposer({
             <Input
               ref={subjectInputRef}
               type="text"
+              dir="auto"
               placeholder={t('subject_placeholder')}
               value={subject}
               onChange={(e) => {
@@ -2341,6 +2342,7 @@ export function EmailComposer({
         {plainTextMode ? (
           <textarea
             ref={bodyRef}
+            dir="auto"
             value={body}
             onChange={(e) => {
               setBody(e.target.value);

--- a/components/email/rich-text-editor.tsx
+++ b/components/email/rich-text-editor.tsx
@@ -64,6 +64,15 @@ const styledBlockAttributes = {
     renderHTML: (attrs: Record<string, string | null>) =>
       attrs.class ? { class: attrs.class } : {},
   },
+  // Per-block auto direction: the browser picks LTR/RTL from each block's first
+  // strong character, so Hebrew/Arabic paragraphs flip to RTL as you type. The
+  // attribute serializes into the sent HTML, so recipients see the same direction.
+  dir: {
+    default: "auto" as string | null,
+    parseHTML: (el: HTMLElement) => el.getAttribute("dir"),
+    renderHTML: (attrs: Record<string, string | null>) =>
+      attrs.dir ? { dir: attrs.dir } : {},
+  },
   "data-signature-block": {
     default: null as string | null,
     parseHTML: (el: HTMLElement) => el.getAttribute("data-signature-block"),
@@ -240,6 +249,8 @@ export function RichTextEditor({
     editorProps: {
       attributes: {
         class: "tiptap min-h-[100px] px-4 py-3 text-sm text-foreground",
+        // Auto-detect overall direction; per-block dir (above) handles mixed content.
+        dir: "auto",
       },
       handleDrop: (view, event) => {
         const upload = onImageUploadRef.current;


### PR DESCRIPTION
## What

The compose surface now **auto-detects text direction**: typing Hebrew, Arabic,
or any RTL script flips that paragraph to right-to-left, per paragraph, while
LTR text stays left-to-right. Mixed messages (some RTL lines, some LTR) each
align correctly.

## How

Pure `dir="auto"` — the browser's built-in bidi detection picks direction from
each block's first strong character. No new dependency.

- **rich-text-editor**: the `Paragraph` and `Heading` nodes are extended with a
  `dir` attribute defaulting to `auto`, so every block renders `dir="auto"`.
  Because `serializeEditorContent` uses ProseMirror's `DOMSerializer`, the
  attribute is preserved in the **sent HTML** — so recipients see the same
  direction, not just the author. The editor root also gets `dir="auto"`.
- **email-composer**: `dir="auto"` on the subject input and the plain-text body
  textarea, so those fields flip too.

## Notes

- Per-**block** (not whole-editor) detection means a Hebrew paragraph followed by
  an English one each get the right direction.
- Existing `dir` on pasted/quoted content is preserved (the attribute parses the
  element's existing `dir`).
- Reading view is unaffected: the message body already renders true-to-life in
  its iframe, where the email's own markup controls direction.

## Test plan

- [x] `npm run typecheck`, `npm run build` — green
- [ ] Type Hebrew/Arabic in the rich editor → that line flips RTL; English stays LTR
- [ ] Type a Hebrew subject → subject field flips RTL
- [ ] Plain-text mode → RTL detection works in the textarea
- [ ] Send an RTL message → received HTML carries `dir="auto"` (recipient sees RTL)
