### PR TITLE
Fix plugin settings slot and privileged tier installs

### DIFF
--- a/app/api/admin/marketplace/route.ts
+++ b/app/api/admin/marketplace/route.ts
@@ -341,6 +341,7 @@ export async function POST(request: NextRequest) {
         author: (manifest.author as string) || 'Unknown',
         description: (manifest.description as string) || '',
         type: (manifest.type as string) || 'hook',
+        ...(manifest.tier === 'privileged' ? { tier: 'privileged' } : {}),
         permissions,
         entrypoint,
         enabled: existingPlugin?.enabled ?? true,

--- a/components/settings/account-settings.tsx
+++ b/components/settings/account-settings.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/components/ui/button';
 import { useRouter } from '@/i18n/navigation';
 import { getMaxAccounts } from '@/lib/account-utils';
 import { formatFileSize, cn } from '@/lib/utils';
+import { PluginSlot } from '@/components/plugins/plugin-slot';
 
 function hostnameOf(serverUrl: string): string {
   try { return new URL(serverUrl).hostname; } catch { return serverUrl; }
@@ -179,6 +180,8 @@ export function AccountSettings() {
           </SettingItem>
         )}
       </SettingsSection>
+
+      <PluginSlot name="settings-section" />
 
       {/* Logged-in accounts list */}
       {accounts.length > 0 && (


### PR DESCRIPTION
## Summary

Fixes two plugin host issues that currently break the marketplace S/MIME plugin flow:

- Mount the `settings-section` plugin slot in Account settings so plugins declaring `ui:settings-section` can render their settings UI.
- Preserve `manifest.tier === "privileged"` when installing plugins through the marketplace API. Direct admin plugin uploads already preserve this field, but marketplace installs were dropping it from the registry entry.

This matters for S/MIME because the published `smime` 1.0.1 bundle declares `tier: "privileged"` and requires same-origin WebCrypto/IndexedDB access. If the tier is dropped during install, the sandbox refuses privileged APIs and the plugin fails at runtime.

## Verification

- Built production Docker image with `docker build -t bulwark-dev .`; Next build and TypeScript completed successfully.
- Verified `/api/plugins` reports S/MIME 1.0.1 with `tier: "privileged"`.
- Verified persisted registry contains `tier: "privileged"` for `smime`.
- Verified source has exactly one live `PluginSlot name="settings-section"` mount.
