### PR TITLE
Fix: keep the session when the auth server is briefly unreachable

### DIFF
--- a/app/api/auth/token/route.ts
+++ b/app/api/auth/token/route.ts
@@ -82,9 +82,16 @@ export async function PUT(request: NextRequest) {
     if (!tokenResponse.ok) {
       const errorText = await tokenResponse.text();
       logger.error('Token refresh failed', { status: tokenResponse.status, error: errorText });
-      cookieStore.delete(cookieName);
-      cookieStore.delete(refreshTokenServerCookieName(slot));
-      return NextResponse.json({ error: 'Refresh failed' }, { status: 401 });
+      // Drop the refresh token only when the server definitively rejected it
+      // (invalid/expired/revoked grant). A 5xx or 429 is an outage - keeping
+      // the cookie lets the session resume once the server is back.
+      const status = tokenResponse.status;
+      if (status === 400 || status === 401 || status === 403) {
+        cookieStore.delete(cookieName);
+        cookieStore.delete(refreshTokenServerCookieName(slot));
+        return NextResponse.json({ error: 'Refresh failed' }, { status: 401 });
+      }
+      return NextResponse.json({ error: 'Token endpoint unavailable' }, { status: 503 });
     }
 
     const tokens = await tokenResponse.json();

--- a/stores/__tests__/auth-store-logout.test.ts
+++ b/stores/__tests__/auth-store-logout.test.ts
@@ -55,7 +55,7 @@ describe('auth-store logout redirects', () => {
     expect(fetchMock).toHaveBeenCalledWith('/api/auth/session?slot=0', { method: 'DELETE', keepalive: true });
   });
 
-  it('marks session expiry, preserves the current path, and redirects to login on refresh failure', async () => {
+  it('marks session expiry, preserves the current path, and redirects to login when the refresh is rejected (401)', async () => {
     vi.useFakeTimers();
 
     const fetchMock = vi.fn(async (input: FetchInput, init?: FetchInit) => {
@@ -63,7 +63,7 @@ describe('auth-store logout redirects', () => {
       const method = init?.method ?? 'GET';
 
       if (url === '/api/auth/token?slot=0' && method === 'PUT') {
-        return { ok: false, json: async () => ({}) };
+        return { ok: false, status: 401, json: async () => ({}) };
       }
 
       if (url === '/api/auth/token?slot=0' && method === 'DELETE') {
@@ -93,5 +93,75 @@ describe('auth-store logout redirects', () => {
     expect(sessionStorage.getItem('session_expired')).toBe('true');
     expect(sessionStorage.getItem('redirect_after_login')).toBe('/en/calendar?view=day');
     expect(replaceSpy).toHaveBeenCalledWith('/en/login');
+  });
+
+  it('keeps the session and schedules a retry when the token endpoint is unavailable (5xx)', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn(async (input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+
+      if (url === '/api/auth/token?slot=0' && method === 'PUT') {
+        return { ok: false, status: 503, json: async () => ({}) };
+      }
+
+      throw new Error(`Unexpected fetch call: ${method} ${url}`);
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+    const replaceSpy = vi.spyOn(browserNavigation, 'replaceWindowLocation').mockImplementation(() => {});
+
+    useAuthStore.setState({
+      isAuthenticated: true,
+      authMode: 'oauth',
+      activeAccountId: null,
+    });
+
+    const token = await useAuthStore.getState().refreshAccessToken();
+
+    expect(token).toBeNull();
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    expect(sessionStorage.getItem('session_expired')).toBeNull();
+    expect(replaceSpy).not.toHaveBeenCalled();
+
+    // A retry is armed: advancing past the ~30 s window fires a second PUT.
+    await vi.advanceTimersByTimeAsync(31_000);
+    const refreshPuts = fetchMock.mock.calls.filter(
+      ([input, init]) => String(input) === '/api/auth/token?slot=0' && init?.method === 'PUT',
+    );
+    expect(refreshPuts.length).toBe(2);
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+  });
+
+  it('keeps the session when the refresh request fails with a network error', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn(async (input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+
+      if (url === '/api/auth/token?slot=0' && method === 'PUT') {
+        throw new TypeError('Failed to fetch');
+      }
+
+      throw new Error(`Unexpected fetch call: ${method} ${url}`);
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+    const replaceSpy = vi.spyOn(browserNavigation, 'replaceWindowLocation').mockImplementation(() => {});
+
+    useAuthStore.setState({
+      isAuthenticated: true,
+      authMode: 'oauth',
+      activeAccountId: null,
+    });
+
+    const token = await useAuthStore.getState().refreshAccessToken();
+
+    expect(token).toBeNull();
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    expect(sessionStorage.getItem('session_expired')).toBeNull();
+    expect(replaceSpy).not.toHaveBeenCalled();
   });
 });

--- a/stores/auth-store.ts
+++ b/stores/auth-store.ts
@@ -75,6 +75,32 @@ function isRateLimitError(error: unknown): error is RateLimitError {
   return error instanceof RateLimitError;
 }
 
+// An auth/session endpoint answered with a server-side error (5xx) - an
+// outage, not a rejection of our credentials.
+class TransientAuthError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(`${message}: ${status}`);
+  }
+}
+
+// True when a restore/refresh attempt failed because the server could not be
+// reached (network error) or answered 5xx (restart, maintenance, proxy
+// hiccup). Such failures must keep the account and its cookies - "stay signed
+// in" has to survive downtime and offline spells. Only a definitive rejection
+// (401/400) may evict. Mirrors the rate-limit carve-out (#104).
+function isTransientAuthError(error: unknown): boolean {
+  if (error instanceof TransientAuthError) return true;
+  // fetch() rejects with TypeError when the network is unreachable.
+  if (error instanceof TypeError) return true;
+  // JMAPClient.connect()/refreshSession() embed the HTTP status in the
+  // message - a 5xx there is the server being down, not an auth failure.
+  if (error instanceof Error) {
+    const m = error.message.match(/(?:Failed to get session|Session refresh failed): (\d{3})/);
+    if (m) return m[1].startsWith('5');
+  }
+  return false;
+}
+
 function getClientRateLimitState(client: IJMAPClient | null): Pick<AuthState, 'isRateLimited' | 'rateLimitUntil'> {
   if (!client) {
     return { isRateLimited: false, rateLimitUntil: null };
@@ -293,6 +319,10 @@ let refreshPromise: Promise<string | null> | null = null;
 const clients = new Map<string, JMAPClient>();
 const refreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const refreshPromises = new Map<string, Promise<string | null>>();
+
+// Pseudo-expiry passed to scheduleRefresh when a refresh failed transiently:
+// the "expiry - 60s" math below turns 90 into a retry in ~30 seconds.
+const TOKEN_REFRESH_RETRY_SECONDS = 90;
 
 function scheduleRefresh(expiresIn: number, refreshFn: () => Promise<string | null>, accountId?: string): void {
   if (accountId) {
@@ -948,9 +978,18 @@ export const useAuthStore = create<AuthState>()(
             const res = await apiFetch(`/api/auth/token?slot=${slot}`, { method: 'PUT' });
 
             if (!res.ok) {
-              notifyParent('sso:session-expired');
-              markSessionExpired();
-              get().logout();
+              // Only a definitive 401 ends the session. Anything else (5xx
+              // while the server restarts, proxy errors) is an outage - keep
+              // the session and retry shortly so "stay signed in" survives
+              // maintenance windows and offline spells.
+              if (res.status === 401) {
+                notifyParent('sso:session-expired');
+                markSessionExpired();
+                get().logout();
+                return null;
+              }
+              debug.error(`Token refresh unavailable (${res.status}), retrying shortly`);
+              scheduleRefresh(TOKEN_REFRESH_RETRY_SECONDS, get().refreshAccessToken, accountId ?? undefined);
               return null;
             }
 
@@ -975,10 +1014,10 @@ export const useAuthStore = create<AuthState>()(
             scheduleRefresh(expires_in, get().refreshAccessToken, accountId ?? undefined);
             return access_token;
           } catch (error) {
-            debug.error('Token refresh failed:', error);
-            notifyParent('sso:session-expired');
-            markSessionExpired();
-            get().logout();
+            // Network failure (offline, Wi-Fi switch, server unreachable) -
+            // not a rejection. Keep the session and retry shortly.
+            debug.error('Token refresh failed, retrying shortly:', error);
+            scheduleRefresh(TOKEN_REFRESH_RETRY_SECONDS, get().refreshAccessToken, accountId ?? undefined);
             return null;
           } finally {
             refreshPromise = null;
@@ -1374,6 +1413,8 @@ export const useAuthStore = create<AuthState>()(
                   scheduleRefresh(expires_in, get().refreshAccessToken, account.id);
                   await syncStalwartAuthContext(account.serverUrl, account.username, client.getAuthHeader(), account.cookieSlot);
                   accountStore.updateAccount(account.id, { isConnected: true, hasError: false });
+                } else if (res.status >= 500) {
+                  throw new TransientAuthError('Token refresh failed', res.status);
                 } else {
                   throw new Error(`Token refresh failed: ${res.status}`);
                 }
@@ -1387,6 +1428,8 @@ export const useAuthStore = create<AuthState>()(
                   clients.set(account.id, client);
                   await syncStalwartAuthContext(serverUrl, username, client.getAuthHeader(), account.cookieSlot);
                   accountStore.updateAccount(account.id, { isConnected: true, hasError: false });
+                } else if (res.status >= 500) {
+                  throw new TransientAuthError('Session restore failed', res.status);
                 } else {
                   throw new Error(`Session cookie missing: ${res.status}`);
                 }
@@ -1398,6 +1441,18 @@ export const useAuthStore = create<AuthState>()(
                   isConnected: false,
                   hasError: true,
                   errorMessage: 'Temporarily rate limited by server',
+                });
+                continue;
+              }
+              // Outage or offline - keep the account (and its cookies) so the
+              // session resumes once the server is reachable again. Same
+              // treatment as the rate-limit case above; only a definitive
+              // rejection below evicts.
+              if (isTransientAuthError(err)) {
+                accountStore.updateAccount(account.id, {
+                  isConnected: false,
+                  hasError: true,
+                  errorMessage: 'Server unreachable',
                 });
                 continue;
               }
@@ -1627,7 +1682,7 @@ export const useAuthStore = create<AuthState>()(
               }
             } catch (error) {
               debug.error('Basic session restore failed:', error);
-              if (isRateLimitError(error)) {
+              if (isRateLimitError(error) || isTransientAuthError(error)) {
                 set({ isLoading: false, error: 'connection_failed', isRateLimited: false, rateLimitUntil: null });
                 return;
               }


### PR DESCRIPTION
## Summary

A server restart, a proxy hiccup, a Wi-Fi switch or a laptop waking before the network is back all ended the session and forced a re-login, despite "stay signed in". Any transient failure was treated like a rejected token.

## Changes

- `/api/auth/token` (PUT): the refresh cookies are only deleted when the OAuth endpoint definitively rejects the grant (400/401/403 -> respond 401). A 5xx or 429 is an outage: cookies are kept and the route responds 503, so the session can resume once the server is back.
- `refreshAccessToken`: logs out only on a definitive 401. On 5xx or a network error it keeps the session and re-arms the existing refresh timer to retry every ~30 seconds. Pending retries are cancelled by the existing timer cleanup in `logout()`/`logoutAll()`.
- Startup restore (multi-account loop and legacy path): transient failures (network error, 5xx - classified by a new `isTransientAuthError` helper) now get the same treatment as the rate-limit carve-out from #104: the account is kept and marked unreachable instead of being evicted with its session cookie deleted.
- Tests: the old "any refresh failure logs out" test now asserts the 401 case explicitly; two new tests cover 503 (session survives, retry fires after ~30 s) and network errors (session survives).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Checklist

- [x] `tsc --noEmit` passes (0 errors)
- [x] `eslint` passes on the changed files
- [x] Auth store tests pass (10/10, including 3 covering the new contract)
- [x] `next build` succeeds (exit 0)

## Notes for Reviewers

- Token validity stays entirely server-enforced: the first definitive 401 after an outage tears the session down exactly as before. This change only stops the client from destroying its own credentials on ambiguous signals (unreachable != unauthorized).
- The normal-operation code path is unchanged; the new branches only activate on 5xx/network failures - so the worst case is identical to today's behavior.
- Follows the transient-failure pattern already established for rate limiting in #104.