### PR TITLE
feat: add 3 new plugin hooks : onBeforeBlobUpload, onBeforeDraftAutoS…

### DIFF
--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -1344,6 +1344,8 @@ export default function Home() {
       draft = fullDraft;
     }
 
+    draft = await emailHooks.onBeforeEditDraft.transform(draft);
+
     const bodyText = draft.bodyValues
       ? Object.values(draft.bodyValues).map(v => v.value).join('\n')
       : '';

--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -17,7 +17,7 @@ import { isFilePreviewable } from "@/lib/file-preview";
 import { buildQuotedHtmlBlock, serializeEditorContent } from "@/components/email/quoted-html";
 import { buildSignatureBlock } from "@/components/email/signature-block";
 import { emailHooks, contactHooks } from "@/lib/plugin-hooks";
-import type { OutgoingEmail, RecipientSuggestion } from "@/lib/plugin-types";
+import type { AlmostSavedDraft, OutgoingEmail, RecipientSuggestion } from "@/lib/plugin-types";
 import { useAuthStore } from "@/stores/auth-store";
 import { useIdentityStore } from "@/stores/identity-store";
 import { useProMultiAccountIdentities, stripCrossAccountIdentityPrefix } from "@/hooks/use-pro-multi-account-identities";
@@ -53,6 +53,7 @@ import { isValidEmail } from "@/lib/validation";
 import { RichTextEditor } from "@/components/email/rich-text-editor";
 import type { Editor } from "@tiptap/react";
 import { htmlToPlainText as htmlToPlainTextShared } from "@/lib/html-to-text";
+import { fileStorage } from "@/lib/plugin-storage";
 
 /**
  * Derives the text/plain alternative from the composer's HTML body, preserving
@@ -1129,7 +1130,16 @@ export function EmailComposer({
       const controller = newAttachments[i].abortController;
       try {
         if (controller?.signal.aborted) continue;
-        const { blobId } = await client.uploadBlob(file);
+        
+        const fileId = generateUUID();
+        await fileStorage.saveFile(fileId, file);
+        
+        const newFileId = await emailHooks.onBeforeBlobUpload.transform(fileId);
+
+        const newFile = await fileStorage.getFile(newFileId) || file;
+        await fileStorage.deleteFile(newFileId);
+
+        const { blobId } = await client.uploadBlob(newFile);
 
         if (controller?.signal.aborted) continue;
         setAttachments(prev =>
@@ -1337,21 +1347,36 @@ export function EmailComposer({
 
     try {
       const previousDraftId = draftIdRef.current;
+      let savedDraft : AlmostSavedDraft = { 
+       to: toAddresses,
+        subject: subject || t('no_subject'),
+        body: plainTextMode ? body : htmlToPlainText(body),
+        cc: ccAddresses,
+        bcc: bccAddresses,
+        identityId: currentIdentityRawId,
+        fromEmail,
+        draftId: previousDraftId || undefined,
+        attachments: uploadedAttachments,
+        fromName,
+        htmlBody: plainTextMode ? undefined : body
+      }
+      savedDraft = await emailHooks.onBeforeDraftAutoSave.transform(savedDraft);
+
       // Use the JMAP client and raw identity id for the *owning* account
       // - falls back to active client for single-account / same-account
       // identities. See `composerClient` derivation above.
       const savedDraftId = await composerClient.createDraft(
-        toAddresses,
-        subject || t('no_subject'),
-        plainTextMode ? body : htmlToPlainText(body),
-        ccAddresses,
-        bccAddresses,
-        currentIdentityRawId,
-        fromEmail,
-        previousDraftId || undefined,
-        uploadedAttachments,
-        fromName,
-        plainTextMode ? undefined : body
+        savedDraft.to,
+        savedDraft.subject,
+        savedDraft.body,
+        savedDraft.cc,
+        savedDraft.bcc,
+        savedDraft.identityId,
+        savedDraft.fromEmail,
+        savedDraft.draftId,
+        savedDraft.attachments,
+        savedDraft.fromName,
+        savedDraft.htmlBody
       );
 
       // Update the ref synchronously so a queued save sees the new id and

--- a/lib/plugin-hooks.ts
+++ b/lib/plugin-hooks.ts
@@ -183,7 +183,14 @@ export const emailHooks = {
   onComposerOpen: new HookBus(),
   onBeforeEmailSend: new HookBus(),
   onAfterEmailSend: new HookBus(),
+  // Transform hook - fires before the draft is auto-saved to the server.
+  // Receive fields passed to client.createDraft and may mutate fields in place.
+  // Return false to cancel the auto-save or a the fields.
+  onBeforeDraftAutoSave: new HookBus(),
   onDraftAutoSave: new HookBus(),
+  // Transform hook - fires before a draft is created from an email in draft mailbox.
+  // Receive a Email object and may mutate fields in place.
+  onBeforeEditDraft: new HookBus(),
   onBeforeEmailDelete: new HookBus(),
   onAfterEmailDelete: new HookBus(),
   onBeforeEmailMove: new HookBus(),
@@ -232,6 +239,12 @@ export const emailHooks = {
   // attachment. Handler receives AttachmentInfo (size/type/name only - the
   // raw file is not exposed). Return false to refuse the upload.
   onBeforeAttachmentUpload: new HookBus(),
+  // Intercept hook fired before a file is uploaded to JMAP server. 
+  // It is fired after onBeforeAttachmentUpload.
+  // Handler receive the {file: File, blobId: 'undefined'} object. 
+  // If it uploaded, it must return the object with true blobId. 
+  // Here, the raw file sended is exposed and can be modified or replaced. 
+  onBeforeBlobUpload: new HookBus(),
   // Observer fired after an attachment has been uploaded and its blobId is
   // available. Handler receives AttachmentInfo with `blobId` populated.
   onAfterAttachmentUpload: new HookBus(),

--- a/lib/plugin-sandbox/consent.ts
+++ b/lib/plugin-sandbox/consent.ts
@@ -60,6 +60,7 @@ const PERMISSION_LABELS: Record<string, { title: string; body: string }> = {
   'crypto:full':      { title: 'Full cryptographic access (high risk)', body: 'Runs with full cryptographic access in a privileged, same-origin context. It can read your message bodies and private keys, store key material, and sign/encrypt on your behalf. Only enable plugins you fully trust — this is comparable to a full-access browser extension.' },
   'email:raw-send':   { title: 'Send raw messages',                body: 'Submit fully-formed (e.g. signed or encrypted) messages on your behalf.' },
   'email:blob-read':  { title: 'Read raw message content',        body: 'Fetch the raw bytes of your messages and attachments (needed to decrypt and verify them).' },
+  'email:blob-write':  { title: 'Alterate raw message content',        body: 'get the raw file content before it is uploaded to alterate it just before is is sended to server. (needed to encrypt)' },
   'email:render-takeover': { title: 'Replace rendered email content', body: 'Replace the displayed content of an opened message (e.g. to show decrypted text and a signature-verification badge).' },
   'calendar:read':    { title: 'Read your calendar',             body: 'Access events, calendars, RSVPs, and reminders.' },
   'calendar:write':   { title: 'Modify your calendar',           body: 'Create, edit, or delete events.' },

--- a/lib/plugin-sandbox/host-api.ts
+++ b/lib/plugin-sandbox/host-api.ts
@@ -9,6 +9,8 @@ import { useAuthStore } from '@/stores/auth-store';
 import { useEmailStore } from '@/stores/email-store';
 import { apiFetch } from '../browser-navigation';
 import { awaitDialog } from './host-dialog';
+import { fileStorage} from '../plugin-storage'
+import { generateUUID } from '../utils';
 
 /**
  * Methods only callable from the privileged (same-origin) tier. These expose
@@ -19,6 +21,8 @@ import { awaitDialog } from './host-dialog';
 const PRIVILEGED_ONLY_METHODS = new Set<string>([
   'jmap.fetchBlob',
   'jmap.sendRaw',
+  'upfiles.get',
+  'upfiles.set',
 ]);
 
 const PERM_PER_METHOD: Record<string, Permission | null> = {
@@ -38,6 +42,11 @@ const PERM_PER_METHOD: Record<string, Permission | null> = {
   // jmap (privileged-tier only; see PRIVILEGED_ONLY_METHODS)
   'jmap.fetchBlob': 'email:blob-read',
   'jmap.sendRaw': 'email:raw-send',
+  // uploaded files (privileged-tier only) : 
+  // Used only to get a file before it is uploaded to alterate it. 
+  // To just read, use jmap.fetchBlob.
+  'upfiles.get' : 'email:blob-write',
+  'upfiles.save' : 'email:blob-write',
   // admin
   'admin.getConfig': 'admin:config',
   'admin.getAllConfig': 'admin:config',
@@ -263,6 +272,19 @@ async function doJmapSendRaw(
   );
 }
 
+// ─── Uploaded files in IndexedDB (privileged tier) ──────────────────────────
+
+async function getFile(fileID:string): Promise<File | null> {
+  return await fileStorage.getFile(fileID)
+}
+
+async function saveFile(formerFileID:string, file: File): Promise<string> {
+  const fileId = generateUUID();
+  await fileStorage.saveFile(fileId, file);
+  await fileStorage.deleteFile(formerFileID);
+  return fileId;
+}
+
 // ─── admin config (same as before) ────────────────────────────
 
 async function adminGetAll(pluginId: string): Promise<Record<string, unknown>> {
@@ -335,6 +357,8 @@ export async function dispatchApiCall(
       args[1] as string,
       args[2] as { delayedUntil?: string; envelopeRecipients?: string[] } | undefined,
     );
+    case 'upfiles.get' : return getFile(args[0] as string);
+    case 'upfiles.save' : return saveFile(args[0] as string, args[1] as File);
 
     case 'admin.getConfig':    return adminGet(plugin.id, args[0] as string);
     case 'admin.getAllConfig': return adminGetAll(plugin.id);

--- a/lib/plugin-sandbox/runtime.tsx
+++ b/lib/plugin-sandbox/runtime.tsx
@@ -189,6 +189,16 @@ function buildPluginApi(manifest: PluginManifest) {
         opts?: { delayedUntil?: string; envelopeRecipients?: string[] },
       ) => callApi('jmap.sendRaw', [rawBytes, identityId, opts]),
     },
+    /**
+     * Used to alterate files before they are uploaded to server.
+     * Edited files are saved on indexedDB and remove once the upload to server begins.
+     */
+    upfiles: {
+      save: (formerFileId:string, file:File) =>
+        callApi('upfiles.save', [formerFileId, file]) as Promise<string>,
+      get: (fileId:string) =>
+        callApi('upfiles.get', [fileId]) as Promise<File>,
+    },
     toast: {
       success: (m: string) => { void callApi('toast.success', [m]); },
       error: (m: string) => { void callApi('toast.error', [m]); },

--- a/lib/plugin-storage.ts
+++ b/lib/plugin-storage.ts
@@ -1,12 +1,13 @@
 // IndexedDB storage for plugin/theme binary blobs (JS bundles, CSS, previews)
 
 const DB_NAME = 'bulwark-plugins';
-// Bumped to 2 to add the theme-skin store; existing stores are preserved.
-const DB_VERSION = 2;
+// Bumped to 3 to add the file-plugin store; existing stores are preserved.
+const DB_VERSION = 3;
 const STORE_PLUGINS = 'plugin-code';
 const STORE_THEMES = 'theme-css';
 const STORE_THEME_SKINS = 'theme-skin';
 const STORE_PREVIEWS = 'previews';
+const STORE_FILE_ACCESS_PLUGIN = 'file-plugin'
 
 function openDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
@@ -26,6 +27,9 @@ function openDB(): Promise<IDBDatabase> {
       if (!db.objectStoreNames.contains(STORE_PREVIEWS)) {
         db.createObjectStore(STORE_PREVIEWS);
       }
+      if (!db.objectStoreNames.contains(STORE_FILE_ACCESS_PLUGIN)) {
+        db.createObjectStore(STORE_FILE_ACCESS_PLUGIN);
+      }
     };
 
     request.onsuccess = () => resolve(request.result);
@@ -33,7 +37,7 @@ function openDB(): Promise<IDBDatabase> {
   });
 }
 
-async function putItem(storeName: string, key: string, value: string | Blob): Promise<void> {
+async function putItem(storeName: string, key: string, value: string | Blob | File): Promise<void> {
   const db = await openDB();
   return new Promise((resolve, reject) => {
     const tx = db.transaction(storeName, 'readwrite');
@@ -111,3 +115,19 @@ export const pluginStorage = {
     await deleteItem(STORE_PREVIEWS, id);
   },
 };
+
+/**
+ * Used in host-api for plugins to access to raw data files
+ * to modify them before they are uploaded.
+ */
+export const fileStorage = {
+      async saveFile(fileId: string, file: File): Promise<void> {
+    await putItem(STORE_FILE_ACCESS_PLUGIN, fileId, file);
+  },
+  async getFile(fileId: string): Promise<File | null> {
+    return getItem<File>(STORE_FILE_ACCESS_PLUGIN, fileId);
+  },
+  async deleteFile(fileId: string): Promise<void> {
+    await deleteItem(STORE_FILE_ACCESS_PLUGIN, fileId);
+  },
+}

--- a/lib/plugin-types.ts
+++ b/lib/plugin-types.ts
@@ -674,6 +674,22 @@ export interface OutgoingEmail {
   /** Free-form custom headers added by the composer or earlier handlers */
   headers?: Record<string, string>;
 }
+/**
+ * Passed to onBeforeDraftAutoSave handlers as a transform value.
+ */
+export interface AlmostSavedDraft{
+   to: string[],
+    subject: string,
+    body: string,
+    cc?: string[],
+    bcc?: string[],
+    identityId?: string,
+    fromEmail?: string,
+    draftId?: string,
+    attachments?: Array<{ blobId: string; name: string; type: string; size: number; disposition?: 'attachment' | 'inline'; cid?: string }>,
+    fromName?: string,
+    htmlBody?: string
+}
 
 /**
  * Passed to onBeforeReply / onBeforeReplyAll / onBeforeForward intercept hooks.
@@ -885,6 +901,8 @@ export const ALL_PERMISSIONS = [
   'email:raw-send',
   // Fetch a message blob's raw bytes by blobId (for decrypt/verify).
   'email:blob-read',
+  // Upload a file to server (for encrypt).
+  'email:blob-write',
   // Replace the rendered body of an opened email (render-takeover).
   'email:render-takeover',
   'calendar:read', 'calendar:write',

--- a/package-lock.json
+++ b/package-lock.json
@@ -6223,6 +6223,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7901,6 +7902,16 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {


### PR DESCRIPTION
## Summary
This PR add 3 new hooks onBeforeBlobUpload, onBeforeDraftAutoSave, onBeforeEditDraft and 2 new host.api methods.
This is needed for true e2e encryption. Indeed, now, when we write an email and then send it encrypted with recipients pub key, the server has seen the drafts and attachments used in the email. This PR try to fix that.

## Changes
### Hooks
-  add `onBeforeBlobUpload` file transformer hook. It is called just before the file is uploaded to the server. This transforms the file and not its properties (name, type, etc) registered in email. It will be used to encrypt the attachments.
-  add `onBeforeDraftAutoSave` AlmostSavedDraft transformer hook. It is called just before the draft is saved by client. It will be used to encrypt the content of the draft.
- add `onBeforeEditDraft` Email transformer hook. It is called just before the composer is populated with values from draft we edit. It is useful to decrypt the draft we encrypt earlier.
### Host API
Added
```
upfiles: {
      save: (formerFileId:string, file:File) =>
        callApi('upfiles.save', [formerFileId, file]) as Promise<string>,
      get: (fileId:string) =>
        callApi('upfiles.get', [fileId]) as Promise<File>,
    },
```
This is related to  `onBeforeBlobUpload` hook. Indeed, editing files uploaded is dangerous, so we want a permission for that. This new host API are created to prevent plugins without permission to just register the   `onBeforeBlobUpload` without declaring the good permission. This new api methods allow the plugin to get the raw file and replace it before upload.

Before uploading email-composer save the file in a store of indexedDB and pass the ID to the transformer. The plugins can edit file and save it to the indexedDB. They return the new ID of the File saved in indexedDB. The save method automatically remove precedent version of File in the indexedDB.

### plugin-storage
We added the store `file-plugin` to save the files and expose the fileStorage API used in the API host methods.

## Related Issues

This add hooks to create a PGP plugin to (#481)

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed => I will do a separate PR on plugins repo it this PR is accepted.
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text (N/A)
- [ ] I have included screenshots or a screen recording for UI changes (N/A)

## Screenshots / Demo

## Notes for Reviewers
The two new API methods are privileged tiers.
