### PR TITLE
feat(send): "Send now" action on the send-delay (undo) toast

### DIFF
--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -1371,6 +1371,27 @@ export default function Home() {
 
     toast.success(t('email_viewer.scheduled_send_created'), {
       duration: undoDurationMs,
+      secondaryAction: (pending.emailId && pending.identityId)
+        ? {
+            label: t('email_viewer.send_now'),
+            onClick: () => {
+              void (async () => {
+                try {
+                  await client.rescheduleEmailSubmission(
+                    pending.submissionId,
+                    pending.emailId!,
+                    pending.identityId!,
+                    new Date(Date.now() + 1000).toISOString(),
+                  );
+                  clearPendingUndoSend();
+                  if (isScheduledView) await fetchScheduledEmails(client);
+                } catch (error) {
+                  console.error('Failed to send now:', error);
+                }
+              })();
+            },
+          }
+        : undefined,
       action: {
         label: t('email_viewer.undo_send'),
         onClick: () => {

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -21,6 +21,7 @@ export interface Toast {
   onClick?: () => void;
   icon?: React.ReactNode;
   action?: ToastAction;
+  secondaryAction?: ToastAction;
 }
 
 interface ToastProps {
@@ -117,25 +118,48 @@ export function ToastItem({ toast, onClose }: ToastProps) {
           {toast.message && (
             <p className="text-[12px] mt-1 text-muted-foreground leading-snug">{toast.message}</p>
           )}
-          {toast.action && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                try {
-                  toast.action!.onClick();
-                  dismiss();
-                } catch {
-                  // Don't close toast on error so user can retry
-                }
-              }}
-              className={cn(
-                "mt-2 text-[12px] font-semibold px-2.5 py-1 rounded-md transition-colors",
-                "bg-foreground/5 hover:bg-foreground/10 dark:bg-white/10 dark:hover:bg-white/15",
-                "text-foreground"
+          {(toast.action || toast.secondaryAction) && (
+            <div className="mt-2 flex items-center gap-2">
+              {toast.secondaryAction && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    try {
+                      toast.secondaryAction!.onClick();
+                      dismiss();
+                    } catch {
+                      // Don't close toast on error so user can retry
+                    }
+                  }}
+                  className={cn(
+                    "text-[12px] font-semibold px-2.5 py-1 rounded-md transition-colors",
+                    "bg-primary text-primary-foreground hover:bg-primary/90"
+                  )}
+                >
+                  {toast.secondaryAction.label}
+                </button>
               )}
-            >
-              {toast.action.label}
-            </button>
+              {toast.action && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    try {
+                      toast.action!.onClick();
+                      dismiss();
+                    } catch {
+                      // Don't close toast on error so user can retry
+                    }
+                  }}
+                  className={cn(
+                    "text-[12px] font-semibold px-2.5 py-1 rounded-md transition-colors",
+                    "bg-foreground/5 hover:bg-foreground/10 dark:bg-white/10 dark:hover:bg-white/15",
+                    "text-foreground"
+                  )}
+                >
+                  {toast.action.label}
+                </button>
+              )}
+            </div>
           )}
         </div>
 

--- a/stores/email-store.ts
+++ b/stores/email-store.ts
@@ -20,7 +20,7 @@ type ScheduledSubmissionMetadata = {
 
 const VIRTUAL_SCHEDULED_MAILBOX_ID = '__scheduled__';
 
-type PendingUndoSend = { submissionId: string; emailId?: string; sendAt: string; isSmime: boolean };
+type PendingUndoSend = { submissionId: string; emailId?: string; identityId?: string; sendAt: string; isSmime: boolean };
 
 interface EmailStore {
   emails: Email[];
@@ -1196,7 +1196,7 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
       set({
         isLoading: false,
         pendingUndoSend: result.scheduled && result.emailSubmissionId && result.sendAt
-          ? { submissionId: result.emailSubmissionId, emailId: result.emailId, sendAt: result.sendAt, isSmime: false }
+          ? { submissionId: result.emailSubmissionId, emailId: result.emailId, identityId, sendAt: result.sendAt, isSmime: false }
           : get().pendingUndoSend,
       });
       return result;
@@ -1220,7 +1220,7 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
       set({
         isLoading: false,
         pendingUndoSend: result.scheduled && result.emailSubmissionId && result.sendAt
-          ? { submissionId: result.emailSubmissionId, emailId: result.emailId, sendAt: result.sendAt, isSmime: true }
+          ? { submissionId: result.emailSubmissionId, emailId: result.emailId, identityId, sendAt: result.sendAt, isSmime: true }
           : get().pendingUndoSend,
       });
       return result;

--- a/stores/toast-store.ts
+++ b/stores/toast-store.ts
@@ -38,6 +38,7 @@ export const useToastStore = create<ToastStore>((set) => ({
 interface ToastOptions {
   message?: string;
   action?: ToastAction;
+  secondaryAction?: ToastAction;
   duration?: number;
 }
 
@@ -48,6 +49,7 @@ function showToast(type: Toast["type"], title: string, options?: string | ToastO
     title,
     message: opts?.message,
     action: opts?.action,
+    secondaryAction: opts?.secondaryAction,
     duration: opts?.duration ?? defaultDuration,
   });
 }


### PR DESCRIPTION
## What
When send-delay is enabled, sending shows the "scheduled to send" toast with a **Cancel send** (undo) action. This adds a **Send now** action to the same toast that releases the delayed message immediately, so you can skip the undo window without waiting it out.

## How
- `toast` gains an optional `secondaryAction` (rendered alongside the existing action).
- The pending undo-send state carries `identityId` so the immediate send can target the right identity.
- "Send now" reschedules the delayed `EmailSubmission` for ~now (`Date.now()+1s`), mirroring the existing scheduled-message Send-now, then clears the undo state.

## Testing
`npm run typecheck` passes. Exercised live: send with a delay, toast shows **Send now** + **Cancel send**; Send now delivers immediately, Cancel restores the draft.