### PR TITLE
feat(mail): return to the list after marking an open message unread (Gmail-style)

### DIFF
--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -3118,6 +3118,12 @@ export default function Home() {
                     onMarkAsRead={async (emailId, read) => {
                       if (client) {
                         await markAsRead(client, emailId, read);
+                        // Marking the open message unread returns to the list
+                        // (Gmail-style, gated on returnToListAfterAction). Staying
+                        // in the reading pane would just re-mark it read on view.
+                        if (!read && useSettingsStore.getState().returnToListAfterAction) {
+                          handleMobileBack();
+                        }
                       }
                     }}
                     onDownloadAttachment={handleDownloadAttachment}


### PR DESCRIPTION
Gmail-style: marking the currently-open message unread returns to the message list instead of staying in the reading pane (where auto-mark-read would just flip it back to read).

Gated on the `returnToListAfterAction` setting from #477 (default on); off keeps you in the viewer. Single-message viewer only, mark-unread only.

Replaces #468, which got stuck closed after a force-push and won't reopen. Same code, fresh PR.
