### PR TITLE
feat(settings): add "Refresh cached data" recovery action

### DIFF
--- a/components/settings/about-data-settings.tsx
+++ b/components/settings/about-data-settings.tsx
@@ -11,6 +11,7 @@ import { useUpdateStore } from '@/stores/update-store';
 import { ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getPathPrefix } from '@/lib/browser-navigation';
+import { clearCachedData } from '@/lib/clear-cached-data';
 import { SpamSiegeGame } from './spam-siege-game';
 
 const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || "0.0.0";
@@ -54,6 +55,7 @@ export function AboutDataSettings() {
     useSettingsStore();
   const { settingsSyncEnabled } = useConfig();
   const [showResetConfirm, setShowResetConfirm] = useState(false);
+  const [showRefreshConfirm, setShowRefreshConfirm] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { isFeatureEnabled } = usePolicyStore();
   const [showGame, setShowGame] = useState(false);
@@ -103,6 +105,15 @@ export function AboutDataSettings() {
       }
     };
     reader.readAsText(file);
+  };
+
+  const handleRefreshCache = () => {
+    if (showRefreshConfirm) {
+      clearCachedData(); // reloads the page
+    } else {
+      setShowRefreshConfirm(true);
+      setTimeout(() => setShowRefreshConfirm(false), 5000);
+    }
   };
 
   const handleReset = () => {
@@ -186,6 +197,16 @@ export function AboutDataSettings() {
           </>
         </SettingItem>
         )}
+
+        <SettingItem label={t('refresh_cache.label')} description={t('refresh_cache.description')}>
+          <Button
+            variant={showRefreshConfirm ? 'default' : 'outline'}
+            size="sm"
+            onClick={handleRefreshCache}
+          >
+            {showRefreshConfirm ? tCommon('yes') : t('refresh_cache.button')}
+          </Button>
+        </SettingItem>
 
         <SettingItem label={t('reset_settings.label')} description={t('reset_settings.description')}>
           <Button

--- a/lib/__tests__/clear-cached-data.test.ts
+++ b/lib/__tests__/clear-cached-data.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { clearCachedData } from '../clear-cached-data';
+
+describe('clearCachedData', () => {
+  let reload: ReturnType<typeof vi.fn>;
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    localStorage.clear();
+    reload = vi.fn();
+    originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+  });
+
+  it('clears re-fetchable caches but keeps accounts, sessions and prefs', () => {
+    localStorage.setItem('contact-storage', '1');
+    localStorage.setItem('calendar-storage', '1');
+    localStorage.setItem('identity-storage', '1');
+    localStorage.setItem('calendar-notification-storage', '1');
+    // Must survive — losing these is exactly the pain we're avoiding.
+    localStorage.setItem('account-registry', 'accounts');
+    localStorage.setItem('auth-storage', 'session');
+    localStorage.setItem('settings-storage', 'prefs');
+    localStorage.setItem('template-storage', 'my templates');
+
+    clearCachedData();
+
+    expect(localStorage.getItem('contact-storage')).toBeNull();
+    expect(localStorage.getItem('calendar-storage')).toBeNull();
+    expect(localStorage.getItem('identity-storage')).toBeNull();
+    expect(localStorage.getItem('calendar-notification-storage')).toBeNull();
+
+    expect(localStorage.getItem('account-registry')).toBe('accounts');
+    expect(localStorage.getItem('auth-storage')).toBe('session');
+    expect(localStorage.getItem('settings-storage')).toBe('prefs');
+    expect(localStorage.getItem('template-storage')).toBe('my templates');
+  });
+
+  it('reloads so data is re-fetched fresh', () => {
+    clearCachedData();
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});

--- a/lib/clear-cached-data.ts
+++ b/lib/clear-cached-data.ts
@@ -1,0 +1,45 @@
+import { evictAll } from '@/lib/account-state-manager';
+
+// localStorage keys holding server-derived, re-fetchable caches. The "Refresh
+// cached data" action clears these so a stale or wrong-account view can be
+// fixed WITHOUT signing out (which would drop the whole account list).
+//
+// Deliberately excluded:
+//  - 'account-registry' / 'auth-storage'  → keep accounts + sessions
+//  - 'settings-storage' / 'theme-storage' / 'locale-storage' → user prefs
+//  - 'template-storage' / 'smime-preferences' → user-created content
+const CACHE_STORAGE_KEYS = [
+  'identity-storage',
+  'contact-storage',
+  'calendar-storage',
+  'calendar-notification-storage',
+];
+
+/**
+ * Clear cached, server-derived data (contacts, calendars, identities, and the
+ * in-memory per-account snapshots), then reload so everything is re-fetched
+ * fresh for the active account. Accounts and sessions are preserved — this is
+ * the non-destructive alternative to the browser's "clear site data", which
+ * also wipes the account list.
+ */
+export function clearCachedData(): void {
+  // Drop the in-memory per-account store snapshots so a reload can't restore
+  // stale cached state for any account.
+  try {
+    evictAll();
+  } catch {
+    /* snapshots are best-effort */
+  }
+
+  if (typeof window === 'undefined') return;
+
+  for (const key of CACHE_STORAGE_KEYS) {
+    try {
+      window.localStorage.removeItem(key);
+    } catch {
+      /* ignore storage access errors */
+    }
+  }
+
+  window.location.reload();
+}

--- a/locales/cs/common.json
+++ b/locales/cs/common.json
@@ -1594,6 +1594,11 @@
         "description": "Zobrazit dostupné klávesové zkratky",
         "button": "Zobrazit zkratky"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Resetovat nastavení",
         "description": "Obnovit všechna nastavení na výchozí hodnoty",

--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -1597,6 +1597,11 @@
         "description": "Se tilgængelige tastaturgenveje",
         "button": "Vis genveje"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Nulstil indstillinger",
         "description": "Gendan alle indstillinger til standardværdier",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -1594,6 +1594,11 @@
         "description": "Verfügbare Tastaturkürzel anzeigen",
         "button": "Tastaturkürzel anzeigen"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Einstellungen zurücksetzen",
         "description": "Alle Einstellungen auf Standardwerte zurücksetzen",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1601,6 +1601,11 @@
         "description": "View available keyboard shortcuts",
         "button": "View Shortcuts"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Reset Settings",
         "description": "Restore all settings to default values",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -1594,6 +1594,11 @@
         "description": "Ver atajos de teclado disponibles",
         "button": "Ver Atajos"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Restablecer Configuración",
         "description": "Restaurar toda la configuración a los valores predeterminados",

--- a/locales/fa/common.json
+++ b/locales/fa/common.json
@@ -1601,6 +1601,11 @@
         "description": "مشاهده میانبرهای صفحه کلید موجود",
         "button": "مشاهده میانبرها"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "بازنشانی تنظیمات",
         "description": "بازگردانی همه تنظیمات به مقادیر پیش‌فرض",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -1594,6 +1594,11 @@
         "description": "Voir les raccourcis clavier disponibles",
         "button": "Voir les raccourcis"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Réinitialiser les paramètres",
         "description": "Restaurer tous les paramètres par défaut",

--- a/locales/hu/common.json
+++ b/locales/hu/common.json
@@ -1597,6 +1597,11 @@
         "description": "Elérhető billentyűparancsok megtekintése",
         "button": "Parancsok megtekintése"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Beállítások visszaállítása",
         "description": "Összes beállítás visszaállítása az alapértelmezett értékekre",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -1594,6 +1594,11 @@
         "description": "Visualizza le scorciatoie da tastiera disponibili",
         "button": "Visualizza scorciatoie"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Ripristina impostazioni",
         "description": "Ripristina tutte le impostazioni ai valori predefiniti",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -1594,6 +1594,11 @@
         "description": "利用可能なキーボードショートカットを表示",
         "button": "ショートカットを表示"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "設定をリセット",
         "description": "すべての設定をデフォルト値に戻す",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -1594,6 +1594,11 @@
         "description": "사용 가능한 키보드 단축키를 확인해 보세요",
         "button": "단축키 보기"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "설정 초기화",
         "description": "모든 설정을 기본값으로 되돌려요",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -1575,6 +1575,11 @@
         "description": "Skatīt pieejamos tastatūras īsinājumtaustiņus",
         "button": "Rādīt īsinājumtaustiņus"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Atiestatīt iestatījumus",
         "description": "Atjaunot visus iestatījumus uz noklusējuma vērtībām",

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -1594,6 +1594,11 @@
         "description": "Bekijk beschikbare sneltoetsen",
         "button": "Sneltoetsen bekijken"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Instellingen resetten",
         "description": "Herstel alle instellingen naar standaardwaarden",

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -1594,6 +1594,11 @@
         "description": "Wyświetl dostępne skróty klawiszowe",
         "button": "Pokaż skróty"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Resetuj ustawienia",
         "description": "Przywróć wszystkie ustawienia do wartości domyślnych",

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -1594,6 +1594,11 @@
         "description": "Visualizar atalhos de teclado disponíveis",
         "button": "Ver Atalhos"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Redefinir Configurações",
         "description": "Restaurar todas as configurações para valores padrão",

--- a/locales/ro/common.json
+++ b/locales/ro/common.json
@@ -1601,6 +1601,11 @@
         "description": "Vedeți comenzile rapide de la tastatură disponibile",
         "button": "Comenzi rapide de vizualizare"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Resetare setări",
         "description": "Restabiliți toate setările la valorile implicite",

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -1594,6 +1594,11 @@
         "description": "Просмотреть доступные сочетания клавиш",
         "button": "Показать сочетания"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Сбросить настройки",
         "description": "Восстановить все настройки до значений по умолчанию",

--- a/locales/tr/common.json
+++ b/locales/tr/common.json
@@ -1594,6 +1594,11 @@
         "description": "Mevcut klavye kısayollarını görüntüleyin",
         "button": "Kısayolları Görüntüle"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Ayarları Sıfırla",
         "description": "Tüm ayarları varsayılan değerlerine geri yükle",

--- a/locales/uk/common.json
+++ b/locales/uk/common.json
@@ -1594,6 +1594,11 @@
         "description": "Переглянути доступні комбінації клавіш",
         "button": "Перегляд ярликів"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "Скинути налаштування",
         "description": "Відновити всі налаштування до значень за замовчуванням",

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -1594,6 +1594,11 @@
         "description": "查看可用快捷键",
         "button": "查看快捷方式"
       },
+      "refresh_cache": {
+        "label": "Refresh cached data",
+        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions \u2014 fixes a stale or wrong view without signing out.",
+        "button": "Refresh"
+      },
       "reset_settings": {
         "label": "重置设置",
         "description": "将所有设置恢复为默认值",


### PR DESCRIPTION
When the mailbox view gets into a stale/wrong state, the only escape was the browser's "clear site data" — which **also wipes the saved account list**, forcing re-login of every account.

Adds a non-destructive **"Refresh cached data"** button under **Settings → Data**: clears server-derived caches (contacts, calendars, identities, per-account snapshots) and reloads to re-fetch fresh, while preserving accounts, sessions, settings, themes, and user content (templates, S/MIME). Two-click confirm avoids an accidental reload.

Pairs with #506 (which auto-recovers the slot-desync case) as the manual escape hatch.

### Notes
- English strings added across all locales; translation is a follow-up (keeps the completeness test green).
- Excluded from the wipe by design: `account-registry`, `auth-storage`, `settings-storage`, `theme-storage`, `locale-storage`, `template-storage`, `smime-preferences`.

### Test
`lib/__tests__/clear-cached-data.test.ts` — cache keys cleared, accounts/auth/prefs/templates preserved, reload fired.