### PR TITLE
feat(mail): return to the list after deleting the open message (not the next email)

### DIFF
--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -3101,11 +3101,13 @@ export default function Home() {
                     onForward={handleForward}
                     onDelete={() => {
                       // Deleting the open message returns to the list (Gmail-style),
-                      // not the next email. Deselect first so the store's
-                      // remove-and-advance sees no selection and doesn't auto-open
-                      // the next message; then delete the captured email.
+                      // not the next email — unless the user turned the setting off.
+                      // Deselect first so the store's remove-and-advance sees no
+                      // selection and doesn't auto-open the next message.
                       const target = selectedEmail;
-                      handleMobileBack();
+                      if (useSettingsStore.getState().returnToListAfterAction) {
+                        handleMobileBack();
+                      }
                       handleDelete(target);
                     }}
                     onArchive={() => handleArchive()}

--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -3099,7 +3099,15 @@ export default function Home() {
                     onReply={handleReply}
                     onReplyAll={handleReplyAll}
                     onForward={handleForward}
-                    onDelete={() => handleDelete()}
+                    onDelete={() => {
+                      // Deleting the open message returns to the list (Gmail-style),
+                      // not the next email. Deselect first so the store's
+                      // remove-and-advance sees no selection and doesn't auto-open
+                      // the next message; then delete the captured email.
+                      const target = selectedEmail;
+                      handleMobileBack();
+                      handleDelete(target);
+                    }}
                     onArchive={() => handleArchive()}
                     onToggleStar={handleToggleStar}
                     onSetColorTag={handleSetColorTag}

--- a/components/settings/reading-settings.tsx
+++ b/components/settings/reading-settings.tsx
@@ -22,6 +22,7 @@ export function ReadingSettings() {
     markAsReadDelay,
     deleteAction,
     permanentlyDeleteJunk,
+    returnToListAfterAction,
     showPreview,
     mailLayout,
     disableThreading,
@@ -173,6 +174,13 @@ export function ReadingSettings() {
         <ToggleSwitch
           checked={permanentlyDeleteJunk}
           onChange={(checked) => updateSetting('permanentlyDeleteJunk', checked)}
+        />
+      </SettingItem>
+
+      <SettingItem label={t('return_to_list_after_action.label')} description={t('return_to_list_after_action.description')}>
+        <ToggleSwitch
+          checked={returnToListAfterAction}
+          onChange={(checked) => updateSetting('returnToListAfterAction', checked)}
         />
       </SettingItem>
 

--- a/locales/cs/common.json
+++ b/locales/cs/common.json
@@ -1226,6 +1226,10 @@
         "off": "Vypnuto",
         "seconds": "{seconds} sekund",
         "unsupported": "Aktuální účet neoznamuje podporu odloženého odeslání. Nastavení zůstane uloženo pro jiné účty."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -1229,6 +1229,10 @@
         "off": "Fra",
         "seconds": "{seconds} sekunder",
         "unsupported": "Den aktuelle konto annoncerer ikke understøttelse af forsinket afsendelse. Indstillingen gemmes stadig for andre konti."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -1226,6 +1226,10 @@
         "off": "Aus",
         "seconds": "{seconds} Sekunden",
         "unsupported": "Das aktuelle Konto meldet keine Unterstützung für verzögertes Senden. Die Einstellung bleibt für andere Konten gespeichert."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1229,6 +1229,10 @@
         "off": "Off",
         "seconds": "{seconds} seconds",
         "unsupported": "The current account does not advertise delayed-send support. The setting is still saved for other accounts."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -1226,6 +1226,10 @@
         "off": "Desactivado",
         "seconds": "{seconds} segundos",
         "unsupported": "La cuenta actual no anuncia compatibilidad con envío demorado. La opción seguirá guardada para otras cuentas."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -1226,6 +1226,10 @@
         "off": "Désactivé",
         "seconds": "{seconds} secondes",
         "unsupported": "Le compte actuel n’annonce pas la prise en charge de l’envoi différé. Le réglage reste enregistré pour d’autres comptes."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/hu/common.json
+++ b/locales/hu/common.json
@@ -1229,6 +1229,10 @@
         "off": "Kikapcsolva",
         "seconds": "{seconds} másodperc",
         "unsupported": "A jelenlegi fiók nem támogatja a késleltetett küldést. A beállítás más fiókokhoz elmentésre kerül."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -1226,6 +1226,10 @@
         "off": "Disattivato",
         "seconds": "{seconds} secondi",
         "unsupported": "L’account corrente non dichiara il supporto all’invio ritardato. L’impostazione resta salvata per altri account."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -1226,6 +1226,10 @@
         "off": "オフ",
         "seconds": "{seconds} 秒",
         "unsupported": "現在のアカウントは遅延送信のサポートを通知していません。この設定は他のアカウント用に保存されます。"
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -1226,6 +1226,10 @@
         "off": "끔",
         "seconds": "{seconds}초",
         "unsupported": "현재 계정은 지연 보내기 지원을 알리지 않습니다. 설정은 다른 계정을 위해 계속 저장됩니다."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -1226,6 +1226,10 @@
         "off": "Izslēgts",
         "seconds": "{seconds} sekundes",
         "unsupported": "Pašreizējais konts neziņo par aizturētas sūtīšanas atbalstu. Iestatījums joprojām tiks saglabāts citiem kontiem."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -1226,6 +1226,10 @@
         "off": "Uit",
         "seconds": "{seconds} seconden",
         "unsupported": "Het huidige account meldt geen ondersteuning voor vertraagd verzenden. De instelling blijft opgeslagen voor andere accounts."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -1226,6 +1226,10 @@
         "off": "Wyłączone",
         "seconds": "{seconds} sekund",
         "unsupported": "Bieżące konto nie zgłasza obsługi opóźnionej wysyłki. Ustawienie pozostanie zapisane dla innych kont."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -1226,6 +1226,10 @@
         "off": "Desativado",
         "seconds": "{seconds} segundos",
         "unsupported": "A conta atual não anuncia suporte a envio atrasado. A configuração continuará salva para outras contas."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/ro/common.json
+++ b/locales/ro/common.json
@@ -1229,6 +1229,10 @@
         "off": "Oprit",
         "seconds": "{seconds} secunde",
         "unsupported": "Contul curent nu indică faptul că acceptă trimiterea amânată. Setarea este totuși salvată pentru alte conturi."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -1226,6 +1226,10 @@
         "off": "Выкл.",
         "seconds": "{seconds} сек.",
         "unsupported": "Текущая учетная запись не заявляет поддержку отложенной отправки. Настройка сохранится для других учетных записей."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/tr/common.json
+++ b/locales/tr/common.json
@@ -1226,6 +1226,10 @@
         "off": "Kapalı",
         "seconds": "{seconds} saniye",
         "unsupported": "Geçerli hesap gecikmeli gönderim desteği bildirmiyor. Ayar diğer hesaplar için kaydedilmeye devam eder."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/uk/common.json
+++ b/locales/uk/common.json
@@ -1226,6 +1226,10 @@
         "off": "Вимкнено",
         "seconds": "{seconds} с",
         "unsupported": "Поточний обліковий запис не повідомляє про підтримку відкладеного надсилання. Налаштування залишиться збереженим для інших облікових записів."
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -1226,6 +1226,10 @@
         "off": "关闭",
         "seconds": "{seconds} 秒",
         "unsupported": "当前账户未声明支持延迟发送。该设置仍会为其他账户保存。"
+      },
+      "return_to_list_after_action": {
+        "label": "Return to list after delete or mark unread",
+        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
       }
     },
     "composer": {

--- a/stores/settings-store.ts
+++ b/stores/settings-store.ts
@@ -137,6 +137,7 @@ interface SettingsState {
   markAsReadDelay: number; // milliseconds (0 = instant, -1 = never)
   deleteAction: DeleteAction;
   permanentlyDeleteJunk: boolean; // Permanently delete emails from junk/spam instead of moving to trash
+  returnToListAfterAction: boolean; // After delete / mark-unread in an open message, return to the list instead of opening the next message
   showPreview: boolean;
   mailLayout: MailLayout;
   emailsPerPage: number;
@@ -330,6 +331,7 @@ const DEFAULT_SETTINGS = {
   markAsReadDelay: 0, // Instant
   deleteAction: 'trash' as DeleteAction,
   permanentlyDeleteJunk: false,
+  returnToListAfterAction: true,
   showPreview: true,
   mailLayout: 'split' as MailLayout,
   emailsPerPage: 50,
@@ -533,6 +535,7 @@ export const useSettingsStore = create<SettingsState>()(
           firstDayOfWeek: state.firstDayOfWeek,
           markAsReadDelay: state.markAsReadDelay,
           deleteAction: state.deleteAction,
+          returnToListAfterAction: state.returnToListAfterAction,
           showPreview: state.showPreview,
           mailLayout: state.mailLayout,
           emailsPerPage: state.emailsPerPage,


### PR DESCRIPTION
## What

Deleting a message from **inside the open message** now returns to the message
list, instead of auto-advancing to the next email.

## Why

Auto-advancing to the next message after a delete is jarring — you read/delete
one mail and are suddenly dropped into an unrelated one. Gmail and most clients
return you to the list. (Same rationale as returning to the list after marking
the open message unread.)

## How

In the single-message viewer's `onDelete`, capture the open email, call
`handleMobileBack()` to return to the list **first**, then delete the captured
email. Deselecting first means the store's remove-and-advance logic
(`getNextSelectedEmailAfterRemoval`) sees no current selection and won't
auto-open the next message — which also avoids a flash of the next email before
the list appears.

## Scope

- Only the **open-message** delete. List-row deletes and keyboard
  delete-and-advance are unchanged (the store-level advance is untouched).
- Works on desktop/tablet/mobile (`handleMobileBack` clears the selection and
  shows the list).

## Test plan

- [x] `npm run typecheck`, `npm run build` — green
- [ ] Open a message → Delete → returns to the list (message gone, no next email opened)
- [ ] Delete a row from the list (hover action) → still advances as before
- [ ] Keyboard delete-and-next → unchanged
