### PR TITLE
i18n: localize the 'Return to list after delete or mark unread' setting

### DIFF
--- a/locales/cs/common.json
+++ b/locales/cs/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "Aktuální účet neoznamuje podporu odloženého odeslání. Nastavení zůstane uloženo pro jiné účty."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Návrat do seznamu po smazání nebo označení jako nepřečtené",
+        "description": "Po smazání nebo označení otevřené zprávy jako nepřečtené se vrátit do seznamu zpráv místo otevření následující zprávy."
       }
     },
     "composer": {

--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -1256,8 +1256,8 @@
         "unsupported": "Den aktuelle konto annoncerer ikke understøttelse af forsinket afsendelse. Indstillingen gemmes stadig for andre konti."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Vend tilbage til listen efter sletning eller markering som ulæst",
+        "description": "Efter sletning eller markering af den åbne besked som ulæst vendes der tilbage til beskedlisten i stedet for at åbne den næste besked."
       }
     },
     "composer": {

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "Das aktuelle Konto meldet keine Unterstützung für verzögertes Senden. Die Einstellung bleibt für andere Konten gespeichert."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Nach Löschen oder Ungelesen-Markieren zur Liste zurückkehren",
+        "description": "Nach dem Löschen oder Als-ungelesen-Markieren der geöffneten E-Mail zurück zur Liste, statt die nächste E-Mail zu öffnen."
       }
     },
     "composer": {

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "La cuenta actual no anuncia compatibilidad con envío demorado. La opción seguirá guardada para otras cuentas."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Volver a la lista tras eliminar o marcar como no leído",
+        "description": "Después de eliminar o marcar como no leído el mensaje abierto, volver a la lista de mensajes en lugar de abrir el mensaje siguiente."
       }
     },
     "composer": {

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "Le compte actuel n’annonce pas la prise en charge de l’envoi différé. Le réglage reste enregistré pour d’autres comptes."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Revenir à la liste après suppression ou marquage comme non lu",
+        "description": "Après avoir supprimé ou marqué comme non lu le message ouvert, revenir à la liste des messages au lieu d'ouvrir le message suivant."
       }
     },
     "composer": {

--- a/locales/hu/common.json
+++ b/locales/hu/common.json
@@ -1256,8 +1256,8 @@
         "unsupported": "A jelenlegi fiók nem támogatja a késleltetett küldést. A beállítás más fiókokhoz elmentésre kerül."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Visszatérés a listához törlés vagy olvasatlanként jelölés után",
+        "description": "A megnyitott üzenet törlése vagy olvasatlanként való megjelölése után visszatérés az üzenetlistához a következő üzenet megnyitása helyett."
       }
     },
     "composer": {

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "L’account corrente non dichiara il supporto all’invio ritardato. L’impostazione resta salvata per altri account."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Torna all'elenco dopo l'eliminazione o il contrassegno come non letto",
+        "description": "Dopo aver eliminato o segnato come non letto il messaggio aperto, torna all'elenco dei messaggi invece di aprire il messaggio successivo."
       }
     },
     "composer": {

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "現在のアカウントは遅延送信のサポートを通知していません。この設定は他のアカウント用に保存されます。"
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "削除または未読にした後に一覧へ戻る",
+        "description": "開いているメッセージを削除または未読にした後、次のメッセージを開かずにメッセージ一覧へ戻ります。"
       }
     },
     "composer": {

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "현재 계정은 지연 보내기 지원을 알리지 않습니다. 설정은 다른 계정을 위해 계속 저장됩니다."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "삭제 또는 읽지 않음으로 표시 후 목록으로 돌아가기",
+        "description": "열려 있는 메시지를 삭제하거나 읽지 않음으로 표시한 후 다음 메시지를 열지 않고 메시지 목록으로 돌아갑니다."
       }
     },
     "composer": {

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "Pašreizējais konts neziņo par aizturētas sūtīšanas atbalstu. Iestatījums joprojām tiks saglabāts citiem kontiem."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Atgriezties sarakstā pēc dzēšanas vai atzīmēšanas kā nelasītu",
+        "description": "Pēc atvērtā ziņojuma dzēšanas vai atzīmēšanas kā nelasīta atgriezieties ziņojumu sarakstā, nevis atveriet nākamo ziņojumu."
       }
     },
     "composer": {

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "Het huidige account meldt geen ondersteuning voor vertraagd verzenden. De instelling blijft opgeslagen voor andere accounts."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Terug naar lijst na verwijderen of markeren als ongelezen",
+        "description": "Na het verwijderen of als ongelezen markeren van het geopende bericht terugkeren naar de berichtenlijst in plaats van het volgende bericht te openen."
       }
     },
     "composer": {

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "Bieżące konto nie zgłasza obsługi opóźnionej wysyłki. Ustawienie pozostanie zapisane dla innych kont."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Powrót do listy po usunięciu lub oznaczeniu jako nieprzeczytane",
+        "description": "Po usunięciu lub oznaczeniu otwartej wiadomości jako nieprzeczytanej wróć do listy wiadomości zamiast otwierać następną."
       }
     },
     "composer": {

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "A conta atual não anuncia suporte a envio atrasado. A configuração continuará salva para outras contas."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Voltar à lista após eliminar ou marcar como não lido",
+        "description": "Depois de eliminar ou marcar como não lida a mensagem aberta, voltar à lista de mensagens em vez de abrir a mensagem seguinte."
       }
     },
     "composer": {

--- a/locales/ro/common.json
+++ b/locales/ro/common.json
@@ -1256,8 +1256,8 @@
         "unsupported": "Contul curent nu indică faptul că acceptă trimiterea amânată. Setarea este totuși salvată pentru alte conturi."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Revenire la listă după ștergere sau marcare ca necitit",
+        "description": "După ștergerea sau marcarea mesajului deschis ca necitit, reveniți la lista de mesaje în loc să deschideți mesajul următor."
       }
     },
     "composer": {

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "Текущая учетная запись не заявляет поддержку отложенной отправки. Настройка сохранится для других учетных записей."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Возврат к списку после удаления или отметки как непрочитанного",
+        "description": "После удаления или отметки открытого письма как непрочитанного возвращаться к списку писем вместо открытия следующего."
       }
     },
     "composer": {

--- a/locales/tr/common.json
+++ b/locales/tr/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "Geçerli hesap gecikmeli gönderim desteği bildirmiyor. Ayar diğer hesaplar için kaydedilmeye devam eder."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Silme veya okunmadı olarak işaretlemeden sonra listeye dön",
+        "description": "Açık iletiyi sildikten veya okunmadı olarak işaretledikten sonra, sonraki iletiyi açmak yerine ileti listesine dön."
       }
     },
     "composer": {

--- a/locales/uk/common.json
+++ b/locales/uk/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "Поточний обліковий запис не повідомляє про підтримку відкладеного надсилання. Налаштування залишиться збереженим для інших облікових записів."
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "Повернення до списку після видалення або позначення як непрочитане",
+        "description": "Після видалення або позначення відкритого листа як непрочитаного повертатися до списку листів замість відкриття наступного."
       }
     },
     "composer": {

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -1253,8 +1253,8 @@
         "unsupported": "当前账户未声明支持延迟发送。该设置仍会为其他账户保存。"
       },
       "return_to_list_after_action": {
-        "label": "Return to list after delete or mark unread",
-        "description": "After deleting or marking the open message unread, go back to the message list instead of opening the next message."
+        "label": "删除或标记为未读后返回列表",
+        "description": "删除打开的邮件或将其标记为未读后，返回邮件列表而不是打开下一封邮件。"
       }
     },
     "composer": {


### PR DESCRIPTION
## Summary

The reading setting `settings.email_behavior.return_to_list_after_action` shipped with its English `label`/`description` as a placeholder in every locale except `fa`, so most users saw untranslated English. This adds the missing translations.

## Changes

- Translate `label` and `description` of `return_to_list_after_action` into: `de, cs, da, es, fr, hu, it, ja, ko, lv, nl, pl, pt, ro, ru, tr, uk, zh` (18 locales).
- Wording reuses each locale's existing `mark_unread` ("mark as unread") phrasing for consistency.

## Type of Change

- [x] Bug fix (non-breaking) / i18n

## Checklist

- [x] Contributing Guide read
- [x] Code follows project style and conventions
- [x] `npm run typecheck && npm run lint` passes
- [x] Build passes (`npm run build`)
- [x] Changes tested locally
- [x] Translations updated (`locales/`)

## Notes for Reviewers

- Values only; key parity with `en` is intact (`test:translations` passes, 40/40). Native speakers are welcome to refine any wording.