### PR TITLE
i18n: restore key parity after the Jalali calendar

### DIFF
--- a/locales/fa/common.json
+++ b/locales/fa/common.json
@@ -681,12 +681,7 @@
     "recipient_email_placeholder": "آدرس ایمیل",
     "recipient_name_placeholder": "نام نمایشی",
     "autocomplete_search_server": "جستجو در سرور",
-    "autocomplete_searching": "در حال جستجو...",
-    "text_direction": {
-      "toggle": "تغییر جهت متن (چپ‌به‌راست / راست‌به‌چپ)",
-      "ltr": "چپ‌به‌راست",
-      "rtl": "راست‌به‌چپ"
-    }
+    "autocomplete_searching": "در حال جستجو..."
   },
   "confirm_dialog": {
     "confirm": "تأیید",
@@ -1885,8 +1880,7 @@
       "validation": {
         "empty": "نام قالب الزامی است",
         "too_long": "نام قالب باید ۲۰۰ کاراکتر یا کمتر باشد"
-      },
-      "image_too_large": "حجم تصویر بیش از حد مجاز (حداکثر ۱ مگابایت)"
+      }
     },
     "files": {
       "display": {

--- a/locales/he/common.json
+++ b/locales/he/common.json
@@ -2823,7 +2823,19 @@
       "sep": "ספט׳",
       "oct": "אוק׳",
       "nov": "נוב׳",
-      "dec": "דצמ׳"
+      "dec": "דצמ׳",
+      "far": "Farvardin",
+      "ord": "Ordibehesht",
+      "kho": "Khordad",
+      "tir": "Tir",
+      "mor": "Mordad",
+      "sha": "Shahrivar",
+      "meh": "Mehr",
+      "aba": "Aban",
+      "aza": "Azar",
+      "dey": "Dey",
+      "bah": "Bahman",
+      "esf": "Esfand"
     },
     "nav_open_menu": "פתח תפריט",
     "webcal_action": {

--- a/locales/sk/common.json
+++ b/locales/sk/common.json
@@ -2723,7 +2723,19 @@
       "sep": "sep",
       "oct": "okt",
       "nov": "nov",
-      "dec": "dec"
+      "dec": "dec",
+      "far": "Farvardin",
+      "ord": "Ordibehesht",
+      "kho": "Khordad",
+      "tir": "Tir",
+      "mor": "Mordad",
+      "sha": "Shahrivar",
+      "meh": "Mehr",
+      "aba": "Aban",
+      "aza": "Azar",
+      "dey": "Dey",
+      "bah": "Bahman",
+      "esf": "Esfand"
     },
     "notifications": {
       "event_created": "Udalosť bola vytvorená",


### PR DESCRIPTION
## Summary

`npm run test:translations` fails on `main` again since the Jalali calendar landed: the two newest locales were missed when the month names were added, and `fa` carries keys that no longer exist anywhere else.

## Changes

- `he` and `sk`: added the twelve Jalali month keys (`calendar.months.far` ... `esf`) with the same Latin transliterations every other non-Persian locale received ("Farvardin", "Ordibehesht", ...).
- `fa`: removed four keys that do not exist in `en` and are not referenced anywhere in the code - the `email_composer.text_direction` block and `settings.templates.image_too_large` - as the suite's no-extra-keys check demands. All other `fa` values verified byte-identical.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Checklist

- [x] `npm run test:translations` passes on this branch (44/44 - fails on current main)
- [x] All 22 locales verified to have identical key sets
- [x] `next build` succeeds (exit 0)

## Notes for Reviewers

- Locale JSON files only, no code changes.