### PR TITLE
Fix: brand push notifications with the configured PWA icon

### DIFF
--- a/app/api/pwa-icon/[size]/route.ts
+++ b/app/api/pwa-icon/[size]/route.ts
@@ -59,10 +59,12 @@ export async function GET(
     domainOverrides.pwaIconUrl ||
     domainOverrides.faviconUrl ||
     (sources.pwaIconUrl?.source !== 'default' ? (sources.pwaIconUrl?.value as string) : '') ||
-    (sources.faviconUrl?.source !== 'default' ? (sources.faviconUrl?.value as string) : '');
-  if (!iconUrl) {
-    return new NextResponse('No PWA icon configured', { status: 404 });
-  }
+    (sources.faviconUrl?.source !== 'default' ? (sources.faviconUrl?.value as string) : '') ||
+    // Fall back to the built-in default so this endpoint ALWAYS returns an app
+    // icon (custom if configured, else the bundled default). This lets callers
+    // that can't run the custom-vs-default check themselves - notably the
+    // service worker's notifications - use a single stable URL.
+    `/icon-${size}x${size}.png`;
 
   const pngHeaders = {
     'Content-Type': 'image/png',

--- a/public/sw.js
+++ b/public/sw.js
@@ -169,8 +169,10 @@ async function handlePush(event) {
   await self.registration.showNotification(title, {
     body,
     tag,
-    icon: `${BASE_PATH}/icon-192x192.png`,
-    badge: `${BASE_PATH}/icon-192x192.png`,
+    // Branded app icon via the PWA-icon endpoint (admin-configured, else the
+    // built-in default). The static /icon-192x192.png ignored admin branding.
+    icon: `${BASE_PATH}/api/pwa-icon/192`,
+    badge: `${BASE_PATH}/api/pwa-icon/192`,
     data,
     renotify: true,
   });
@@ -281,8 +283,8 @@ async function showMailtoFocusNotification(state) {
     await self.registration.showNotification(state.focusNotificationTitle || "Bulwark", {
       body: state.focusNotificationBody || "The request was opened in Bulwark. Click to bring it to the front.",
       tag: "bulwark-mailto-focus",
-      icon: `${BASE_PATH}/icon-192x192.png`,
-      badge: `${BASE_PATH}/icon-192x192.png`,
+      icon: `${BASE_PATH}/api/pwa-icon/192`,
+      badge: `${BASE_PATH}/api/pwa-icon/192`,
       data: { kind: "protocol-mailto-focus" },
       renotify: true,
     });


### PR DESCRIPTION
## Summary

Push notifications always showed the bundled Bulwark logo, even when an admin had configured a custom PWA/favicon icon. The service worker hard-coded the notification `icon`/`badge` to the static `/icon-192x192.png`, so it never picked up the admin branding that the manifest already honors via `/api/pwa-icon`.

## Changes

- `public/sw.js`: both `showNotification` calls now use `${BASE_PATH}/api/pwa-icon/192` for `icon` and `badge`.
- `app/api/pwa-icon/[size]/route.ts`: fall back to the bundled default icon instead of returning `404` when no custom icon is configured, so the endpoint always returns an app icon — giving the service worker (which can't run the custom-vs-default check itself) a single stable URL.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Contributing Guide read
- [x] Code follows project style and conventions
- [x] `npm run typecheck && npm run lint` passes
- [x] Build passes (`npm run build`)
- [x] Changes tested locally
- [ ] Translations updated (locales/) — n/a, no new user-facing strings

## Notes for Reviewers

- Mirrors how `manifest.ts` already resolves the app icon (custom → `/api/pwa-icon`, else default); this change just makes the endpoint self-sufficient so notifications can reuse it. Verified live: a custom admin icon now appears in push notifications, with clean fallback to the bundled default when none is set.