### PR TITLE
fix(calendar): classify self-organized imported events as editable via organizerCalendarAddress fallback

### DIFF
--- a/lib/__tests__/calendar-participants.test.ts
+++ b/lib/__tests__/calendar-participants.test.ts
@@ -132,6 +132,42 @@ describe('isOrganizer', () => {
     const event = makeEvent({ org: orgParticipant });
     expect(isOrganizer(event, [])).toBe(false);
   });
+
+  it('matches the event-level organizerCalendarAddress when no owner role is set', () => {
+    // Stalwart / imported self-organized events: the user's participant only
+    // carries `attendee`, the organizer lives in organizerCalendarAddress.
+    const event = makeEvent({
+      self: {
+        '@type': 'Participant',
+        name: 'Alice',
+        email: '',
+        roles: { attendee: true },
+        participationStatus: 'accepted',
+        sendTo: { imip: 'mailto:alice@example.com' },
+        kind: 'individual',
+      },
+    });
+    event.organizerCalendarAddress = 'mailto:alice@example.com';
+    expect(isOrganizer(event, ['alice@example.com'])).toBe(true);
+  });
+
+  it('matches the event-level organizerCalendarAddress case-insensitively', () => {
+    const event = makeEvent({ att1: attendeeParticipant });
+    event.organizerCalendarAddress = 'mailto:Alice@Example.com';
+    expect(isOrganizer(event, ['alice@example.com'])).toBe(true);
+  });
+
+  it('falls back to replyTo when organizerCalendarAddress is absent', () => {
+    const event = makeEvent({ att1: attendeeParticipant });
+    event.replyTo = { imip: 'mailto:alice@example.com' };
+    expect(isOrganizer(event, ['alice@example.com'])).toBe(true);
+  });
+
+  it('returns false when the event organizer is someone else', () => {
+    const event = makeEvent({ att1: attendeeParticipant });
+    event.organizerCalendarAddress = 'mailto:someoneelse@example.com';
+    expect(isOrganizer(event, ['alice@example.com'])).toBe(false);
+  });
 });
 
 describe('getUserParticipantId', () => {

--- a/lib/calendar-participants.ts
+++ b/lib/calendar-participants.ts
@@ -35,12 +35,39 @@ function participantMatchesEmail(p: CalendarParticipant, lowerEmails: string[]):
   return false;
 }
 
+/**
+ * Collects the event-level organizer calendar address(es).
+ * Stalwart conveys the organizer via `organizerCalendarAddress` / `replyTo`
+ * rather than a participant `roles.owner` flag, so self-organized events
+ * imported from another server have no owner participant to match against.
+ */
+function getEventOrganizerEmails(event: CalendarEvent): string[] {
+  const emails: string[] = [];
+  if (event.organizerCalendarAddress) {
+    emails.push(event.organizerCalendarAddress.replace(/^mailto:/i, '').toLowerCase());
+  }
+  if (event.replyTo) {
+    for (const addr of Object.values(event.replyTo)) {
+      emails.push(addr.replace(/^mailto:/i, '').toLowerCase());
+    }
+  }
+  return emails.filter(Boolean);
+}
+
 export function isOrganizer(event: CalendarEvent, userEmails: string[]): boolean {
-  if (!event.participants) return false;
+  if (userEmails.length === 0) return false;
   const lower = userEmails.map(e => e.toLowerCase());
-  return Object.values(event.participants).some(p =>
-    p.roles?.owner && participantMatchesEmail(p, lower)
-  );
+
+  if (event.participants) {
+    const ownerMatch = Object.values(event.participants).some(p =>
+      p.roles?.owner && participantMatchesEmail(p, lower)
+    );
+    if (ownerMatch) return true;
+  }
+
+  // Fall back to the event-level organizer address (Stalwart / imported events
+  // mark the organizer here instead of via a participant `owner` role).
+  return getEventOrganizerEmails(event).some(email => lower.includes(email));
 }
 
 export function getUserParticipantId(event: CalendarEvent, userEmails: string[]): string | null {


### PR DESCRIPTION
## Summary

isOrganizer previously only recognized the current user as an event organizer when a participant carried the roles.owner flag. Self-organized events imported from other servers (e.g. Zimbra) using Vandelay don't set that flag - they convey the organizer at the event level via organizerCalendarAddress (or replyTo) instead. This PR adds a fallback so those events are correctly identified as organized by the user.

## Changes

<!-- A bulleted list of the key changes made. -->

- Added a getEventOrganizerEmails helper that collects event-level organizer addresses from organizerCalendarAddress and replyTo, stripping the mailto: prefix and normalizing to lowercase.
- Reworked isOrganizer to check participant roles.owner first, then fall back to matching the event-level organizer address(es) against the user's emails.
- Changed the early-return guard from !event.participants to userEmails.length === 0, so events with no participants can still match via the organizer-address fallback.
- Added tests covering the organizerCalendarAddress match (including case-insensitivity), the replyTo fallback, and the negative case where the organizer is someone else.

## Related Issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Fixes #525

## Type of Change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [X] I have added or updated documentation if needed
- [X] I have updated translations (`locales/`) if my changes affect user-facing text
- [X] I have included screenshots or a screen recording for UI changes
