### PR TITLE
fix(auth): guard account switch against slot→token desync

### DIFF
--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -26,6 +26,9 @@ export class RateLimitError extends Error {
 
 // JMAP protocol types - these are intentionally flexible due to server variations
 interface JMAPSession {
+  // The authenticated login (JMAP spec Session.username) — server-confirmed,
+  // unlike the client-side constructor username or the sending identity.
+  username?: string;
   apiUrl: string;
   downloadUrl: string;
   uploadUrl?: string;
@@ -3410,6 +3413,14 @@ export class JMAPClient implements IJMAPClient {
 
   getUsername(): string {
     return this.username || this.session?.accounts?.[this.accountId]?.name || '';
+  }
+
+  // Server-confirmed authenticated login from the JMAP Session object. Use
+  // this (not getUsername(), which echoes the constructor arg, nor the
+  // sending identity) to verify a slot's token resolved to the expected
+  // account.
+  getSessionUsername(): string | undefined {
+    return this.session?.username;
   }
 
   supportsEmailSubmission(): boolean {

--- a/stores/__tests__/auth-store-switch-guard.test.ts
+++ b/stores/__tests__/auth-store-switch-guard.test.ts
@@ -1,52 +1,68 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { connectedAccountId } from '../auth-store';
-import { useIdentityStore } from '../identity-store';
+import { describe, it, expect } from 'vitest';
+import { connectedAccountCandidates } from '../auth-store';
 import type { Identity } from '@/lib/jmap/types';
 
-// Covers the make-or-break bit of the account-switch identity guard: the
-// connected session's accountId must be derived with the SAME canonicalisation
-// as login (primary-identity email for OAuth, where the JMAP session username
-// is often a preferred_username claim, not the address). Comparing the raw
-// JMAP username would both false-positive on OAuth and miss real desyncs.
+// The account-switch guard force-re-auths only when the connected session
+// matches NONE of its server-confirmed identifiers. accountId is generated
+// from the primary-identity email (OAuth) OR the login username (basic), so
+// the candidate set must cover both: the JMAP Session.username (authenticated
+// login) and the primary sending-identity email.
 
 const SERVER = 'https://mail.example.com';
 
-const fakeClient = (jmapUsername: string, identities: Identity[] | Error) =>
+const fakeClient = (opts: {
+  sessionUsername?: string;
+  constructorUsername?: string;
+  identities?: Identity[] | Error;
+}) =>
   ({
-    getUsername: () => jmapUsername,
+    getSessionUsername: () => opts.sessionUsername,
+    getUsername: () => opts.constructorUsername ?? '',
     getIdentities: async () => {
-      if (identities instanceof Error) throw identities;
-      return identities;
+      if (opts.identities instanceof Error) throw opts.identities;
+      return opts.identities ?? [];
     },
   }) as never;
 
 const id = (over: Partial<Identity> = {}): Identity => ({
-  id: 'id-1',
-  name: 'Real User',
-  email: 'real@example.com',
-  mayDelete: true,
-  ...over,
+  id: 'id-1', name: 'Real User', email: 'real@example.com', mayDelete: true, ...over,
 });
 
-describe('connectedAccountId (account-switch guard)', () => {
-  beforeEach(() => {
-    useIdentityStore.setState({ identities: [], preferredPrimaryId: null } as never);
+describe('connectedAccountCandidates (account-switch guard)', () => {
+  it('includes the primary-identity email (OAuth registers by email)', async () => {
+    const out = await connectedAccountCandidates(
+      fakeClient({ sessionUsername: 'preferred_user', identities: [id()] }), SERVER,
+    );
+    expect(out).toContain('real@example.com@mail.example.com');
   });
 
-  it('derives from the primary-identity EMAIL, not the JMAP session username', async () => {
-    // OAuth: JMAP username is a preferred_username claim, the real address lives
-    // on the identity. The id must be built from the email.
-    const result = await connectedAccountId(fakeClient('preferred_user', [id()]), SERVER);
-    expect(result).toBe('real@example.com@mail.example.com');
+  it('includes the session login username (basic auth registers by login)', async () => {
+    // support@ case: login is the email, but the primary sending identity is a
+    // different address. The login must still be accepted.
+    const out = await connectedAccountCandidates(
+      fakeClient({ sessionUsername: 'support@linux-hosting.co.il', identities: [id({ email: 'alias@elsewhere.com' })] }),
+      SERVER,
+    );
+    expect(out).toContain('support@linux-hosting.co.il@mail.example.com');
+    expect(out).toContain('alias@elsewhere.com@mail.example.com');
   });
 
-  it('falls back to the JMAP username when identities cannot be fetched', async () => {
-    const result = await connectedAccountId(fakeClient('basic@example.com', new Error('no idents')), SERVER);
-    expect(result).toBe('basic@example.com@mail.example.com');
+  it('excludes the constructor username (cannot mask a desync)', async () => {
+    // A desynced slot: client built for support@ but the token resolves to
+    // shuki@. Candidates come only from the server (session + identities),
+    // never the constructor echo, so support@ is NOT among them.
+    const out = await connectedAccountCandidates(
+      fakeClient({ sessionUsername: 'shuki@linux-hosting.co.il', constructorUsername: 'support@linux-hosting.co.il', identities: [id({ email: 'shuki@linux-hosting.co.il' })] }),
+      SERVER,
+    );
+    expect(out).not.toContain('support@linux-hosting.co.il@mail.example.com');
+    expect(out).toContain('shuki@linux-hosting.co.il@mail.example.com');
   });
 
-  it('returns null when the session identity cannot be determined at all', async () => {
-    const broken = { getUsername: () => { throw new Error('disconnected'); } } as never;
-    expect(await connectedAccountId(broken, SERVER)).toBeNull();
+  it('returns empty when nothing can be confirmed (caller must not bounce)', async () => {
+    const out = await connectedAccountCandidates(
+      fakeClient({ sessionUsername: undefined, identities: new Error('no idents') }), SERVER,
+    );
+    expect(out).toEqual([]);
   });
 });

--- a/stores/__tests__/auth-store-switch-guard.test.ts
+++ b/stores/__tests__/auth-store-switch-guard.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { connectedAccountId } from '../auth-store';
+import { useIdentityStore } from '../identity-store';
+import type { Identity } from '@/lib/jmap/types';
+
+// Covers the make-or-break bit of the account-switch identity guard: the
+// connected session's accountId must be derived with the SAME canonicalisation
+// as login (primary-identity email for OAuth, where the JMAP session username
+// is often a preferred_username claim, not the address). Comparing the raw
+// JMAP username would both false-positive on OAuth and miss real desyncs.
+
+const SERVER = 'https://mail.example.com';
+
+const fakeClient = (jmapUsername: string, identities: Identity[] | Error) =>
+  ({
+    getUsername: () => jmapUsername,
+    getIdentities: async () => {
+      if (identities instanceof Error) throw identities;
+      return identities;
+    },
+  }) as never;
+
+const id = (over: Partial<Identity> = {}): Identity => ({
+  id: 'id-1',
+  name: 'Real User',
+  email: 'real@example.com',
+  mayDelete: true,
+  ...over,
+});
+
+describe('connectedAccountId (account-switch guard)', () => {
+  beforeEach(() => {
+    useIdentityStore.setState({ identities: [], preferredPrimaryId: null } as never);
+  });
+
+  it('derives from the primary-identity EMAIL, not the JMAP session username', async () => {
+    // OAuth: JMAP username is a preferred_username claim, the real address lives
+    // on the identity. The id must be built from the email.
+    const result = await connectedAccountId(fakeClient('preferred_user', [id()]), SERVER);
+    expect(result).toBe('real@example.com@mail.example.com');
+  });
+
+  it('falls back to the JMAP username when identities cannot be fetched', async () => {
+    const result = await connectedAccountId(fakeClient('basic@example.com', new Error('no idents')), SERVER);
+    expect(result).toBe('basic@example.com@mail.example.com');
+  });
+
+  it('returns null when the session identity cannot be determined at all', async () => {
+    const broken = { getUsername: () => { throw new Error('disconnected'); } } as never;
+    expect(await connectedAccountId(broken, SERVER)).toBeNull();
+  });
+});

--- a/stores/auth-store.ts
+++ b/stores/auth-store.ts
@@ -303,20 +303,27 @@ function scheduleRefresh(expiresIn: number, refreshFn: () => Promise<string | nu
  * resolves to the wrong account before it surfaces as the wrong mailbox.
  * Returns null when it can't determine the identity (treated as "don't block").
  */
-export async function connectedAccountId(client: JMAPClient, serverUrl: string): Promise<string | null> {
+export async function connectedAccountCandidates(client: JMAPClient, serverUrl: string): Promise<string[]> {
+  // accountId is generated differently per auth mode: OAuth/SSO registers from
+  // the primary-identity EMAIL, basic auth from the typed login username. A
+  // single derivation can't match both, so collect every server-confirmed
+  // identifier the connected session exposes — the JMAP Session.username
+  // (authenticated login) and the primary sending-identity email — and let the
+  // caller accept the session if the target accountId matches ANY of them.
+  // Deliberately excludes client.getUsername(), which echoes the constructor
+  // username (always the target) and would defeat the desync check. An empty
+  // result means nothing could be confirmed → the caller should NOT force a
+  // re-auth.
+  const ids = new Set<string>();
   try {
-    const jmapUsername = client.getUsername();
-    let canonical = jmapUsername;
-    try {
-      const { primaryIdentity } = loadIdentities(await client.getIdentities(), jmapUsername);
-      canonical = primaryIdentity?.email || jmapUsername;
-    } catch {
-      /* identities unavailable — fall back to the JMAP session username */
-    }
-    return generateAccountId(canonical, serverUrl);
-  } catch {
-    return null;
-  }
+    const sessionUser = client.getSessionUsername();
+    if (sessionUser) ids.add(generateAccountId(sessionUser, serverUrl));
+  } catch { /* session unavailable */ }
+  try {
+    const { primaryIdentity } = loadIdentities(await client.getIdentities(), client.getUsername());
+    if (primaryIdentity?.email) ids.add(generateAccountId(primaryIdentity.email, serverUrl));
+  } catch { /* identities unavailable */ }
+  return [...ids];
 }
 
 function clearRefreshTimer(accountId?: string): void {
@@ -1237,9 +1244,9 @@ export const useAuthStore = create<AuthState>()(
         // connection then succeeds and we would silently show the wrong
         // mailbox. On mismatch, drop the poisoned cookies for this slot and
         // force a clean re-auth instead of surfacing someone else's mail.
-        const connectedId = await connectedAccountId(targetClient, targetAccount.serverUrl);
-        if (connectedId && connectedId !== accountId) {
-          debug.error(`switchAccount: slot ${targetAccount.cookieSlot} for ${accountId} resolved to ${connectedId} — forcing re-auth`);
+        const connectedCandidates = await connectedAccountCandidates(targetClient, targetAccount.serverUrl);
+        if (connectedCandidates.length > 0 && !connectedCandidates.includes(accountId)) {
+          debug.error(`switchAccount: slot ${targetAccount.cookieSlot} for ${accountId} resolved to [${connectedCandidates.join(", ")}] — forcing re-auth`);
           clients.delete(accountId);
           try { targetClient.disconnect(); } catch { /* noop */ }
           apiFetch(`/api/auth/token?slot=${targetAccount.cookieSlot}`, { method: 'DELETE' }).catch(() => {});

--- a/stores/auth-store.ts
+++ b/stores/auth-store.ts
@@ -296,6 +296,29 @@ function scheduleRefresh(expiresIn: number, refreshFn: () => Promise<string | nu
   }
 }
 
+/**
+ * Derive the accountId a *connected* client actually belongs to, using the
+ * same canonicalisation as login (primary-identity email for OAuth, else the
+ * JMAP session username). Lets a caller detect a slot->token mapping that
+ * resolves to the wrong account before it surfaces as the wrong mailbox.
+ * Returns null when it can't determine the identity (treated as "don't block").
+ */
+export async function connectedAccountId(client: JMAPClient, serverUrl: string): Promise<string | null> {
+  try {
+    const jmapUsername = client.getUsername();
+    let canonical = jmapUsername;
+    try {
+      const { primaryIdentity } = loadIdentities(await client.getIdentities(), jmapUsername);
+      canonical = primaryIdentity?.email || jmapUsername;
+    } catch {
+      /* identities unavailable — fall back to the JMAP session username */
+    }
+    return generateAccountId(canonical, serverUrl);
+  } catch {
+    return null;
+  }
+}
+
 function clearRefreshTimer(accountId?: string): void {
   if (accountId) {
     const timer = refreshTimers.get(accountId);
@@ -1203,6 +1226,26 @@ export const useAuthStore = create<AuthState>()(
 
           set({ isLoading: false });
           // Redirect to login so the user can re-authenticate
+          replaceWindowLocation(getLocaleLoginPath());
+          return;
+        }
+
+        // GUARD: verify the connected session actually belongs to the target
+        // account before we bind it. A corrupted slot->token mapping (e.g.
+        // persisted client state left over from an older build, or any future
+        // slot desync) can hand back a *different* account's token; the
+        // connection then succeeds and we would silently show the wrong
+        // mailbox. On mismatch, drop the poisoned cookies for this slot and
+        // force a clean re-auth instead of surfacing someone else's mail.
+        const connectedId = await connectedAccountId(targetClient, targetAccount.serverUrl);
+        if (connectedId && connectedId !== accountId) {
+          debug.error(`switchAccount: slot ${targetAccount.cookieSlot} for ${accountId} resolved to ${connectedId} — forcing re-auth`);
+          clients.delete(accountId);
+          try { targetClient.disconnect(); } catch { /* noop */ }
+          apiFetch(`/api/auth/token?slot=${targetAccount.cookieSlot}`, { method: 'DELETE' }).catch(() => {});
+          apiFetch(`/api/auth/session?slot=${targetAccount.cookieSlot}`, { method: 'DELETE' }).catch(() => {});
+          accountStore.updateAccount(accountId, { isConnected: false, hasError: true, errorMessage: 'session_mismatch' });
+          set({ isLoading: false, error: 'connection_failed', activeAccountId: state.activeAccountId });
           replaceWindowLocation(getLocaleLoginPath());
           return;
         }


### PR DESCRIPTION
### Problem
On account switch, the target client connects with the token at the account's stored `cookieSlot`. If that slot→token mapping is ever wrong — corrupted client state persisted by an older build, or any future slot desync — the connection **succeeds as a different account** and the UI silently shows the **wrong mailbox**. Observed in the wild: switching repeatedly kept showing another account's mail; only a full site-data wipe + re-login cleared it.

### Fix
Post-connect identity guard in `switchAccount`: derive the connected session's `accountId` (primary-identity email for OAuth, else the JMAP session username) and compare to the account being switched to. On mismatch: drop the poisoned slot cookies, force a clean re-auth — never bind a session whose identity doesn't match.

Belt-and-suspenders on top of `8b164c5` (per-account cookie slot through OAuth flows): that prevents new corruption at allocation time; this catches any **residual/leftover** mapping at switch time and converts "silently wrong mailbox" into "re-login".

### Notes
- Guard returns `null` (non-blocking) when identity can't be determined — never wedges a switch on a transient identities-fetch failure.
- Canonicalisation matters: comparing the raw JMAP username would false-positive on OAuth (`preferred_username` ≠ email). Unit test added for exactly that.

### Test
`stores/__tests__/auth-store-switch-guard.test.ts` — 3 cases (email-derived id, JMAP-username fallback, null when undeterminable). Typecheck clean.