### PR TITLE
fix(pro): show Edit button on draft emails opened in a new tab

### DIFF
--- a/components/pro/pro-email-tab-body.tsx
+++ b/components/pro/pro-email-tab-body.tsx
@@ -6,6 +6,7 @@ import { EmailViewer } from "@/components/email/email-viewer";
 import { ErrorBoundary, EmailViewerErrorFallback } from "@/components/error";
 import { useAuthStore } from "@/stores/auth-store";
 import { useEmailStore } from "@/stores/email-store";
+import { useIdentityStore } from "@/stores/identity-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { toast } from "@/stores/toast-store";
 import { useProTabStore, type ProEmailTabData, type ProReplyContext } from "@/stores/pro-tab-store";
@@ -56,6 +57,7 @@ export function ProEmailTabBody({ tabId, data }: ProEmailTabBodyProps) {
   const setEmailKeywordsLocal = useEmailStore((s) => s.setEmailKeywordsLocal);
   const mailboxes = useEmailStore((s) => s.mailboxes);
   const settingsKeywords = useSettingsStore((s) => s.emailKeywords);
+  const identities = useIdentityStore((s) => s.identities);
 
   const closeTab = useProTabStore((s) => s.closeTab);
   const openComposeTab = useProTabStore((s) => s.openComposeTab);
@@ -227,6 +229,44 @@ export function ProEmailTabBody({ tabId, data }: ProEmailTabBodyProps) {
     handleReply(body);
   }, [handleReply]);
 
+  const handleEditDraft = useCallback(() => {
+    if (!email) return;
+
+    const bodyText = email.bodyValues
+      ? Object.values(email.bodyValues).map((v) => v.value).join('\n')
+      : '';
+    const htmlBody = email.htmlBody?.[0]?.partId && email.bodyValues?.[email.htmlBody[0].partId]
+      ? email.bodyValues[email.htmlBody[0].partId].value
+      : undefined;
+
+    // Preserve the identity that matches the draft's From address.
+    const draftFromEmail = email.from?.[0]?.email;
+    const matchedIdentity = draftFromEmail
+      ? identities.find((id) => id.email === draftFromEmail)
+      : null;
+
+    composerSessionIdRef.current += 1;
+    openComposeTab({
+      sessionId: composerSessionIdRef.current,
+      mode: 'compose',
+      title: email.subject || t('email_composer.new_message'),
+      initialData: {
+        to: email.to?.map((a) => a.email).filter(Boolean).join(', ') || '',
+        cc: email.cc?.map((a) => a.email).filter(Boolean).join(', ') || '',
+        bcc: email.bcc?.map((a) => a.email).filter(Boolean).join(', ') || '',
+        subject: email.subject || '',
+        body: htmlBody || bodyText,
+        showCc: (email.cc?.length || 0) > 0,
+        showBcc: (email.bcc?.length || 0) > 0,
+        selectedIdentityId: matchedIdentity?.id ?? null,
+        subAddressTag: '',
+        mode: 'compose',
+        draftId: email.id,
+      },
+    });
+    closeTab(tabId);
+  }, [email, identities, openComposeTab, closeTab, tabId, t]);
+
   return (
     <div className="flex h-full w-full flex-col bg-background">
       <ErrorBoundary fallback={EmailViewerErrorFallback}>
@@ -243,6 +283,7 @@ export function ProEmailTabBody({ tabId, data }: ProEmailTabBodyProps) {
           onSetColorTag={handleSetColorTag}
           onDownloadAttachment={handleDownloadAttachment}
           onQuickReply={handleQuickReply}
+          onEditDraft={handleEditDraft}
           onMoveToMailbox={handleMoveToMailbox}
           currentUserEmail={client?.getUsername()}
           currentUserName={client?.getUsername()?.split('@')[0]}


### PR DESCRIPTION
## Summary

Adds the ability to edit an existing draft from the Pro email view. When a draft is open, selecting "Edit draft" now opens the email in compose. This now matches the side preview functionality.

## Changes

- Added a handleEditDraft callback in pro-email-tab-body.tsx that opens a compose tab seeded from the current draft (to/cc/bcc, subject, HTML or plain-text body, and cc/bcc visibility) and passes the existing draftId through.
- Resolved the draft's From address against the user's identities so the correct selectedIdentityId is carried into the composer; falls back to null when no match is found.
- Wired the new handler to the email viewer via a new onEditDraft prop.
- Imported useIdentityStore and subscribed to identities to support the identity matching.

## Type of Change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [X] I have added or updated documentation if needed
- [X] I have updated translations (`locales/`) if my changes affect user-facing text
- [X] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

### Before

<img width="1302" height="342" alt="image" src="https://github.com/user-attachments/assets/fc40389f-8b0c-426f-a5dd-cc60190c3c38" />

### After

<img width="1285" height="362" alt="image" src="https://github.com/user-attachments/assets/b0144859-fe4d-4be2-8720-30dd761ca3f4" />
