### PR TITLE
fix: enable thread expansion in focused list

### DIFF
--- a/components/email/thread-list-item.tsx
+++ b/components/email/thread-list-item.tsx
@@ -660,7 +660,7 @@ export const ThreadListItem = React.forwardRef<HTMLDivElement, ThreadListItemPro
                   onToggle={toggleThreadSelection}
                   selectLabel={tBatch('select')}
                 />
-                {!isMobile && !isFocusedMailLayout && (
+                {!isMobile && (
                   <button
                     data-expand-toggle
                     onClick={(e) => {
@@ -892,7 +892,7 @@ export const ThreadListItem = React.forwardRef<HTMLDivElement, ThreadListItemPro
           )}
         </div>
 
-        {isExpanded && !isMobile && !isFocusedMailLayout && (
+        {isExpanded && !isMobile && (
           <div className="bg-muted/20 animate-in slide-in-from-top-2 duration-200">
             {isLoading ? (
               <div className="py-4 flex items-center justify-center text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- adds the desktop thread expand control in the focused list layout
- render expanded thread messages below focused-list rows
- preserve the existing mobile conversation behavior

Fixes #617

## Validation
- `npm run typecheck`
- `npx eslint components/email/thread-list-item.tsx`