### PR TITLE
feat(headers): add parsing for Stalwart spam headers

### DIFF
--- a/lib/email-headers.ts
+++ b/lib/email-headers.ts
@@ -118,7 +118,8 @@ export function parseAuthenticationResults(header: string): AuthenticationResult
  */
 export function parseSpamScore(header: string): { score: number; status: string } | null {
   // Try X-Spam-Status format: "No, score=-0.25"
-  const statusMatch = header.match(/^(Yes|No),?\s+score=([-\d.]+)/i);
+  // And try X-Spam-Score format (Stalwart): "ham, score=-0.25"
+  const statusMatch = header.match(/^(Yes|No|spam|ham),?\s+score=([-\d.]+)/i);
   if (statusMatch) {
     return {
       status: statusMatch[1].toLowerCase(),

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -1240,10 +1240,10 @@ export class JMAPClient implements IJMAPClient {
       email.authenticationResults = parseAuthenticationResults(value);
     }
 
-    for (const headerName of ['X-Spam-Status', 'X-Spam-Result', 'X-Rspamd-Score']) {
+    for (const headerName of ['X-Spam-Score', 'X-Spam-Status', 'X-Spam-Result', 'X-Rspamd-Score']) {
       if (!headersRecord[headerName]) continue;
       const value = Array.isArray(headersRecord[headerName]) ? headersRecord[headerName][0] : headersRecord[headerName];
-      const spamResult = parseSpamScore(value as string);
+      const spamResult = parseSpamScore((value as string).trim());
       if (spamResult) {
         email.spamScore = spamResult.score;
         email.spamStatus = spamResult.status;


### PR DESCRIPTION
## Summary

Example of headers created by Stalwart below

```
X-Spam-Result: TRUSTED_DOMAIN (-7.00),
	PROB_HAM_LOW (-2.00),
	RBL_SENDERSCORE_REPUT_9 (-1.00),
	DMARC_POLICY_ALLOW (-0.50),
	RCVD_DKIM_ARC_DNSWL_MED (-0.50)
X-Spam-Score: ham, score=-5.60, avg_confidence=0.26
X-Spam-Status: No
```

Only need to add small tweak by detecting spam|ham as well as Yes|No The most useful header is X-Spam-Score, so we make sure to parse that before X-Spam-Status

## Changes

<!-- A bulleted list of the key changes made. -->

- parse `X-Spam-Score` header in addition to previously defined ones
- parse Stalwart style (`ham|spam` in place of `Yes|No`)
- trim header before parsing, as sometimes the header value starts with whitespace

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [X] I have added or updated documentation if needed
- [X] I have updated translations (`locales/`) if my changes affect user-facing text
- [X] I have included screenshots or a screen recording for UI changes
