### PR TITLE
feat: add NEXT_PUBLIC_LOCALE_PREFIX build argument to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # at build time, so it cannot be changed without rebuilding.
 ARG NEXT_PUBLIC_BASE_PATH=
 ENV NEXT_PUBLIC_BASE_PATH=$NEXT_PUBLIC_BASE_PATH
+# Optional: avoid next-intl rewrite loops when served under a subpath.
+# Baked in at build time.
+ARG NEXT_PUBLIC_LOCALE_PREFIX=
+ENV NEXT_PUBLIC_LOCALE_PREFIX=$NEXT_PUBLIC_LOCALE_PREFIX
 # Optional: fallback UI locale (e.g. tr, de, fr) used when the visitor's
 # Accept-Language header does not match any supported locale. Baked in at
 # build time because next-intl wires it into client-side routing too.


### PR DESCRIPTION
## Summary

This PR adds the missing `NEXT_PUBLIC_LOCALE_PREFIX` build argument to the Dockerfile. Currently, building the image with `--build-arg NEXT_PUBLIC_LOCALE_PREFIX=always` (as suggested in the README for subpath deployments) fails because the argument is not declared and passed to the environment. This change aligns the Docker build process with the documented workflow.

## Changes

- Added `ARG NEXT_PUBLIC_LOCALE_PREFIX=` to the builder stage in the Dockerfile.
- Added `ENV NEXT_PUBLIC_LOCALE_PREFIX=$NEXT_PUBLIC_LOCALE_PREFIX` after the `BASE_PATH` environment variable to ensure it's available during the Next.js build.
- Added a descriptive comment to clarify the purpose of this variable.

## Related Issues

Related to the documented deployment instructions for subpaths. Fixes the build error when using the `--build-arg` flag as described in the README.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed (N/A — aligns with existing README)
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text (N/A)
- [ ] I have included screenshots or a screen recording for UI changes (N/A — build only)

## Screenshots / Demo

N/A — build configuration change only.

## Notes for Reviewers

This is a minimal change that simply declares the `ARG` and `ENV`, mirroring how `NEXT_PUBLIC_BASE_PATH` is already handled in the same Dockerfile. It does not change the default build behavior (since the variable defaults to empty).