### PR TITLE
fix: stop unified-mailbox from mutating client-returned email objects

### DIFF
--- a/lib/__tests__/unified-mailbox.test.ts
+++ b/lib/__tests__/unified-mailbox.test.ts
@@ -120,16 +120,17 @@ describe('fetchUnifiedEmails', () => {
     expect(result).toEqual({ emails: [], total: 0, hasMore: false, errors: new Map() });
   });
 
-  it('CHARACTERISATION: mutates the source email objects in place (shared reference)', async () => {
+  it('does NOT mutate the source email objects (decorates copies)', async () => {
     const original = makeEmail('m1', '2026-01-01T00:00:00Z');
     const acc = makeAccount(
       { accountId: 'A', accountLabel: 'Label A', mailboxes: [makeMailbox({ role: 'inbox' })] },
       { getEmails: vi.fn(async (): Promise<FetchResult> => ({ emails: [original], total: 1, hasMore: false })) },
     );
-    await fetchUnifiedEmails([acc], 'inbox', 20, 0);
-    // The very object passed back by the client was mutated, not a copy.
-    expect(original.accountId).toBe('A');
-    expect(original.accountLabel).toBe('Label A');
+    const res = await fetchUnifiedEmails([acc], 'inbox', 20, 0);
+    // The returned email carries the account info, but the client's object is untouched.
+    expect(res.emails[0]).toMatchObject({ id: 'm1', accountId: 'A', accountLabel: 'Label A' });
+    expect('accountId' in original).toBe(false);
+    expect('accountLabel' in original).toBe(false);
   });
 });
 

--- a/lib/unified-mailbox.ts
+++ b/lib/unified-mailbox.ts
@@ -119,16 +119,19 @@ export async function fetchUnifiedEmails(
 
     const { account, result } = outcome.value;
 
-    // Decorate each email with the source account info.
-    for (const email of result.emails) {
-      email.accountId = account.accountId;
-      email.accountLabel = account.accountLabel;
-      email.sourceClientAccountId = account.clientAccountId;
-      email.sourceAccountId = account.jmapAccountId;
-      email.sourceFolder = resolveSourceFolderName(email, account.mailboxes);
-    }
+    // Decorate each email with the source account info. The per-account client
+    // returns shared object references; decorate shallow copies instead of
+    // mutating them in place so retained callers/snapshots aren't corrupted.
+    const decorated = result.emails.map((email) => ({
+      ...email,
+      accountId: account.accountId,
+      accountLabel: account.accountLabel,
+      sourceClientAccountId: account.clientAccountId,
+      sourceAccountId: account.jmapAccountId,
+      sourceFolder: resolveSourceFolderName(email, account.mailboxes),
+    }));
 
-    mergedEmails = mergedEmails.concat(result.emails);
+    mergedEmails = mergedEmails.concat(decorated);
     totalSum += result.total;
     if (result.hasMore) {
       anyHasMore = true;
@@ -247,14 +250,16 @@ async function fanOutUnifiedQuery(
   for (const outcome of results) {
     if (outcome.status !== 'fulfilled' || outcome.value === null) continue;
     const { account, result } = outcome.value;
-    for (const email of result.emails) {
-      email.accountId = account.accountId;
-      email.accountLabel = account.accountLabel;
-      email.sourceClientAccountId = account.clientAccountId;
-      email.sourceAccountId = account.jmapAccountId;
-      email.sourceFolder = resolveSourceFolderName(email, account.mailboxes);
-    }
-    mergedEmails = mergedEmails.concat(result.emails);
+    // Decorate shallow copies, not the shared client-returned objects.
+    const decorated = result.emails.map((email) => ({
+      ...email,
+      accountId: account.accountId,
+      accountLabel: account.accountLabel,
+      sourceClientAccountId: account.clientAccountId,
+      sourceAccountId: account.jmapAccountId,
+      sourceFolder: resolveSourceFolderName(email, account.mailboxes),
+    }));
+    mergedEmails = mergedEmails.concat(decorated);
     totalSum += result.total;
     if (result.hasMore) anyHasMore = true;
   }
@@ -383,14 +388,16 @@ async function fanOutCrossQuery(
   for (const outcome of results) {
     if (outcome.status !== 'fulfilled' || outcome.value === null) continue;
     const { account, result } = outcome.value;
-    for (const email of result.emails) {
-      email.accountId = account.accountId;
-      email.accountLabel = account.accountLabel;
-      email.sourceClientAccountId = account.clientAccountId;
-      email.sourceAccountId = account.jmapAccountId;
-      email.sourceFolder = resolveSourceFolderName(email, account.mailboxes);
-    }
-    mergedEmails = mergedEmails.concat(result.emails);
+    // Decorate shallow copies, not the shared client-returned objects.
+    const decorated = result.emails.map((email) => ({
+      ...email,
+      accountId: account.accountId,
+      accountLabel: account.accountLabel,
+      sourceClientAccountId: account.clientAccountId,
+      sourceAccountId: account.jmapAccountId,
+      sourceFolder: resolveSourceFolderName(email, account.mailboxes),
+    }));
+    mergedEmails = mergedEmails.concat(decorated);
     totalSum += result.total;
     if (result.hasMore) anyHasMore = true;
   }


### PR DESCRIPTION
## Summary

The cross-account fan-out helpers in lib/unified-mailbox.ts stamp the source
account info (accountId, accountLabel, sourceClientAccountId, sourceAccountId,
sourceFolder) onto every email before merging. main does this by MUTATING each
email object in place:

      email.accountId = account.accountId;
      email.accountLabel = account.accountLabel;
      ... (3 more fields)

Those objects are shared references handed back by the per-account JMAP client.
Mutating them in place could surprise any caller that retained them and corrupt
an account-state snapshot. The cross-account "All accounts" feature (a29c33b)
widened the bug: it carried the original two mutation sites forward and added a
third in the shared/group fan-out, so there are now three sites:

  - lib/unified-mailbox.ts  fetchUnifiedEmails
  - lib/unified-mailbox.ts  fanOutUnifiedQuery
  - lib/unified-mailbox.ts  fanOutCrossQuery   (new, from the cross-account feature)


## Changes

- lib/unified-mailbox.ts: at all THREE fan-out sites, decorate shallow copies
  instead of mutating the client's objects:

      const decorated = result.emails.map((email) => ({
        ...email,
        accountId: account.accountId,
        accountLabel: account.accountLabel,
        sourceClientAccountId: account.clientAccountId,
        sourceAccountId: account.jmapAccountId,
        sourceFolder: resolveSourceFolderName(email, account.mailboxes),
      }));
      mergedEmails = mergedEmails.concat(decorated);

  All five stamped fields are preserved; the merged result is identical, only the
  client's original objects are now left untouched.
- lib/__tests__/unified-mailbox.test.ts: flips the existing CHARACTERISATION test
  ("mutates the source email objects in place") into "does NOT mutate the source
  email objects (decorates copies)" - asserts the returned email carries the
  account info while the input object has neither accountId nor accountLabel.

## Related Issues

## Type of Change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
