### PR TITLE
ci: build and publish images with NEXT_PUBLIC_LOCALE_PREFIX=always

### DIFF
--- a/.github/workflows/docker-publish-releases.yml
+++ b/.github/workflows/docker-publish-releases.yml
@@ -118,3 +118,114 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+  build-always:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            NEXT_PUBLIC_LOCALE_PREFIX=always
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=always-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=always-${{ matrix.platform }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests-always
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests-always/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-always-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests-always/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-always:
+    runs-on: ubuntu-latest
+    needs: build-always
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests-always
+          pattern: digests-always-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-always,onlatest=true
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=semver,pattern={{major}}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests-always
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Summary

This PR extends the existing GitHub Actions workflow to automatically build and publish Docker images with the `NEXT_PUBLIC_LOCALE_PREFIX` environment variable set to `always`. As documented in the README, this configuration is required for users who want to serve the webmail at a subpath to avoid `next-intl` rewrite loops. This provides pre-built images (`-always` suffix) for these users, removing the need for them to build their own custom images.

**Important:** The `NEXT_PUBLIC_BASE_PATH` is intentionally NOT set in these builds. Each user may have a different subpath (e.g., `/webmail`, `/mail`, `/apps/email`), and since `NEXT_PUBLIC_*` variables are inlined at build time, hardcoding a specific base path would make the image unusable for most users. Setting only `NEXT_PUBLIC_LOCALE_PREFIX=always` is the correct approach.

## Changes

- Added new `build-always` job that builds images with `build-args: NEXT_PUBLIC_LOCALE_PREFIX=always` only.
- Added `merge-always` job that creates a separate multi-arch manifest list with `-always` suffixed tags (e.g., `ghcr.io/bulwarkmail/webmail:1.7.6-always` and `latest-always`).
- The new images are built for all supported platforms (linux/amd64, linux/arm64) and published alongside the default builds.
- The existing default builds remain unchanged, ensuring backward compatibility.

## Related Issues

Closes the need for users to manually rebuild images when deploying to a subpath. Related to documentation in the README.

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [x] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions (YAML formatting)
- [x] I have run `npm run typecheck && npm run lint` and there are no errors (N/A — CI change only)
- [x] The build passes (`npm run build`) (N/A — CI change only)
- [ ] I have tested my changes locally — Note: I have replicated the existing job structure and made minimal modifications, following the same logic as the current workflow.
- [ ] I have added or updated documentation if needed — I will update the README in a follow-up PR to mention the `-always` images if this is merged.
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text (N/A)
- [ ] I have included screenshots or a screen recording for UI changes (N/A)

## Screenshots / Demo

N/A — CI/CD pipeline changes only.

## Notes for Reviewers

- The `build-always` and `merge-always` jobs are copies of the `build` and `merge` jobs, with `build-args: NEXT_PUBLIC_LOCALE_PREFIX=always` added.
- I used `flavor: suffix=-always,onlatest=true` to ensure that the `latest` tag also gets the `-always` suffix, preventing it from overwriting the standard `latest` image.
- **Important limitation (inherited from the original workflow):** These jobs run on both `release: published` and `workflow_dispatch` events. If triggered manually from a non-release branch, the `latest-always` tag could be overwritten with a non-release build. This is a pre-existing issue in the original workflow that this PR does not attempt to fix, as it would require changing the main workflow's behavior and be out of scope for this change. The `-always` images are primarily intended for release builds.
- The `NEXT_PUBLIC_BASE_PATH` is intentionally omitted — users should set it according to their own subpath deployment needs, not via a pre-built image.