### PR TITLE
fix: keep email list scrollable when bottom reading-pane is enabled with no conversation selected

### DIFF
--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -2667,7 +2667,9 @@ export default function Home() {
           <div
             className={cn(
               "relative flex flex-col bg-background",
-              isHorizontalMailLayout ? "md:w-full md:h-auto" : "h-full border-r border-border",
+              isHorizontalMailLayout
+                ? (shouldHideHorizontalViewerPane ? "md:w-full md:min-h-0" : "md:w-full md:h-auto")
+                : "h-full border-r border-border",
               // Mobile: full width, hidden when viewing email
               "max-md:flex-1 max-md:border-r-0 max-md:border-b-0",
               isMobile && activeView !== "list" && "max-md:hidden",


### PR DESCRIPTION
## Summary

When the reading pane was configured to sit at the bottom (horizontal mail layout), the message list pane used md:h-auto, letting it grow to fit its content. If the list ran past the bottom of the browser viewport, it would overflow without becoming scrollable, pushing the compose button below the fold and out of reach. This PR switches the pane to md:min-h-0 when the viewer pane is hidden, allowing the flex container to constrain its height so the list scrolls within bounds and the compose button stays visible.

## Changes

- In the horizontal mail layout branch, conditionally apply md:min-h-0 (instead of md:h-auto) to the message list pane when shouldHideHorizontalViewerPane is true, so the pane respects its flex container's height and the list becomes scrollable rather than overflowing.

## Related Issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Fixes #524

## Type of Change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [X] I have added or updated documentation if needed
- [X] I have updated translations (`locales/`) if my changes affect user-facing text
- [X] I have included screenshots or a screen recording for UI changes
