### PR TITLE
Fix keyboard shortcuts not firing on non-Latin keyboard layouts

### DIFF
--- a/hooks/use-keyboard-shortcuts.ts
+++ b/hooks/use-keyboard-shortcuts.ts
@@ -55,15 +55,25 @@ function isInputFocused(): boolean {
   return isInput || isContentEditable;
 }
 
-// Latin letter shortcuts must fire regardless of the active keyboard layout
-// (e.g. Cyrillic, Greek): derive the physical letter from event.code
-// (KeyA..KeyZ) instead of the layout-dependent event.key. Non-letter keys keep
-// event.key, which is either layout-independent (arrows, Enter, Escape) or
-// intentionally symbol-based (#, !, ?, /).
+// Shortcuts must fire regardless of the active keyboard layout (e.g. Cyrillic,
+// Greek). Derive the key from the PHYSICAL key (event.code) instead of the
+// layout-dependent event.key: letters from KeyA..KeyZ, and the symbol shortcuts
+// (/, ?, #, !) from their US-QWERTY positions so they stay reachable on non-Latin
+// layouts. Arrows/Enter/Escape keep event.key, which is already layout-neutral.
 function physicalShortcutKey(event: KeyboardEvent): string {
   const code = event.code;
   if (code && code.length === 4 && code.startsWith("Key")) {
     return code.charAt(3).toLowerCase();
+  }
+  switch (code) {
+    case "Slash":
+      return event.shiftKey ? "?" : "/";
+    case "Digit1":
+      if (event.shiftKey) return "!";
+      break;
+    case "Digit3":
+      if (event.shiftKey) return "#";
+      break;
   }
   return event.key.toLowerCase();
 }

--- a/hooks/use-keyboard-shortcuts.ts
+++ b/hooks/use-keyboard-shortcuts.ts
@@ -55,6 +55,19 @@ function isInputFocused(): boolean {
   return isInput || isContentEditable;
 }
 
+// Latin letter shortcuts must fire regardless of the active keyboard layout
+// (e.g. Cyrillic, Greek): derive the physical letter from event.code
+// (KeyA..KeyZ) instead of the layout-dependent event.key. Non-letter keys keep
+// event.key, which is either layout-independent (arrows, Enter, Escape) or
+// intentionally symbol-based (#, !, ?, /).
+function physicalShortcutKey(event: KeyboardEvent): string {
+  const code = event.code;
+  if (code && code.length === 4 && code.startsWith("Key")) {
+    return code.charAt(3).toLowerCase();
+  }
+  return event.key.toLowerCase();
+}
+
 export function useKeyboardShortcuts({
   enabled = true,
   emails,
@@ -75,7 +88,7 @@ export function useKeyboardShortcuts({
       if (isInputFocused()) return;
 
       const h = handlersRef.current;
-      const key = event.key.toLowerCase();
+      const key = physicalShortcutKey(event);
       const hasModifier = event.ctrlKey || event.metaKey || event.altKey;
 
       // Shortcuts that work with modifiers


### PR DESCRIPTION
## Problem

Keyboard shortcuts are matched against `event.key`, which returns the
**layout-dependent** character. On any non-Latin keyboard layout (Cyrillic,
Greek, …) the physical keys emit non-Latin characters, so the shortcuts
(`c` compose, `j`/`k` navigation, `r` reply, `e` archive, `?` help, `/` search,
…) never match and don't fire. Users have to switch back to a Latin layout every
time, which is a constant annoyance.

```js
// hooks/use-keyboard-shortcuts.ts
const key = event.key.toLowerCase();   // 'с' (Cyrillic) on a RU layout, not 'c'
```

## Fix

Derive the shortcut key from the **physical** key (`event.code`) instead:

- **Letters** → `KeyA`..`KeyZ` → the Latin letter, regardless of layout.
- **Symbol shortcuts** (`/`, `?`, `#`, `!`) → mapped from their US-QWERTY
  physical positions (`Slash`, shifted `Digit1` / `Digit3`), so they stay
  reachable on layouts where those characters are elsewhere or unreachable.
- **Other keys** (arrows, `Enter`, `Escape`) keep `event.key`, which is already
  layout-neutral.

```js
function physicalShortcutKey(event: KeyboardEvent): string {
  const code = event.code;
  if (code && code.length === 4 && code.startsWith("Key")) {
    return code.charAt(3).toLowerCase();
  }
  switch (code) {
    case "Slash":  return event.shiftKey ? "?" : "/";
    case "Digit1": if (event.shiftKey) return "!"; break;
    case "Digit3": if (event.shiftKey) return "#"; break;
  }
  return event.key.toLowerCase();
}
```

Shift combos (`R`, `Shift+I`, …) still work because `event.shiftKey` is checked
separately. No behaviour change on a Latin/US layout.

## Testing

Built from source and deployed; verified letter **and** symbol shortcuts
(including `?` to open the shortcuts help) now fire with a Russian keyboard
layout active, and Latin-layout behaviour is unchanged.
