### PR TITLE
fix(csp): allow external/data fonts so email webfonts render

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -112,7 +112,7 @@ export async function proxy(request: NextRequest) {
     `script-src ${scriptSrc}`,
     `style-src 'self' 'unsafe-inline'`,
     `img-src 'self' data: blob: https:`,
-    `font-src 'self'`,
+    `font-src 'self' https: data:`,
     `connect-src ${connectSrc}`,
     frameSrc,
     `object-src 'self' blob:`,


### PR DESCRIPTION
## Problem
The page CSP sets `font-src 'self'`, which blocks fonts referenced by rendered email CSS — e.g. brand webfonts loaded over `https:`. The console fills with `CSP … font-src 'self'` violations when viewing such mail, and the fonts fall back.

## Fix
Allow `https:` and `data:` for `font-src` in the page CSP (`proxy.ts`).

Email bodies render inside the sandboxed iframe, which keeps its **own** stricter blocking-mode `font-src` (`data:` only until the user unblocks external content), so this does not weaken the per-email privacy posture — it just lets the host page's font loads succeed.

## Test plan
- [x] `tsc --noEmit` clean; existing CSP tests pass
- [ ] Open an email referencing an external webfont → no `font-src` CSP error; font renders