### PR TITLE
Fix: label the close-dialog draft button with the generic Save

### DIFF
--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -2754,7 +2754,7 @@ export function EmailComposer({
               </Button>
               <Button onClick={handleSaveDraftAndClose}>
                 <Save className="w-4 h-4 me-2" />
-                {t('save_draft')}
+                {tCommon('save')}
               </Button>
             </div>
           </div>

--- a/locales/cs/common.json
+++ b/locales/cs/common.json
@@ -647,7 +647,6 @@
     "continue_draft": "Pokračovat v úpravě konceptu",
     "close_draft_title": "Uložit nebo zahodit koncept?",
     "close_draft_message": "Máte neuložené změny. Chcete je uložit jako koncept, nebo zahodit?",
-    "save_draft": "Uložit koncept",
     "smime_sign_on": "Podepisování S/MIME zapnuto",
     "smime_sign_off": "Zapnout podepisování S/MIME",
     "smime_encrypt_on": "Šifrování S/MIME zapnuto",

--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -649,7 +649,6 @@
     "continue_draft": "Fortsæt kladde",
     "close_draft_title": "Gem eller kassér kladde?",
     "close_draft_message": "Du har ugemte ændringer. Vil du gemme dette som en kladde eller kassere det?",
-    "save_draft": "Gem kladde",
     "smime_sign_on": "S/MIME-signering aktiveret",
     "smime_sign_off": "Aktivér S/MIME-signering",
     "smime_encrypt_on": "S/MIME-kryptering aktiveret",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -654,7 +654,6 @@
     "continue_draft": "Entwurf fortsetzen",
     "close_draft_title": "Entwurf speichern oder verwerfen?",
     "close_draft_message": "Sie haben ungespeicherte Änderungen. Möchten Sie diese als Entwurf speichern oder verwerfen?",
-    "save_draft": "Entwurf speichern",
     "drop_files": "Dateien zum Anhängen ablegen",
     "show_less": "Weniger anzeigen",
     "forgot_attachment": {

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -650,7 +650,6 @@
     "continue_draft": "Continue draft",
     "close_draft_title": "Save or discard draft?",
     "close_draft_message": "You have unsaved changes. Would you like to save this as a draft or discard it?",
-    "save_draft": "Save Draft",
     "smime_sign_on": "S/MIME signing enabled",
     "smime_sign_off": "Enable S/MIME signing",
     "smime_encrypt_on": "S/MIME encryption enabled",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -654,7 +654,6 @@
     "continue_draft": "Continuar borrador",
     "close_draft_title": "¿Guardar o descartar borrador?",
     "close_draft_message": "Tiene cambios sin guardar. ¿Desea guardar esto como borrador o descartarlo?",
-    "save_draft": "Guardar borrador",
     "drop_files": "Suelta archivos para adjuntar",
     "show_less": "Mostrar menos",
     "forgot_attachment": {

--- a/locales/fa/common.json
+++ b/locales/fa/common.json
@@ -650,7 +650,6 @@
     "continue_draft": "ادامه پیش‌نویس",
     "close_draft_title": "ذخیره یا دور انداختن پیش‌نویس؟",
     "close_draft_message": "تغییرات ذخیره نشده دارید. ذخیره یا دور انداختن؟",
-    "save_draft": "ذخیره پیش‌نویس",
     "smime_sign_on": "امضای S/MIME فعال",
     "smime_sign_off": "فعال کردن امضای S/MIME",
     "smime_encrypt_on": "رمزنگاری S/MIME فعال",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -654,7 +654,6 @@
     "continue_draft": "Continuer le brouillon",
     "close_draft_title": "Enregistrer ou supprimer le brouillon ?",
     "close_draft_message": "Vous avez des modifications non enregistrées. Voulez-vous enregistrer comme brouillon ou supprimer ?",
-    "save_draft": "Enregistrer le brouillon",
     "drop_files": "Déposez les fichiers à joindre",
     "show_less": "Afficher moins",
     "forgot_attachment": {

--- a/locales/he/common.json
+++ b/locales/he/common.json
@@ -599,7 +599,6 @@
     "continue_draft": "המשך טיוטה",
     "close_draft_title": "לשמור או למחוק טיוטה?",
     "close_draft_message": "יש לך שינויים שלא נשמרו. האם תרצה לשמור את זה כטיוטה או למחוק אותו?",
-    "save_draft": "שמור טיוטה",
     "smime_sign_on": "חתימת S/MIME מופעלת",
     "smime_sign_off": "אפשר חתימת S/MIME",
     "smime_encrypt_on": "הצפנת S/MIME מופעלת",

--- a/locales/hu/common.json
+++ b/locales/hu/common.json
@@ -650,7 +650,6 @@
     "continue_draft": "Piszkozat folytatása",
     "close_draft_title": "Piszkozat mentése vagy elvetése?",
     "close_draft_message": "Nem mentett változtatások vannak. Szeretnéd piszkozatként menteni vagy elvetni?",
-    "save_draft": "Piszkozat mentése",
     "smime_sign_on": "S/MIME aláírás engedélyezve",
     "smime_sign_off": "S/MIME aláírás engedélyezése",
     "smime_encrypt_on": "S/MIME titkosítás engedélyezve",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -654,7 +654,6 @@
     "continue_draft": "Continua bozza",
     "close_draft_title": "Salvare o eliminare la bozza?",
     "close_draft_message": "Hai modifiche non salvate. Vuoi salvare come bozza o eliminare?",
-    "save_draft": "Salva bozza",
     "drop_files": "Trascina i file per allegarli",
     "show_less": "Mostra meno",
     "forgot_attachment": {

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -654,7 +654,6 @@
     "continue_draft": "下書きを続ける",
     "close_draft_title": "下書きを保存または破棄しますか？",
     "close_draft_message": "未保存の変更があります。下書きとして保存しますか、それとも破棄しますか？",
-    "save_draft": "下書きを保存",
     "drop_files": "ファイルをドロップして添付",
     "show_less": "折りたたむ",
     "forgot_attachment": {

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -647,7 +647,6 @@
     "continue_draft": "이어서 작성하기",
     "close_draft_title": "임시보관함에 저장할까요?",
     "close_draft_message": "저장되지 않은 내용이 있어요. 임시보관함에 저장할까요, 아니면 삭제할까요?",
-    "save_draft": "임시보관",
     "smime_sign_on": "S/MIME 서명 켜짐",
     "smime_sign_off": "S/MIME 서명 켜기",
     "smime_encrypt_on": "S/MIME 암호화 켜짐",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -647,7 +647,6 @@
     "continue_draft": "Turpināt melnrakstu",
     "close_draft_title": "Saglabāt vai atmest melnrakstu?",
     "close_draft_message": "Ir nesaglabātas izmaiņas. Vai vēlaties saglabāt kā melnrakstu vai atmest?",
-    "save_draft": "Saglabāt melnrakstu",
     "smime_sign_on": "S/MIME paraksts iespējots",
     "smime_sign_off": "Iespējot S/MIME parakstu",
     "smime_encrypt_on": "S/MIME šifrēšana iespējota",

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -654,7 +654,6 @@
     "continue_draft": "Concept voortzetten",
     "close_draft_title": "Concept opslaan of verwijderen?",
     "close_draft_message": "U heeft niet-opgeslagen wijzigingen. Wilt u dit als concept opslaan of verwijderen?",
-    "save_draft": "Concept opslaan",
     "drop_files": "Sleep bestanden om bij te voegen",
     "show_less": "Minder tonen",
     "forgot_attachment": {

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -647,7 +647,6 @@
     "continue_draft": "Kontynuuj szkic",
     "close_draft_title": "Zapisać czy odrzucić szkic?",
     "close_draft_message": "Masz niezapisane zmiany. Czy chcesz zapisać jako szkic czy odrzucić?",
-    "save_draft": "Zapisz szkic",
     "smime_sign_on": "Podpisywanie S/MIME włączone",
     "smime_sign_off": "Włącz podpisywanie S/MIME",
     "smime_encrypt_on": "Szyfrowanie S/MIME włączone",

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -654,7 +654,6 @@
     "continue_draft": "Continuar rascunho",
     "close_draft_title": "Salvar ou descartar rascunho?",
     "close_draft_message": "Você tem alterações não salvas. Deseja salvar como rascunho ou descartar?",
-    "save_draft": "Salvar rascunho",
     "drop_files": "Solte arquivos para anexar",
     "show_less": "Mostrar menos",
     "forgot_attachment": {

--- a/locales/ro/common.json
+++ b/locales/ro/common.json
@@ -650,7 +650,6 @@
     "continue_draft": "Continuă schița",
     "close_draft_title": "Să salvați sau să renunțați la schiță?",
     "close_draft_message": "Aveți modificări nesalvate. Doriți să salvați acest mesaj ca schiță sau să îl ignorați?",
-    "save_draft": "Salvează schița",
     "smime_sign_on": "S/MIME semnarea activată",
     "smime_sign_off": "Activați semnarea cu „S/MIME”",
     "smime_encrypt_on": "S/MIME criptare activată",

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -647,7 +647,6 @@
     "continue_draft": "Продолжить черновик",
     "close_draft_title": "Сохранить или удалить черновик?",
     "close_draft_message": "Есть несохранённые изменения. Сохранить как черновик или удалить?",
-    "save_draft": "Сохранить черновик",
     "smime_sign_on": "Подпись S/MIME включена",
     "smime_sign_off": "Включить подпись S/MIME",
     "smime_encrypt_on": "Шифрование S/MIME включено",

--- a/locales/sk/common.json
+++ b/locales/sk/common.json
@@ -650,7 +650,6 @@
     "continue_draft": "Pokračovať v koncepte",
     "close_draft_title": "Uložiť alebo zahoditť koncept?",
     "close_draft_message": "Máte neuložené zmeny. Chcete ich uložiť ako koncept alebo zahoditť?",
-    "save_draft": "Uložiť koncept",
     "smime_sign_on": "Podpisovanie S/MIME zapnuté",
     "smime_sign_off": "Zapnúť podpisovanie S/MIME",
     "smime_encrypt_on": "Šifrovanie S/MIME zapnuté",

--- a/locales/tr/common.json
+++ b/locales/tr/common.json
@@ -650,7 +650,6 @@
     "continue_draft": "Taslağa devam et",
     "close_draft_title": "Taslak kaydedilsin mi yoksa silinsin mi?",
     "close_draft_message": "Kaydedilmemiş değişiklikleriniz var. Bunu taslak olarak kaydetmek ister misiniz yoksa vazgeçmek mi?",
-    "save_draft": "Taslağı Kaydet",
     "smime_sign_on": "S/MIME imzalama etkin",
     "smime_sign_off": "S/MIME imzalamayı etkinleştir",
     "smime_encrypt_on": "S/MIME şifreleme etkin",

--- a/locales/uk/common.json
+++ b/locales/uk/common.json
@@ -647,7 +647,6 @@
     "continue_draft": "Продовжити чернетку",
     "close_draft_title": "Зберегти чи видалити чернетку?",
     "close_draft_message": "У вас є незбережені зміни. Зберегти це як чернетку чи видалити?",
-    "save_draft": "Зберегти чернетку",
     "smime_sign_on": "Підпис S/MIME увімкнено",
     "smime_sign_off": "Увімкнути підпис S/MIME",
     "smime_encrypt_on": "Шифрування S/MIME увімкнено",

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -647,7 +647,6 @@
     "continue_draft": "继续编辑草稿",
     "close_draft_title": "保存或丢弃草稿？",
     "close_draft_message": "您有未保存的更改。要将其保存为草稿还是丢弃？",
-    "save_draft": "保存草稿",
     "smime_sign_on": "S/MIME 签名已启用",
     "smime_sign_off": "启用 S/MIME 签名",
     "smime_encrypt_on": "S/MIME 加密已启用",


### PR DESCRIPTION
## Summary

The third button of the "Save or discard draft?" dialog wraps onto two lines in several languages, making the button row look broken next to its one-line siblings. Shortening the label fixes this at the root, in every locale at once.

## Why

- "Save Draft" is a verb-plus-object label, and in many languages that compound is simply long: German "Entwurf speichern", French "Enregistrer le brouillon", Portuguese "Salvar rascunho", Russian "Сохранить черновик". Any of these can exceed the button width the dialog allows, so the wrapping is not a single-locale glitch but structural.
- The context the object provides is redundant here: the dialog title ("Save or discard draft?") and its message already state that a draft is what would be saved. Within that dialog, a bare "Save" is unambiguous - the same pattern the neighbouring buttons already use ("Cancel", "Discard", not "Discard draft").
- `common.save` already exists, translated in all 22 locales, and the composer already has the `common` translator in scope - so the fix is one changed line of code and zero new translations.
- Deliberately *not* fixed with `whitespace-nowrap`: on narrow phones that would turn the wrap into horizontal overflow. A short label degrades gracefully everywhere.

## Changes

- The dialog's save button uses `common.save` instead of `email_composer.save_draft`.
- `email_composer.save_draft` had exactly this one consumer, so the now-dead key is removed from all 22 locales (verified programmatically: only this key removed, every other value byte-identical).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Checklist

- [x] `tsc --noEmit` passes (0 errors)
- [x] `eslint` passes on the changed file
- [x] Translation parity test passes (44/44)
- [x] `next build` succeeds (exit 0)

## Notes for Reviewers

- Resulting button rows, for a feel of the symmetry: en "Cancel / Discard / Save", de "Abbrechen / Verwerfen / Speichern", fr "Annuler / Supprimer / Enregistrer".