### PR TITLE
Fix: notification sound preview - base-path prefix + longer default beep

### DIFF
--- a/lib/notification-sound.ts
+++ b/lib/notification-sound.ts
@@ -1,4 +1,5 @@
 import { debug } from '@/lib/debug';
+import { withBasePath } from '@/lib/browser-navigation';
 
 export type NotificationSoundChoice = 'default' | 'cheerful' | 'involved' | 'swift' | 'relax';
 
@@ -20,15 +21,29 @@ function playBeep() {
 
   oscillator.frequency.value = 800;
   oscillator.type = 'sine';
-  gainNode.gain.value = 0.1;
 
-  oscillator.start();
-  oscillator.stop(audioContext.currentTime + 0.15);
+  // Longer, enveloped tone. A 150 ms blip was easy to miss on Bluetooth
+  // outputs, whose audio path can take 100-200 ms to wake up and route - by
+  // the time sound reached the headphones the blip was already over. The
+  // fade in/out also avoids click artifacts.
+  const now = audioContext.currentTime;
+  const duration = 0.45;
+  const peak = 0.12;
+  gainNode.gain.setValueAtTime(0.0001, now);
+  gainNode.gain.exponentialRampToValueAtTime(peak, now + 0.04);
+  gainNode.gain.setValueAtTime(peak, now + duration - 0.08);
+  gainNode.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+
+  oscillator.start(now);
+  oscillator.stop(now + duration + 0.02);
   oscillator.onended = () => audioContext.close();
 }
 
 function playFile(file: string) {
-  const audio = new Audio(file);
+  // Prefix with the deployment base path (e.g. /webmail); a raw "/notification/
+  // x.mp3" 404s under a subpath, which made playFile fall back to the beep for
+  // every choice.
+  const audio = new Audio(withBasePath(file));
   audio.volume = 0.3;
   audio.play().catch((e) => {
     debug.log('push', 'Could not play audio file, falling back to beep:', e);


### PR DESCRIPTION
## Summary

On a subpath deployment (e.g. `/webmail`), the notification sound picker's preview always played the default beep regardless of the selected sound — and that beep was easy to miss on Bluetooth.

## Changes

- `playFile()` now prefixes the sound file with `withBasePath()`. The raw `/notification/*.mp3` path 404s under a deployment base path, so `audio.play()` rejected and fell back to the beep for every non-default choice.
- The default beep is now ~0.45 s with a fade in/out instead of a 150 ms blip — long enough to survive Bluetooth output wake-up latency (~100–200 ms) and free of click artifacts.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Contributing Guide read
- [x] Code follows project style and conventions
- [x] `npm run typecheck && npm run lint` passes
- [x] Build passes (`npm run build`)
- [x] Changes tested locally
- [ ] Translations updated (locales/) — n/a, no new user-facing strings

## Notes for Reviewers

- Verified live: the mp3s are served correctly at the base-pathed URL (HTTP 200); only the request URL was wrong. On root deployments `withBasePath` is a no-op, so behaviour is unchanged there.