### PR TITLE
fix: HTML-escape sender/subject in reply/forward quote header (#482)

### DIFF
--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -11,7 +11,7 @@ import { debug } from "@/lib/debug";
 import { toast } from "@/stores/toast-store";
 import { useContextMenu } from "@/hooks/use-context-menu";
 import { ContextMenu, ContextMenuItem, ContextMenuSeparator } from "@/components/ui/context-menu";
-import { sanitizeSignatureHtml, sanitizeEmailHtml } from "@/lib/email-sanitization";
+import { sanitizeSignatureHtml, sanitizeEmailHtml, escapeHtml } from "@/lib/email-sanitization";
 import { buildReplySubject, buildForwardSubject } from "@/lib/subject-prefix";
 import { isFilePreviewable } from "@/lib/file-preview";
 import { buildQuotedHtmlBlock, serializeEditorContent } from "@/components/email/quoted-html";
@@ -344,9 +344,8 @@ export function EmailComposer({
 
       const date = replyTo.receivedAt ? formatDateTime(replyTo.receivedAt, timeFormat, { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' }) : "";
       const from = replyTo.from?.[0];
-      const fromStr = from ? `${from.name || from.email}` : tCommon('unknown');
-      // Forward "From:" shows the full sender incl. address; reply line keeps
-      // the bare name (reads naturally in the localized "On … wrote:" line).
+      // Forward "From:" and the reply "On … wrote:" line both show the full
+      // sender incl. address ("Name <email>"), like Gmail/Outlook (#482).
       const fromStrFull = from
         ? (from.name && from.email && from.name !== from.email
             ? `${from.name} <${from.email}>`
@@ -374,7 +373,7 @@ export function EmailComposer({
       if (mode === 'forward') {
         return `${prefix}${signatureBlock}\n\n${tQuote('forwarded_separator')}\n${tQuote('from_label')}: ${fromStrFull}\n${tQuote('date_label')}: ${date}\n${tQuote('subject_label')}: ${replyTo.subject || ''}\n\n${originalText}`;
       } else if (mode === 'reply' || mode === 'replyAll') {
-        return `${prefix}${signatureBlock}\n\n${tQuote('reply_line', { date, from: fromStr })}\n${quotedText}`;
+        return `${prefix}${signatureBlock}\n\n${tQuote('reply_line', { date, from: fromStrFull })}\n${quotedText}`;
       }
       return prefix;
     }
@@ -396,7 +395,7 @@ export function EmailComposer({
 
     const date = replyTo.receivedAt ? formatDateTime(replyTo.receivedAt, timeFormat, { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' }) : "";
     const from = replyTo.from?.[0];
-    const fromStr = from ? `${from.name || from.email}` : tCommon('unknown');
+    // Forward and reply quote lines both show the full "Name <email>" sender (#482).
     const fromStrFull = from
       ? (from.name && from.email && from.name !== from.email
           ? `${from.name} <${from.email}>`
@@ -431,9 +430,11 @@ export function EmailComposer({
 
     // Build quoted content as HTML
     if (replyTo.htmlBody && (mode === 'reply' || mode === 'replyAll' || mode === 'forward')) {
+      // HTML-escape user-controlled values: an unescaped sender "Name <email>"
+      // has its "<email>" eaten as a bogus HTML tag by the rich-text editor (#482).
       const quoteHeader = mode === 'forward'
-        ? `${tQuote('forwarded_separator')}<br>${tQuote('from_label')}: ${fromStrFull}<br>${tQuote('date_label')}: ${date}<br>${tQuote('subject_label')}: ${replyTo.subject || ''}<br><br>`
-        : `${tQuote('reply_line', { date, from: fromStr })}<br>`;
+        ? `${tQuote('forwarded_separator')}<br>${tQuote('from_label')}: ${escapeHtml(fromStrFull)}<br>${tQuote('date_label')}: ${escapeHtml(date)}<br>${tQuote('subject_label')}: ${escapeHtml(replyTo.subject || '')}<br><br>`
+        : `${tQuote('reply_line', { date: escapeHtml(date), from: escapeHtml(fromStrFull) })}<br>`;
       // Embed the original as a QuotedHtml island (verbatim, schema-free) so
       // its layout survives the editor round-trip. Sanitize first to strip
       // scripts/styles/head; cid rewrite afterwards so data-cid markers
@@ -447,9 +448,9 @@ export function EmailComposer({
     if (replyTo.body) {
       const escapedOriginal = replyTo.body.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '<br>');
       if (mode === 'forward') {
-        return `${prefix}${signatureBlock}<br><br>${tQuote('forwarded_separator')}<br>${tQuote('from_label')}: ${fromStrFull}<br>${tQuote('date_label')}: ${date}<br>${tQuote('subject_label')}: ${replyTo.subject || ''}<br><br>${escapedOriginal}`;
+        return `${prefix}${signatureBlock}<br><br>${tQuote('forwarded_separator')}<br>${tQuote('from_label')}: ${escapeHtml(fromStrFull)}<br>${tQuote('date_label')}: ${escapeHtml(date)}<br>${tQuote('subject_label')}: ${escapeHtml(replyTo.subject || '')}<br><br>${escapedOriginal}`;
       } else if (mode === 'reply' || mode === 'replyAll') {
-        return `${prefix}${signatureBlock}<br><br>${tQuote('reply_line', { date, from: fromStr })}<br><blockquote style="margin:0 0 0 0.8ex;border-left:2px solid #ccc;padding-left:1ex">${escapedOriginal}</blockquote>`;
+        return `${prefix}${signatureBlock}<br><br>${tQuote('reply_line', { date: escapeHtml(date), from: escapeHtml(fromStrFull) })}<br><blockquote style="margin:0 0 0 0.8ex;border-left:2px solid #ccc;padding-left:1ex">${escapedOriginal}</blockquote>`;
       }
     }
     return prefix;

--- a/lib/__tests__/quote-header.test.ts
+++ b/lib/__tests__/quote-header.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { buildQuoteHeader } from '@/lib/quote-header';
+
+const base = {
+  newTo: [] as string[],
+  newCc: [] as string[],
+  locale: 'en',
+  timeFormat: '24h' as const,
+  unknownLabel: 'Unknown',
+};
+
+const sender = { name: 'Display Name', email: 'user@domain.tld' };
+
+describe('buildQuoteHeader (#482 — sender address survives HTML rendering)', () => {
+  it('forward TEXT keeps the full "Name <email>" sender', async () => {
+    const h = await buildQuoteHeader({
+      mode: 'forward',
+      email: { from: [sender], subject: 'Hello', receivedAt: '2026-01-01T10:00:00Z' },
+      ...base,
+    });
+    expect(h.text).toContain('From: Display Name <user@domain.tld>');
+  });
+
+  it('forward HTML escapes the angle brackets so the address is not eaten as a tag', async () => {
+    const h = await buildQuoteHeader({
+      mode: 'forward',
+      email: { from: [sender], subject: 'Hello', receivedAt: '2026-01-01T10:00:00Z' },
+      ...base,
+    });
+    // The regression: a raw "<user@domain.tld>" is parsed as an HTML tag by the
+    // rich-text composer and dropped, leaving only "From: Display Name".
+    expect(h.html).toContain('Display Name &lt;user@domain.tld&gt;');
+    expect(h.html).not.toContain('<user@domain.tld>');
+  });
+
+  it('forward HTML escapes a subject containing markup (injection hardening)', async () => {
+    const h = await buildQuoteHeader({
+      mode: 'forward',
+      email: { from: [sender], subject: 'Hi <b>x</b>', receivedAt: '2026-01-01T10:00:00Z' },
+      ...base,
+    });
+    expect(h.html).toContain('Hi &lt;b&gt;x&lt;/b&gt;');
+    expect(h.html).not.toContain('<b>x</b>');
+  });
+
+  it('forward HTML escapes a malicious display name', async () => {
+    const h = await buildQuoteHeader({
+      mode: 'forward',
+      email: {
+        from: [{ name: '<img src=x onerror=alert(1)>', email: 'evil@x.tld' }],
+        subject: 'Hello',
+        receivedAt: '2026-01-01T10:00:00Z',
+      },
+      ...base,
+    });
+    expect(h.html).not.toContain('<img src=x');
+    expect(h.html).toContain('&lt;img src=x');
+  });
+
+  it('reply line includes the full "Name <email>" sender, escaped in HTML', async () => {
+    const h = await buildQuoteHeader({
+      mode: 'reply',
+      email: { from: [sender], subject: 'Hello', receivedAt: '2026-01-01T10:00:00Z' },
+      ...base,
+    });
+    // TEXT keeps the real angle brackets ("On <date>, Display Name <user@domain.tld> wrote:").
+    expect(h.text).toContain('Display Name <user@domain.tld> wrote:');
+    // HTML escapes them so the address survives the rich-text editor (#482).
+    expect(h.html).toContain('Display Name &lt;user@domain.tld&gt;');
+    expect(h.html).not.toContain('<user@domain.tld>');
+  });
+
+  it('reply line stays HTML-safe for a display name containing markup', async () => {
+    const evil = await buildQuoteHeader({
+      mode: 'reply',
+      email: { from: [{ name: '<b>x</b>', email: 'e@x.tld' }], subject: 'Hello', receivedAt: '2026-01-01T10:00:00Z' },
+      ...base,
+    });
+    expect(evil.html).not.toContain('<b>x</b>');
+    expect(evil.html).toContain('&lt;b&gt;x&lt;/b&gt;');
+  });
+
+  it('reply line falls back to bare email when there is no display name', async () => {
+    const h = await buildQuoteHeader({
+      mode: 'reply',
+      email: { from: [{ email: 'noname@x.tld' }], subject: 'Hello', receivedAt: '2026-01-01T10:00:00Z' },
+      ...base,
+    });
+    expect(h.text).toContain('noname@x.tld wrote:');
+    expect(h.text).not.toContain('<noname@x.tld>');
+  });
+});

--- a/lib/quote-header.ts
+++ b/lib/quote-header.ts
@@ -8,6 +8,7 @@
 
 import { formatDateTime } from "@/lib/utils";
 import { emailHooks } from "@/lib/plugin-hooks";
+import { escapeHtml } from "@/lib/email-sanitization";
 import type { QuoteHeader, QuoteHeaderContext } from "@/lib/plugin-types";
 
 // Localized label set the caller passes in. Labels live on the client where
@@ -62,10 +63,8 @@ function defaultHeader(args: BuildArgs): QuoteHeader {
       })
     : "";
   const from = email.from?.[0];
-  const fromStr = from ? `${from.name || from.email}` : unknownLabel;
-  // Forward header "From:" shows the full sender incl. address ("Name
-  // <email>"), like every mail client. The reply line keeps the bare name
-  // (reads more naturally in "On … wrote:").
+  // Both the forward "From:" line and the reply "On … wrote:" line show the
+  // full sender incl. address ("Name <email>"), like Gmail/Outlook (#482).
   const fromStrFull = from
     ? (from.name && from.email && from.name !== from.email
         ? `${from.name} <${from.email}>`
@@ -75,13 +74,19 @@ function defaultHeader(args: BuildArgs): QuoteHeader {
 
   if (mode === "forward") {
     const text = `${labels.forwardedSeparator}\n${labels.fromLabel}: ${fromStrFull}\n${labels.dateLabel}: ${date}\n${labels.subjectLabel}: ${subject}\n`;
-    const html = `<div>${labels.forwardedSeparator}<br>${labels.fromLabel}: ${fromStrFull}<br>${labels.dateLabel}: ${date}<br>${labels.subjectLabel}: ${subject}<br><br></div>`;
+    // Escape the interpolated values for the HTML variant: the sender string is
+    // "Name <email>", and the unescaped "<email>" would be parsed as an HTML tag
+    // by the rich-text composer and silently dropped (#482). Subject/name are
+    // likewise user-controlled. Label/separator strings are trusted i18n text.
+    const html = `<div>${labels.forwardedSeparator}<br>${labels.fromLabel}: ${escapeHtml(fromStrFull)}<br>${labels.dateLabel}: ${escapeHtml(date)}<br>${labels.subjectLabel}: ${escapeHtml(subject)}<br><br></div>`;
     return { html, text, wrapInBlockquote: false };
   }
 
-  const replyLine = labels.formatReplyLine({ date, from: fromStr });
-  const text = `${replyLine}\n`;
-  const html = `<div>${replyLine}<br></div>`;
+  const text = `${labels.formatReplyLine({ date, from: fromStrFull })}\n`;
+  // Escape the interpolated sender/date for the HTML reply line: the sender is
+  // now "Name <email>", and the unescaped "<email>" would be parsed as an HTML
+  // tag by the rich-text composer and dropped (#482). Label template is trusted.
+  const html = `<div>${labels.formatReplyLine({ date: escapeHtml(date), from: escapeHtml(fromStrFull) })}<br></div>`;
   return { html, text, wrapInBlockquote: true };
 }
 


### PR DESCRIPTION
## Summary

Replying to / forwarding a message whose sender has a display name produced a
quote header that dropped the email address:

  Expected:  From: Display Name <user@domain.tld>
  Actual:    From: Display Name

The forward header builder already emits the full "Name <email>" sender. The bug
is that the HTML variant interpolated that string UNESCAPED:

  lib/quote-header.ts (forward):
    const html = `... From: ${fromStrFull} ...`;   // fromStrFull = "Name <email>"

The composer is rich-text (HTML). When this markup is inserted into the editor,
the browser parses the "<user@domain.tld>" run as a bogus/unknown HTML tag and
does not render it - so only "From: Display Name" remains. The plain-text variant
and the message details panel escape correctly, which is why the address shows
THERE but vanishes in the composer body (the reporter read this as "the data is
present, so it's a builder issue" - correct: it is an HTML-escaping bug).

Reproduced directly against current main:

  FORWARD html = <div>... From: Display Name <user@domain.tld><br> ...</div>
                                       ^^^^^^^^^^^^^^^^^^^ eaten as a tag

Regression origin: PR #367 ("localize reply/forward quote header incl. sender
address", commit 05e2837) added the "<email>" into the HTML string without
escaping it. Before #367 the forward header showed only the bare name, so the
missing-address symptom is new since #367.


## Changes

HTML-escape the user-controlled values (sender, subject, date) in EVERY HTML
quote-header path; the plain-text variants are unchanged. Uses the existing
escapeHtml() from lib/email-sanitization.ts.

- lib/quote-header.ts (production path, via app/(main)/[locale]/page.tsx ->
  buildQuoteHeader): escape fromStrFull + subject + date in the forward HTML;
  escape the reply-line's interpolated from/date in the reply HTML.
- components/email/email-composer.tsx (inline fallback, used when no plugin/
  page-prepared header is present): same escaping in both HTML branches
  (htmlBody original and plain-body original), for forward and reply.

After the fix the forward HTML is:

  From: Display Name &lt;user@domain.tld&gt;

which the editor renders as the intended "From: Display Name <user@domain.tld>".

Side benefit (security): the subject and display name were previously injected
RAW into the composer document. A crafted subject or display name (e.g.
"<img src=x onerror=...>") is now escaped - this closes an HTML-injection vector
into the compose editor.

## Related Issues


Closes #482

## Type of Change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

## Notes for Reviewers

