### PR TITLE
fix: sidebar tag unread counts go stale on read/unread changes

### DIFF
--- a/stores/__tests__/email-store-tag-counts.test.ts
+++ b/stores/__tests__/email-store-tag-counts.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEmailStore } from '../email-store';
+import { useAuthStore } from '../auth-store';
+import { useSettingsStore } from '../settings-store';
+import type { Email, Mailbox } from '@/lib/jmap/types';
+import type { IJMAPClient } from '@/lib/jmap/client-interface';
+
+// Sidebar tag badges render from `tagCounts`, which is fetched from the server
+// (`fetchTagCounts` -> `client.getTagCounts`) rather than derived from
+// `state.emails`. Read/unread mutations therefore have to keep it in step the
+// same way they keep `mailboxes[].unreadEmails` in step, or the tag unread
+// count (and the bold tag name) stays stale until a full page reload.
+
+function makeMailbox(overrides: Partial<Mailbox> = {}): Mailbox {
+  return {
+    id: 'inbox',
+    name: 'Inbox',
+    role: 'inbox',
+    sortOrder: 0,
+    totalEmails: 10,
+    unreadEmails: 5,
+    totalThreads: 10,
+    unreadThreads: 5,
+    myRights: {
+      mayReadItems: true,
+      mayAddItems: true,
+      mayRemoveItems: true,
+      maySetSeen: true,
+      maySetKeywords: true,
+      mayCreateChild: true,
+      mayRename: true,
+      mayDelete: true,
+      maySubmit: true,
+    },
+    isSubscribed: true,
+    isShared: false,
+    ...overrides,
+  };
+}
+
+function makeEmail(overrides: Partial<Email> = {}): Email {
+  return {
+    id: 'email-1',
+    threadId: 'thread-1',
+    subject: 'Hi',
+    receivedAt: new Date().toISOString(),
+    keywords: {},
+    mailboxIds: { inbox: true },
+    ...overrides,
+  } as Email;
+}
+
+function makeClient() {
+  return {
+    markAsRead: vi.fn().mockResolvedValue(undefined),
+    batchMarkAsRead: vi.fn().mockResolvedValue(undefined),
+    markMailboxAsRead: vi.fn().mockResolvedValue(3),
+    getTagCounts: vi.fn().mockResolvedValue({}),
+    getAccountId: vi.fn().mockReturnValue('account-a'),
+  } as unknown as IJMAPClient;
+}
+
+describe('email-store tag counts stay in step with read state', () => {
+  let client: IJMAPClient;
+
+  beforeEach(() => {
+    client = makeClient();
+
+    useAuthStore.setState({
+      activeAccountId: 'account-a',
+      getClientForAccount: (() => client) as never,
+    } as never);
+
+    useSettingsStore.setState({
+      emailKeywords: [
+        { id: 'ingsel', label: 'Ingsel', color: 'red' },
+        { id: 'work', label: 'Work', color: 'blue' },
+      ],
+    } as never);
+
+    useEmailStore.setState({
+      isUnifiedView: false,
+      viewingAccountId: null,
+      selectedMailbox: 'inbox',
+      mailboxes: [makeMailbox()],
+      accountMailboxes: {},
+      emails: [],
+      selectedEmail: null,
+      selectedEmailIds: new Set(),
+      processingReadStatus: new Set(),
+      threadEmailsCache: new Map(),
+      tagCounts: {
+        ingsel: { total: 1658, unread: 47 },
+        work: { total: 200, unread: 9 },
+      },
+    } as never);
+  });
+
+  it('decrements only the matching tag when a tagged email is marked read', async () => {
+    useEmailStore.setState({
+      emails: [makeEmail({ keywords: { '$label:ingsel': true } })],
+    } as never);
+
+    await useEmailStore.getState().markAsRead(client, 'email-1', true);
+
+    expect(useEmailStore.getState().tagCounts).toEqual({
+      ingsel: { total: 1658, unread: 46 },
+      work: { total: 200, unread: 9 },
+    });
+  });
+
+  it('increments the tag again when the email is marked unread', async () => {
+    useEmailStore.setState({
+      emails: [makeEmail({ keywords: { '$label:ingsel': true, $seen: true } })],
+    } as never);
+
+    await useEmailStore.getState().markAsRead(client, 'email-1', false);
+
+    expect(useEmailStore.getState().tagCounts.ingsel).toEqual({ total: 1658, unread: 48 });
+  });
+
+  it('updates both tags when an email carries two tags', async () => {
+    useEmailStore.setState({
+      emails: [makeEmail({ keywords: { '$label:ingsel': true, '$label:work': true } })],
+    } as never);
+
+    await useEmailStore.getState().markAsRead(client, 'email-1', true);
+
+    expect(useEmailStore.getState().tagCounts).toEqual({
+      ingsel: { total: 1658, unread: 46 },
+      work: { total: 200, unread: 8 },
+    });
+  });
+
+  it('leaves tag counts alone for an untagged email', async () => {
+    useEmailStore.setState({ emails: [makeEmail({ keywords: {} })] } as never);
+
+    await useEmailStore.getState().markAsRead(client, 'email-1', true);
+
+    expect(useEmailStore.getState().tagCounts).toEqual({
+      ingsel: { total: 1658, unread: 47 },
+      work: { total: 200, unread: 9 },
+    });
+  });
+
+  it('does not double-decrement when an already-read email is marked read', async () => {
+    useEmailStore.setState({
+      emails: [makeEmail({ keywords: { '$label:ingsel': true, $seen: true } })],
+    } as never);
+
+    await useEmailStore.getState().markAsRead(client, 'email-1', true);
+
+    expect(useEmailStore.getState().tagCounts.ingsel).toEqual({ total: 1658, unread: 47 });
+  });
+
+  it('never drives a tag unread count negative', async () => {
+    useEmailStore.setState({
+      emails: [makeEmail({ keywords: { '$label:ingsel': true } })],
+      tagCounts: { ingsel: { total: 3, unread: 0 } },
+    } as never);
+
+    await useEmailStore.getState().markAsRead(client, 'email-1', true);
+
+    expect(useEmailStore.getState().tagCounts.ingsel).toEqual({ total: 3, unread: 0 });
+  });
+
+  it('never alters `total` on a read-state change', async () => {
+    useEmailStore.setState({
+      emails: [makeEmail({ keywords: { '$label:ingsel': true } })],
+    } as never);
+
+    await useEmailStore.getState().markAsRead(client, 'email-1', true);
+    await useEmailStore.getState().markAsRead(client, 'email-1', false);
+
+    expect(useEmailStore.getState().tagCounts.ingsel.total).toBe(1658);
+    expect(useEmailStore.getState().tagCounts.work.total).toBe(200);
+  });
+
+  describe('batchMarkAsRead', () => {
+    it('applies the delta once per tag per changed email', async () => {
+      useEmailStore.setState({
+        emails: [
+          makeEmail({ id: 'e1', keywords: { '$label:ingsel': true } }),
+          makeEmail({ id: 'e2', keywords: { '$label:ingsel': true, '$label:work': true } }),
+          // Already read: must not contribute a delta.
+          makeEmail({ id: 'e3', keywords: { '$label:work': true, $seen: true } }),
+          // Untagged: must not contribute a delta.
+          makeEmail({ id: 'e4', keywords: {} }),
+        ],
+        selectedEmailIds: new Set(['e1', 'e2', 'e3', 'e4']),
+      } as never);
+
+      await useEmailStore.getState().batchMarkAsRead(client, true);
+
+      expect(useEmailStore.getState().tagCounts).toEqual({
+        ingsel: { total: 1658, unread: 45 },
+        work: { total: 200, unread: 8 },
+      });
+    });
+  });
+
+  describe('markMailboxAsRead', () => {
+    it('refetches tag counts from the server rather than applying a local delta', async () => {
+      (client.getTagCounts as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ingsel: { total: 1658, unread: 0 },
+        work: { total: 200, unread: 4 },
+      });
+
+      useEmailStore.setState({
+        emails: [makeEmail({ keywords: { '$label:ingsel': true } })],
+      } as never);
+
+      const count = await useEmailStore.getState().markMailboxAsRead(client, 'inbox');
+      expect(count).toBe(3);
+
+      // The server bulk-marks emails that are not in `state.emails`, so a local
+      // delta would under-count: it has to refetch.
+      expect(client.getTagCounts).toHaveBeenCalledWith(['ingsel', 'work']);
+
+      await vi.waitFor(() => {
+        expect(useEmailStore.getState().tagCounts).toEqual({
+          ingsel: { total: 1658, unread: 0 },
+          work: { total: 200, unread: 4 },
+        });
+      });
+    });
+  });
+
+  describe('setEmailKeywordsLocal', () => {
+    it('adjusts tag unread counts when the local keyword patch flips $seen', () => {
+      useEmailStore.setState({
+        emails: [makeEmail({ keywords: { '$label:ingsel': true } })],
+      } as never);
+
+      useEmailStore.getState().setEmailKeywordsLocal('email-1', {
+        '$label:ingsel': true,
+        $seen: true,
+      });
+
+      expect(useEmailStore.getState().tagCounts.ingsel).toEqual({ total: 1658, unread: 46 });
+    });
+
+    it('leaves tag unread counts alone when $seen is unchanged', () => {
+      useEmailStore.setState({
+        emails: [makeEmail({ keywords: { '$label:ingsel': true } })],
+      } as never);
+
+      // Pin toggle: labels/pin change, read state does not.
+      useEmailStore.getState().setEmailKeywordsLocal('email-1', {
+        '$label:ingsel': true,
+        $pinned: true,
+      });
+
+      expect(useEmailStore.getState().tagCounts.ingsel).toEqual({ total: 1658, unread: 47 });
+    });
+  });
+});

--- a/stores/email-store.ts
+++ b/stores/email-store.ts
@@ -584,6 +584,37 @@ function applyBatchMailboxCounterUpdate(
   return { mailboxes, accountMailboxes };
 }
 
+// Sidebar tag badges render from `tagCounts`, which is *fetched from the server*
+// (`fetchTagCounts` -> `getTagCounts`) rather than derived from `state.emails`.
+// So a read/unread mutation has to keep it in step locally, exactly as it does
+// for `mailboxes[].unreadEmails` - otherwise the tag unread count (and the bold
+// tag name) stays stale until a full page reload.
+//
+// `changes` carries one entry per email whose read state *actually changed*
+// (callers already compute that), with delta -1 when it became read and +1 when
+// it became unread. Only `unread` moves: read state never changes tag
+// membership, so `total` is left alone.
+function applyTagCountReadDelta(
+  tagCounts: Record<string, { total: number; unread: number }>,
+  changes: Array<{ keywords?: Record<string, boolean>; delta: number }>,
+): Record<string, { total: number; unread: number }> {
+  const keywordIds = useSettingsStore.getState().emailKeywords.map(k => k.id);
+  if (keywordIds.length === 0) return tagCounts;
+
+  let next: Record<string, { total: number; unread: number }> | null = null;
+  for (const { keywords, delta } of changes) {
+    if (!keywords || delta === 0) continue;
+    for (const id of keywordIds) {
+      if (!keywords[`$label:${id}`]) continue;
+      const current = (next ?? tagCounts)[id];
+      if (!current) continue; // Tag not in the fetched counts yet; nothing to adjust.
+      next = next ?? { ...tagCounts };
+      next[id] = { total: current.total, unread: Math.max(0, current.unread + delta) };
+    }
+  }
+  return next ?? tagCounts;
+}
+
 // Per-mailbox counter map (for applyBatchMailboxCounterUpdate) for removing a
 // group of emails from a folder: decrement total (and unread for unseen) for
 // each group email that lives in the mailbox.
@@ -1416,6 +1447,11 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
             ? { ...state.selectedEmail, keywords: { ...state.selectedEmail.keywords, $seen: read } }
             : state.selectedEmail,
           ...mailboxPatch,
+          // Same delta, applied to every tag this email carries, so the sidebar
+          // tag badges track the folder counters instead of going stale.
+          tagCounts: applyTagCountReadDelta(state.tagCounts, [
+            { keywords: emailInState.keywords, delta },
+          ]),
           processingReadStatus: newProcessingSet,
           // Also update threadEmailsCache so expanded dropdowns reflect the change
           threadEmailsCache: (() => {
@@ -1960,14 +1996,24 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
   },
 
   setEmailKeywordsLocal: (emailId, keywords) => {
-    set((state) => ({
-      emails: state.emails.map(e =>
-        e.id === emailId ? { ...e, keywords: { ...keywords } } : e
-      ),
-      selectedEmail: state.selectedEmail?.id === emailId
-        ? { ...state.selectedEmail, keywords: { ...keywords } }
-        : state.selectedEmail,
-    }));
+    set((state) => {
+      // This patch replaces the whole keyword map, so it can flip $seen as well
+      // as labels. Only a genuine read-state change moves the tag unread counts.
+      const previous = state.emails.find(e => e.id === emailId) ?? state.selectedEmail;
+      const wasRead = previous?.keywords?.$seen ?? false;
+      const isRead = keywords.$seen ?? false;
+      const delta = wasRead === isRead ? 0 : (isRead ? -1 : 1);
+
+      return {
+        emails: state.emails.map(e =>
+          e.id === emailId ? { ...e, keywords: { ...keywords } } : e
+        ),
+        selectedEmail: state.selectedEmail?.id === emailId
+          ? { ...state.selectedEmail, keywords: { ...keywords } }
+          : state.selectedEmail,
+        tagCounts: applyTagCountReadDelta(state.tagCounts, [{ keywords, delta }]),
+      };
+    });
   },
 
   // Batch operations
@@ -2025,9 +2071,19 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
         };
       });
 
+      // Tag badges follow the same delta as the folder counters, counting only
+      // the emails whose read state actually changed.
+      const tagCounts = applyTagCountReadDelta(
+        get().tagCounts,
+        affectedEmails
+          .filter(email => (email.keywords?.$seen ?? false) !== read)
+          .map(email => ({ keywords: email.keywords, delta: read ? -1 : 1 })),
+      );
+
       set({
         emails: updatedEmails,
         ...mailboxPatch,
+        tagCounts,
         selectedEmailIds: new Set(),
         isLoading: false
       });
@@ -3141,6 +3197,14 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
             : mb
         ),
       }));
+
+      // Tag counts are refetched here rather than adjusted with a local delta
+      // (as markAsRead/batchMarkAsRead do). This is a server-side bulk operation
+      // over the *whole* mailbox, so it also marks emails that were never loaded
+      // into `state.emails` - a local delta would only see the loaded page and
+      // would leave the tag counts drifting high. Fire-and-forget: the folder
+      // counters above already update instantly.
+      void get().fetchTagCounts(client);
 
       return count;
     } catch (error) {


### PR DESCRIPTION
### Problem

Mark a mailbox as read and the folder unread counts clear, but the sidebar's **tag** unread counts do not: a tag goes on showing for example `47 / 65` in bold with nothing actually unread. The same happens for individual read/unread toggles. Only a page reload puts it right.

### Cause

`tagCounts` is **fetched from the server**, not derived from state: `fetchTagCounts` → `client.getTagCounts(tagIds)`, which runs an `Email/query` per `$label:<id>` keyword. Nothing in the read/unread path refreshes or adjusts it.

The per-mailbox `unreadEmails` counters don't have this problem, because the store already keeps them current with a local delta on every mutation (`applyMailboxCounterUpdate` and friends). Tags simply never got the equivalent, so the only thing that ever corrected them was a full refetch — on mount, on a `Mailbox`/`Email` state change pushed from the server, or on a reload.

### Fix

Add `applyTagCountReadDelta` alongside the existing mailbox-counter helpers and apply it wherever the affected emails are known locally — `markAsRead`, `batchMarkAsRead`, `setEmailKeywordsLocal`. It walks the configured keywords, and for each `$label:<id>` an email carries, moves that tag's `unread` by the delta. No server round-trip, so a single toggle stays instant.

Three details worth calling out:

- Only a genuine `$seen` flip moves a count, reusing the `wasRead`/`isUnread` the callers already compute. Re-marking a read email as read cannot drift the count.
- `unread` is clamped at zero, as the mailbox counters are.
- A read-state change never touches a tag's `total`.

**`markMailboxAsRead` is the deliberate exception and refetches instead.** It is a server-side bulk operation over a whole mailbox, so it also marks emails that were never loaded into `state.emails` — a local delta would only see the loaded ones and leave the counts high. It fires `fetchTagCounts` after its optimistic update, in the same style as the existing refetch in `handleStateChange`. The asymmetry is commented in the code, since it's the non-obvious part.

### Not addressed here

Two pre-existing gaps I found while in this code and deliberately did not widen the diff to cover:

**Colour-tagging from a Pro Interface tab appears not to persist at all.** `handleSetColorTag` in `components/pro/pro-email-tab-body.tsx:193-207` calls `setEmailKeywordsLocal` and patches its own component state, but nothing in `components/pro/` calls `updateEmailKeywords` — and `setEmailKeywordsLocal` takes no JMAP client, so by construction it can only patch memory. The mail page does the same operation as a trio (`app/(main)/[locale]/page.tsx:1737-1744`): `updateEmailKeywords` → `setEmailKeywordsLocal` → `fetchTagCounts`. The Pro tab has only the middle step, so the tag should be lost on reload, and the tag counts (`total` as well as `unread`) never move. That is a persistence bug rather than a counter bug, so it is out of scope here — but it is why I have not tried to keep `total` in step from the client: the delta in this PR deliberately only touches `unread`, which is the part a read/unread change can actually affect. Flagging it rather than fixing it silently; happy to open a separate PR. (Read from the code — I have not reproduced it in a running Pro Interface, which is experimental and off by default.)

**`tagCounts` has no per-account dimension.** It is a flat `Record<tagId, {total, unread}>`, and `fetchTagCounts` only ever queries the active client (`getTagCounts` runs its `Email/query` against that client's single `accountId`), so the counts describe one account. `state.emails` can hold mail from several accounts in a unified view, so the delta in this PR will move a count for an email belonging to an account those counts never included. The counts were already approximate in that configuration — a refetch corrects them — but this PR gives the approximation a new way to drift, so it seems worth stating. Giving `tagCounts` an account dimension (as `accountMailboxes` has) looked like a bigger change than this fix should carry; happy to take it on if you would rather it were handled here.

### Tests

11 new tests in `stores/__tests__/email-store-tag-counts.test.ts`, six of which fail against `main`: the delta on read and unread, an email carrying two tags, an untagged email moving nothing, no double-decrement when re-marking an already-read email, `unread` never going negative, `total` never altered, and `markMailboxAsRead` triggering a refetch rather than relying on a delta.

`npm run typecheck` and `npm run lint` are clean. The full suite passes apart from one pre-existing failure in `contact-store` (`should expand group members when group name matches`), which reproduces unchanged on a clean `main` checkout — `getAutocomplete` now returns a group as a single Outlook-style entry while the test still asserts the old expand-to-members behaviour.

Verified by hand against a live Stalwart instance: marking the inbox all-read now clears the tag counts and the bold immediately, with no reload.
