### PR TITLE
fix(email-viewer): hide images that fail to load

### DIFF
--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -3100,6 +3100,26 @@ export function EmailViewer({
         lastBodyHeightRef.current = initialHeight;
         setIframeReady(true);
 
+        // Hide images that fail to load (dead/mixed-content/unreachable external
+        // URLs) rather than leaving the browser's broken-image placeholder and
+        // alt text, which read as stray label text in an otherwise image-only
+        // email (e.g. a blocked "logo" alt). Blocked images already carry a 1x1
+        // transparent pixel (naturalWidth 1) and display:none, so they're skipped.
+        const hideIfBroken = (img: HTMLImageElement) => {
+          if (img.complete && img.naturalWidth === 0 && img.getAttribute('src')) {
+            img.style.display = 'none';
+          }
+        };
+        doc.querySelectorAll('img').forEach((el) => {
+          const img = el as HTMLImageElement;
+          if (img.complete) {
+            hideIfBroken(img);
+          } else {
+            img.addEventListener('error', () => { img.style.display = 'none'; }, { once: true });
+            img.addEventListener('load', () => hideIfBroken(img), { once: true });
+          }
+        });
+
         // Make links open in new tab
         doc.querySelectorAll('a').forEach(a => {
           a.setAttribute('target', '_blank');


### PR DESCRIPTION
## Problem
An image-only email whose external images fail to load (dead URL, mixed content, or otherwise unreachable even when allowed) renders as the browser's broken-image placeholder plus the `alt` text. In an otherwise empty body this reads as stray label text — e.g. a `logo` alt sitting alone in the middle of the message.

## Change
After the iframe loads, hide any `<img>` that failed to load (`complete && naturalWidth === 0`), and attach one-shot `error`/`load` handlers for in-flight images. Sanitizer-blocked external images already use a 1×1 transparent pixel with `display:none`, so they're naturally skipped.

## Testing
`npm run typecheck` passes. Verified on an image-only email whose remote images don't resolve — the broken-image alt text no longer appears.