### PR TITLE
feat(email-list): always show the per-row selection checkbox

### DIFF
--- a/components/email/email-list-item.tsx
+++ b/components/email/email-list-item.tsx
@@ -143,26 +143,24 @@ export function EmailListItem({ email, selected, onClick, onDoubleClick, onConte
         className={cn('px-4', isFocusedMailLayout ? 'flex items-center' : 'flex items-start')}
         style={{ gap: 'var(--density-item-gap)', paddingBlock: 'var(--density-item-py)' }}
       >
-        {/* Checkbox - only visible when in selection mode */}
-        {selectedEmailIds.size > 0 && (
-          <button
-            onClick={handleCheckboxClick}
-            className={cn(
-              "p-3 lg:p-1 rounded flex-shrink-0 transition-all duration-200",
-              !isFocusedMailLayout && 'mt-2',
-              "hover:bg-muted/50 hover:scale-110",
-              "active:scale-95",
-              "animate-in fade-in zoom-in-95 duration-150",
-              isChecked && "text-primary"
-            )}
-          >
-            {isChecked ? (
-              <CheckSquare className="w-4 h-4 animate-in zoom-in-50 duration-200" />
-            ) : (
-              <Square className="w-4 h-4 text-muted-foreground opacity-60 hover:opacity-100 transition-opacity" />
-            )}
-          </button>
-        )}
+        {/* Selection checkbox - always visible so selecting is discoverable and you
+            never have to enter "select mode" (which used to grab the first row). */}
+        <button
+          onClick={handleCheckboxClick}
+          className={cn(
+            "p-3 lg:p-1 rounded flex-shrink-0 transition-all duration-200",
+            !isFocusedMailLayout && 'mt-2',
+            "hover:bg-muted/50 hover:scale-110",
+            "active:scale-95",
+            isChecked && "text-primary"
+          )}
+        >
+          {isChecked ? (
+            <CheckSquare className="w-4 h-4 animate-in zoom-in-50 duration-200" />
+          ) : (
+            <Square className="w-4 h-4 text-muted-foreground opacity-60 hover:opacity-100 transition-opacity" />
+          )}
+        </button>
 
         {/* Unread indicator */}
         {isUnread && (


### PR DESCRIPTION
## Problem
The per-row selection checkbox only appears once selection mode is active, and the only way to enter selection mode is the list toolbar's checkbox — which immediately selects the **first** message. Two issues follow:

1. **Discoverability** — it isn't obvious you can multi-select at all.
2. **Accidental deletion** — if you're mid-list and click the toolbar checkbox to "start selecting", it selects row 1. Unaware of that, you pick a few messages and delete — and row 1 goes with them.

## Change
Render the selection checkbox on **every** row, always — not just in selection mode. Selecting becomes discoverable, and you select exactly the rows you click (no implicit first-row selection). Clicking the row body still opens the email; clicking its checkbox toggles only that email.

One small component change in `email-list-item.tsx` (drops the `selectedEmailIds.size > 0` gate around the checkbox and its entrance animation).

## Testing
`npm run typecheck` passes. Exercised live.