### PR TITLE
Feat/integration test setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,8 @@ scripts/
 TODO.md
 *.md
 !README.md
+# Sibling projects / test harness - not part of the webmail image
+examples/
+integration/
+e2e/
+**/node_modules

--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -2143,6 +2143,7 @@ export function EmailComposer({
                 </div>
               ) : identities.length > 1 ? (
                 <select
+                  data-testid="composer-from"
                   value={selectedIdentityId || primaryIdentity?.id || ''}
                   onChange={(e) => setSelectedIdentityId(e.target.value)}
                   className="flex-1 bg-transparent text-sm text-foreground outline-none cursor-pointer hover:text-muted-foreground transition-colors min-w-0 truncate"
@@ -2174,7 +2175,7 @@ export function EmailComposer({
                       })}
                 </select>
               ) : (
-                <span className="text-sm text-foreground flex-1 truncate">
+                <span data-testid="composer-from" className="text-sm text-foreground flex-1 truncate">
                   {subAddressTag ? (
                     <span className="font-mono">
                       {generateSubAddress(primaryIdentity?.email || '', subAddressTag, subAddressDelimiter)}

--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -2050,7 +2050,7 @@ export function EmailComposer({
   };
 
   return (
-    <div ref={composerRootRef} className={cn("flex h-full bg-background", className)}>
+    <div ref={composerRootRef} data-testid="email-composer" className={cn("flex h-full bg-background", className)}>
       <PluginSlot
         name="composer-sidebar"
         className="hidden md:flex shrink-0 h-full overflow-hidden border-e border-border"
@@ -2108,6 +2108,7 @@ export function EmailComposer({
           disabled={!canSend || isSending}
           title={getSendTooltip()}
           size="sm"
+          data-testid="composer-send"
           className="md:hidden h-9 px-4"
         >
           <Send className="w-4 h-4 me-1.5" />
@@ -2236,7 +2237,7 @@ export function EmailComposer({
           </div>
 
           {/* To field */}
-          <div className={cn("flex items-center gap-2 px-4 py-2.5 border-b border-border/50 relative", shakeField === 'to' && "animate-shake")}>
+          <div data-testid="composer-to" className={cn("flex items-center gap-2 px-4 py-2.5 border-b border-border/50 relative", shakeField === 'to' && "animate-shake")}>
             <span className="text-sm text-muted-foreground w-12 md:w-16 shrink-0">{t('to')}:</span>
             <RecipientChipInput
               chips={to}
@@ -2381,6 +2382,7 @@ export function EmailComposer({
             <span className="text-sm text-muted-foreground w-12 md:w-16 shrink-0">{t('subject_label')}</span>
             <Input
               ref={subjectInputRef}
+              data-testid="composer-subject"
               type="text"
               placeholder={t('subject_placeholder')}
               value={subject}
@@ -2603,6 +2605,7 @@ export function EmailComposer({
                   onClick={() => handleSend()}
                   disabled={!canSend || isSending}
                   title={getSendTooltip()}
+                  data-testid="composer-send"
                   className="rounded-e-none border-e border-primary-foreground/20"
                 >
                   <Send className="w-4 h-4 me-2" />
@@ -2641,6 +2644,7 @@ export function EmailComposer({
                 onClick={() => handleSend()}
                 disabled={!canSend || isSending}
                 title={getSendTooltip()}
+                data-testid="composer-send"
                 className="hidden md:inline-flex"
               >
                 <Send className="w-4 h-4 me-2" />

--- a/components/email/thread-list-item.tsx
+++ b/components/email/thread-list-item.tsx
@@ -166,6 +166,10 @@ const SingleEmailItem = React.forwardRef<HTMLDivElement, SingleEmailItemProps>(
         ref={ref}
         {...dragHandlers}
         {...longPressHandlers}
+        data-testid="email-list-item"
+        data-email-id={email.id}
+        data-subject={email.subject || ''}
+        data-unread={isUnread ? 'true' : 'false'}
         className={cn(
           "relative group cursor-pointer select-none transition-shadow duration-200 border-b border-border overflow-hidden",
           resolvedColorTag ? resolvedColorTag : (

--- a/components/layout/account-switcher.tsx
+++ b/components/layout/account-switcher.tsx
@@ -151,6 +151,8 @@ export function AccountSwitcher({ variant = "rail", className }: AccountSwitcher
       <button
         ref={buttonRef}
         onClick={() => setOpen(!open)}
+        data-testid="account-switcher"
+        data-active-account-id={activeAccountId ?? undefined}
         className={cn(
           "flex items-center gap-2 rounded-md transition-colors",
           variant === "rail"
@@ -213,6 +215,9 @@ export function AccountSwitcher({ variant = "rail", className }: AccountSwitcher
                 >
                 <button
                   onClick={() => handleSwitch(account.id)}
+                  data-testid="account-option"
+                  data-account-id={account.id}
+                  data-account-email={account.email || account.username}
                   className={cn(
                     "w-full flex items-start gap-3 px-3 py-2.5 text-start transition-colors",
                     isActive ? "bg-accent/50" : "hover:bg-muted",
@@ -274,6 +279,7 @@ export function AccountSwitcher({ variant = "rail", className }: AccountSwitcher
             <div className="border-t border-border">
               <button
                 onClick={handleAddAccount}
+                data-testid="add-account"
                 className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
                 role="menuitem"
               >

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -220,8 +220,13 @@ function SidebarRowCounts({
   ) : null;
 
   return (
-    <span className="ms-2 flex-shrink-0 flex items-baseline gap-1" title={totalCount > 0 ? `${unreadCount} unread / ${totalCount} total` : `${unreadCount} unread`}>
-
+    <span
+      className="ms-2 flex-shrink-0 flex items-baseline gap-1"
+      title={totalCount > 0 ? `${unreadCount} unread / ${totalCount} total` : `${unreadCount} unread`}
+      data-testid="folder-counts"
+      data-unread={unreadCount}
+      data-total={totalCount}
+    >
       {unreadNode}
       {unreadCount > 0 && totalCount > 0 && (
         <span className="text-xs text-muted-foreground/60">/</span>
@@ -249,6 +254,10 @@ interface SidebarRowProps {
   isValidDropTarget?: boolean;
   isInvalidDropTarget?: boolean;
   onContextMenu?: (e: React.MouseEvent) => void;
+  /** Stable identifiers for integration tests (not user-visible). */
+  testRole?: string | null;
+  testName?: string;
+  testMailboxId?: string;
 }
 
 function SidebarRow({
@@ -269,6 +278,9 @@ function SidebarRow({
   isValidDropTarget,
   isInvalidDropTarget,
   onContextMenu,
+  testRole,
+  testName,
+  testMailboxId,
 }: SidebarRowProps) {
   const t = useTranslations('sidebar');
   const leftPad = isCollapsed ? 0 : ROW_PX_BASE + depth * INDENT_STEP;
@@ -277,6 +289,10 @@ function SidebarRow({
     <div
       {...(dropHandlers || {})}
       onContextMenu={onContextMenu}
+      data-testid="folder-row"
+      data-folder-role={testRole ?? undefined}
+      data-folder-name={testName ?? undefined}
+      data-mailbox-id={testMailboxId ?? undefined}
       style={{ paddingBlock: 'var(--density-sidebar-py)' }}
       className={cn(
         "group w-full flex items-center max-lg:min-h-[44px] text-sm transition-colors duration-150",
@@ -477,6 +493,9 @@ function MailboxTreeItem({
       <SidebarRow
         icon={<Icon className={getIconClass(isSelected, isVirtualNode, colorful, roleKey)} />}
         label={label}
+        testRole={node.role}
+        testName={node.name}
+        testMailboxId={node.id}
         depth={node.depth}
         isSelected={isSelected}
         isVirtual={isVirtualNode}
@@ -1047,6 +1066,9 @@ export function Sidebar({
                       key={unifiedId}
                       icon={<Icon className={getIconClass(isSelected, false, colorfulSidebarIcons, count.role)} />}
                       label={t(`unified_${count.role}`)}
+                      testRole={count.role}
+                      testName={`unified-${count.role}`}
+                      testMailboxId={unifiedId}
                       depth={0}
                       isSelected={isSelected}
                       unread={count.unreadEmails}
@@ -1068,6 +1090,8 @@ export function Sidebar({
                       key={id}
                       icon={<Icon className={getIconClass(isSelected, false, colorfulSidebarIcons)} />}
                       label={label}
+                      testName={id}
+                      testMailboxId={id}
                       depth={0}
                       isSelected={isSelected}
                       unread={unread}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -79,6 +79,8 @@ export default [
       "e2e/**",
       "local-data/**/*.mjs",
       "benchmark/**",
+      "examples/**",
+      "integration/**",
     ],
   },
 ];

--- a/integration/.env.example
+++ b/integration/.env.example
@@ -1,0 +1,11 @@
+# Credentials for the integration-test Stalwart mail server.
+# Copy to `.env` (docker compose reads it automatically): cp .env.example .env
+
+# Recovery admin (format user:password). Stays valid after bootstrap so the
+# Stalwart admin UI on http://localhost:8025 remains reachable and stalwart-cli
+# can be invoked via `docker exec`.
+STALWART_RECOVERY_ADMIN=admin:bootstrap-secret
+
+# Shared password for every test mailbox (alice/bob/carol @ example.org).
+# The Playwright harness reads the same value from IT_ACCOUNT_PASSWORD.
+TEST_ACCOUNT_PASSWORD=test-pass-123

--- a/integration/.gitignore
+++ b/integration/.gitignore
@@ -1,0 +1,10 @@
+# Local docker env (copied from .env.example)
+.env
+
+# Arch-specific stalwart-cli binary, fetched by stalwart/prepare-stalwart-cli.sh
+stalwart/stalwart-cli
+
+# Playwright/test artifacts
+node_modules/
+test-results/
+playwright-report/

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,0 +1,123 @@
+# Integration tests — webmail ⇆ Stalwart
+
+End-to-end tests that run the **Bulwark webmail against a real Stalwart mail
+server** in Docker and drive it with Playwright. The focus is the mail/folder
+**synchronisation** behaviour that multi-account webmail clients get wrong:
+unread/total counters, folder-list sync, and the account-scoped Unified Mailbox.
+
+Everything here is self-contained and separate from the app's root
+`playwright.config.ts` (which only smoke-tests the UI against `npm run dev`).
+
+## What's in the stack
+
+| Service   | Image                                   | Ports (host)                       | Purpose                                                   |
+| --------- | --------------------------------------- | ---------------------------------- | -------------------------------------------------------- |
+| `stalwart`| built from [`stalwart/`](stalwart/)     | `8025` JMAP+admin, `1025` SMTP, `1143` IMAP | Real MTA, declaratively bootstrapped with test mailboxes |
+| `webmail` | built from [`webmail.Dockerfile`](webmail.Dockerfile) | `3000`                | The app under test (Next.js, **dev mode** — see below)   |
+
+Provisioned mailboxes (domain `example.org`, shared password `test-pass-123`):
+`alice`, `bob`, `carol`. Admin: `admin` / `bootstrap-secret`.
+
+### Two things worth knowing
+
+- **The webmail runs in Next.js dev mode.** The browser talks JMAP *directly*
+  to Stalwart at `http://localhost:8025` (cross-origin, plain HTTP). The app's
+  production CSP pins `connect-src` to `'self' https:` and would block that;
+  dev mode widens it to allow `http:`. Dev mode also ships the test hooks from
+  source without a production rebuild. See the header of `webmail.Dockerfile`.
+- **CORS.** Stalwart doesn't emit CORS headers by default. The bootstrap enables
+  `usePermissiveCors` (see `stalwart/plan-accounts.ndjson.tpl`) so the browser
+  origin (`:3000`) may call the JMAP origin (`:8025`).
+
+## Running
+
+```bash
+# One-shot: brings the stack up and runs the whole suite in the Playwright
+# container (browsers preinstalled, host networking to reach the stack).
+integration/run-tests.sh
+
+# A single spec:
+integration/run-tests.sh 01-login
+```
+
+`run-tests.sh` is the recommended entry point because Playwright's browser
+bundles can't always be downloaded/installed on the host; the official
+`mcr.microsoft.com/playwright` image sidesteps that.
+
+### Running against a host browser instead
+
+If you *can* install Playwright browsers on your machine:
+
+```bash
+cd integration && cp .env.example .env
+bash stalwart/prepare-stalwart-cli.sh
+docker compose up -d --build --wait
+npx playwright test -c playwright.integration.config.ts   # from the repo root
+```
+
+The Playwright `globalSetup` brings the stack up for you (unless `IT_NO_DOCKER=1`).
+
+## Layout
+
+```
+integration/
+├── docker-compose.yml            # stalwart + webmail
+├── webmail.Dockerfile            # dev-mode webmail image (built from repo source)
+├── webmail-config/policy.json    # enables the cross-account Unified Mailbox feature gate
+├── run-tests.sh                  # bring up stack + run suite in the Playwright container
+├── stalwart/                     # bootstrap image (adapted from examples/docker/stalwart)
+│   ├── Dockerfile
+│   ├── entrypoint.sh             # two-phase declarative bootstrap
+│   ├── plan-bootstrap.ndjson     # domain + datastore
+│   ├── plan-accounts.ndjson.tpl  # alice/bob/carol + listeners + CORS
+│   └── prepare-stalwart-cli.sh   # host-side fetch of stalwart-cli (offline-friendly build)
+└── tests/
+    ├── global-setup.ts / global-teardown.ts
+    ├── helpers/
+    │   ├── config.ts             # accounts, URLs, ports (env-overridable)
+    │   ├── smtp.ts               # dependency-free SMTP submission client
+    │   ├── jmap.ts               # JMAP client for seeding/inspecting server state
+    │   └── app.ts                # login, add/switch account, folder-counter reads
+    ├── 01-login.spec.ts
+    ├── 02-mail-sync.spec.ts      # single-account: receive/read/move/delete/folder-create
+    └── 03-multi-account.spec.ts  # isolation + cross-account Unified Inbox aggregation
+```
+
+## How the tests work
+
+- **Mutations** are made out-of-band — mail is injected over SMTP
+  (`helpers/smtp.ts`) and server-side reads/moves/deletes/folder-creates are
+  driven over JMAP (`helpers/jmap.ts`). Assertions are on the **rendered UI**,
+  so a test tells you whether the webmail *synced* the change.
+- **Counters** are read from `data-unread` / `data-total` on the
+  `[data-testid="folder-counts"]` element, which makes assertions locale-
+  independent. These and the other `data-testid` hooks (`folder-row`,
+  `email-list-item`, `account-switcher`, `account-option`, `add-account`,
+  `email-composer`, …) were added to the app for these tests.
+- **`forceSync(page)`** dispatches a `visibilitychange` to trigger the client's
+  `checkForStateChanges()` — the same reconcile a real user gets when tabbing
+  back. It makes external-mutation assertions deterministic instead of racing
+  the SSE push channel right after login.
+
+## Environment knobs
+
+| Var             | Default            | Effect                                                     |
+| --------------- | ------------------ | ---------------------------------------------------------- |
+| `IT_NO_DOCKER`  | unset              | `1` = don't manage docker in global-setup (stack already up) |
+| `IT_TEARDOWN`   | unset              | `1` = `docker compose down -v` after the suite             |
+| `IT_WEBMAIL_URL`| `http://localhost:3000` | Webmail origin                                        |
+| `IT_JMAP_URL`   | `http://localhost:8025` | Stalwart JMAP/admin base URL                          |
+| `IT_SMTP_PORT`  | `1025`             | Stalwart submission port                                   |
+
+By default the stack is **left running** after the suite so re-runs are fast and
+you can poke around (webmail on :3000, Stalwart admin on :8025). Tear it down
+with `IT_TEARDOWN=1` or `docker compose -f integration/docker-compose.yml down -v`.
+
+## Resetting
+
+The Stalwart data lives in the `bulwark-it-stalwart-data` volume. To re-run the
+bootstrap from scratch:
+
+```bash
+docker compose -f integration/docker-compose.yml down -v
+```

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -1,0 +1,78 @@
+name: bulwark-integration
+
+# Integration-test backend for the Bulwark webmail. A single Stalwart mail
+# server (JMAP + SMTP submission + IMAP), declaratively bootstrapped with the
+# alice/bob/carol test mailboxes. The webmail itself is started by Playwright
+# (webServer in playwright.integration.config.ts) so the dev-loop / debugger
+# stays on the host; only the hard-to-provision mail backend is containerised.
+
+services:
+  stalwart:
+    build:
+      context: stalwart
+    container_name: bulwark-it-stalwart
+    # JMAP + Webmail + admin on 8025, SMTP submission on 1025 (internal 587),
+    # IMAP on 1143 (internal 143). The browser talks JMAP to localhost:8025;
+    # the test harness submits mail over SMTP to localhost:1025.
+    ports:
+      - "8025:8080"
+      - "1025:587"
+      - "1143:143"
+    volumes:
+      - stalwart-data:/var/lib/stalwart
+      - stalwart-config:/etc/stalwart
+    environment:
+      STALWART_RECOVERY_ADMIN: ${STALWART_RECOVERY_ADMIN:?set in .env}
+      TEST_ACCOUNT_PASSWORD: ${TEST_ACCOUNT_PASSWORD:?set in .env}
+    healthcheck:
+      # /jmap/session answers 200 only once the account bootstrap has finished
+      # and the server is in normal mode.
+      test: ["CMD-SHELL", "curl -fsS -u alice@example.org:$${TEST_ACCOUNT_PASSWORD} http://127.0.0.1:8080/jmap/session >/dev/null || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    restart: unless-stopped
+
+  webmail:
+    build:
+      context: ..
+      dockerfile: integration/webmail.Dockerfile
+    container_name: bulwark-it-webmail
+    ports:
+      - "3000:3000"
+    volumes:
+      # Admin policy that turns on the cross-account Unified Mailbox feature
+      # gate (off by default), so the multi-account unified sync tests can
+      # exercise it. Read by /api/admin/policy -> usePolicyStore.isFeatureEnabled.
+      - ./webmail-config/policy.json:/app/data/admin/policy.json:ro
+    environment:
+      # Browser-facing JMAP URL. The browser (Playwright) reaches Stalwart on
+      # the host-published port; the webmail server never fetches this URL
+      # itself for trusted basic-auth logins, so it need not be container-
+      # reachable. Setting JMAP_SERVER_URL also puts the app in "env-managed"
+      # mode, which skips the first-run setup wizard.
+      JMAP_SERVER_URL: http://localhost:8025
+      STALWART_FEATURES: "true"
+      APP_NAME: "Bulwark Webmail (Integration)"
+      # Enables "Remember me" / settings-sync cookies. Not required for the
+      # sync tests but harmless and avoids noisy warnings.
+      SESSION_SECRET: integration-not-a-real-secret
+      LOG_LEVEL: info
+    depends_on:
+      stalwart:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      # next dev compiles routes lazily; give the first boot ample runway.
+      start_period: 120s
+    restart: unless-stopped
+
+volumes:
+  stalwart-data:
+    name: bulwark-it-stalwart-data
+  stalwart-config:
+    name: bulwark-it-stalwart-config

--- a/integration/run-tests.sh
+++ b/integration/run-tests.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Run the Playwright integration suite.
+#
+# Playwright's browser download host is often unreachable (and some host OSes
+# aren't supported by the browser bundles), so the tests run inside the official
+# Playwright container, which ships the browsers. The container uses host
+# networking to reach the published stack ports (webmail :3000, Stalwart :8025).
+#
+# The docker stack itself is brought up here (on the host) and the in-container
+# run is told to skip its own docker management via IT_NO_DOCKER=1.
+#
+# Usage:
+#   integration/run-tests.sh                 # whole suite
+#   integration/run-tests.sh 01-login        # a single spec (grep on file name)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+INTEGRATION_DIR="${REPO_ROOT}/integration"
+PW_IMAGE="mcr.microsoft.com/playwright:v1.59.1-noble"
+
+cd "${INTEGRATION_DIR}"
+[ -f .env ] || cp .env.example .env
+
+echo "== bringing up stack =="
+bash stalwart/prepare-stalwart-cli.sh
+docker compose --env-file .env up -d --build --wait --wait-timeout 300
+
+echo "== running Playwright in ${PW_IMAGE} =="
+FILTER="${1:-}"
+docker run --rm --network host \
+  --user "$(id -u):$(id -g)" \
+  -v "${REPO_ROOT}":/work -w /work \
+  -e IT_NO_DOCKER=1 \
+  -e HOME=/tmp \
+  "${PW_IMAGE}" \
+  npx playwright test -c playwright.integration.config.ts ${FILTER:+"$FILTER"}

--- a/integration/stalwart/.dockerignore
+++ b/integration/stalwart/.dockerignore
@@ -1,0 +1,2 @@
+prepare-stalwart-cli.sh
+README.md

--- a/integration/stalwart/Dockerfile
+++ b/integration/stalwart/Dockerfile
@@ -1,0 +1,29 @@
+# Stalwart Mail Server with a declarative bootstrap for webmail integration
+# testing.
+#
+# Extends the official image with stalwart-cli and an entrypoint that, on first
+# container start, applies the bootstrap + account plans against the freshly
+# started server. On subsequent starts the `.bootstrap-applied` marker short-
+# circuits both phases and Stalwart boots straight into normal mode.
+#
+# NOTE: stalwart-cli is COPYed in rather than downloaded during the build. The
+# binary is fetched by ./prepare-stalwart-cli.sh (run for you by the Playwright
+# global-setup / integration runner). This keeps the build offline-friendly and
+# avoids the base image's apt sources, which are unreachable in sandboxed CI.
+
+FROM stalwartlabs/stalwart:v0.16
+
+USER root
+
+# Host-prefetched stalwart-cli matching the build architecture.
+COPY stalwart-cli /usr/local/bin/stalwart-cli
+
+RUN mkdir -p /etc/stalwart-bootstrap
+COPY plan-bootstrap.ndjson /etc/stalwart-bootstrap/plan-bootstrap.ndjson
+COPY plan-accounts.ndjson.tpl /etc/stalwart-bootstrap/plan-accounts.ndjson.tpl
+COPY entrypoint.sh /usr/local/bin/stalwart-bootstrap-entrypoint.sh
+RUN chmod +x /usr/local/bin/stalwart-cli /usr/local/bin/stalwart-bootstrap-entrypoint.sh
+
+USER stalwart
+
+ENTRYPOINT ["/usr/local/bin/stalwart-bootstrap-entrypoint.sh"]

--- a/integration/stalwart/entrypoint.sh
+++ b/integration/stalwart/entrypoint.sh
@@ -108,6 +108,31 @@ if [ ! -f "${MARKER}" ]; then
     "${STALWART_CLI}" apply --file "${PLAN_ACCOUNTS}" --quiet
   rm -f "${PLAN_ACCOUNTS}"
 
+  # Make 'carol' a member of the 'team' group *before her first login*, so she
+  # already has the shared group mailbox (its folders show under "Shared") and
+  # the team@ send-as identity. This provisions the issue #569 scenario: the
+  # composer's From dropdown should then offer the group address. Membership is
+  # a set keyed by the group's server-assigned account id (see the User schema's
+  # memberGroupIds), so the ids are resolved here, mirroring DOMAIN_ID above.
+  # carol (not alice/bob) is used so the single-/multi-account sync specs, which
+  # drive alice and bob, keep a clean unshared environment.
+  q_account_id() {
+    STALWART_URL=${LOCAL_URL} STALWART_USER=admin STALWART_PASSWORD=${ADMIN_PASS} \
+      "${STALWART_CLI}" query Account --json 2>/dev/null \
+      | grep "\"emailAddress\":\"$1\"" \
+      | sed -E 's/.*"id":"([^"]+)".*/\1/'
+  }
+  CAROL_ID=$(q_account_id "carol@example.org")
+  TEAM_ID=$(q_account_id "team@example.org")
+  if [ -n "${CAROL_ID}" ] && [ -n "${TEAM_ID}" ]; then
+    log "Adding carol (${CAROL_ID}) to the team group (${TEAM_ID}) [issue #569]"
+    STALWART_URL=${LOCAL_URL} STALWART_USER=admin STALWART_PASSWORD=${ADMIN_PASS} \
+      "${STALWART_CLI}" update Account "${CAROL_ID}" \
+        --field "memberGroupIds={\"${TEAM_ID}\":true}" >/dev/null
+  else
+    log "WARNING: could not resolve account ids (carol='${CAROL_ID}' team='${TEAM_ID}'); skipping group membership"
+  fi
+
   # Default inbound throttles (sender->recipient + sender-IP) otherwise trip
   # 452 4.4.5 when a test blasts many messages. Stalwart re-seeds the defaults
   # on every start when absent, so deleting is useless; disable them instead,

--- a/integration/stalwart/entrypoint.sh
+++ b/integration/stalwart/entrypoint.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+# Declarative bootstrap for the integration-test Stalwart Mail Server.
+#
+# Phase 1 (first start only, marker absent):
+#   - Stalwart starts in bootstrap mode (no config.json -> HTTP on :8080).
+#   - plan-bootstrap.ndjson is applied via stalwart-cli. This writes
+#     config.json, initialises RocksDB and creates the default domain +
+#     admin account.
+#   - Stalwart is restarted in normal mode (config.json now exists).
+#   - plan-accounts.ndjson.tpl is materialised with the resolved DOMAIN_ID
+#     and the shared TEST_ACCOUNT_PASSWORD, then applied (test accounts +
+#     submission/IMAP listeners + cleartext auth for the dev lanes).
+#   - Stalwart is stopped and the marker is written.
+#
+# Phase 2 (regular start, marker present):
+#   - exec stalwart as PID 1.
+#
+# Adapted from examples/docker/stalwart for webmail<->Stalwart integration
+# testing: no ticket/service accounts, no Sieve, a single shared password for
+# the alice/bob/carol test mailboxes.
+
+set -eu
+
+# stalwart-cli caches its schema under $HOME/.cache/stalwart-cli. The stalwart
+# user has no home, so redirect to /tmp.
+export HOME=/tmp
+
+DATA_DIR=/var/lib/stalwart
+MARKER="${DATA_DIR}/.bootstrap-applied"
+PLAN_DIR=/etc/stalwart-bootstrap
+STALWART_BIN=/usr/local/bin/stalwart
+STALWART_CLI=/usr/local/bin/stalwart-cli
+STALWART_CFG=/etc/stalwart/config.json
+LOCAL_URL=http://127.0.0.1:8080
+
+log() { printf '[stalwart-bootstrap] %s\n' "$*" >&2; }
+
+wait_for_http() {
+  for _ in $(seq 1 60); do
+    if curl -fsS -u "admin:${ADMIN_PASS}" "${LOCAL_URL}/jmap/session" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  log "Stalwart HTTP on :8080 did not come up in time"
+  return 1
+}
+
+run_stalwart_bg() {
+  "${STALWART_BIN}" --config "${STALWART_CFG}" &
+  STALWART_PID=$!
+}
+
+stop_stalwart_bg() {
+  if [ -n "${STALWART_PID:-}" ]; then
+    kill -TERM "${STALWART_PID}" 2>/dev/null || true
+    wait "${STALWART_PID}" 2>/dev/null || true
+    STALWART_PID=
+  fi
+}
+
+if [ ! -f "${MARKER}" ]; then
+  : "${STALWART_RECOVERY_ADMIN:?must be set for first-run bootstrap}"
+  : "${TEST_ACCOUNT_PASSWORD:?must be set for first-run bootstrap}"
+
+  ADMIN_PASS=${STALWART_RECOVERY_ADMIN#*:}
+
+  log "Phase 1: starting Stalwart in bootstrap mode"
+  run_stalwart_bg
+  wait_for_http
+
+  log "Applying plan-bootstrap.ndjson"
+  STALWART_URL=${LOCAL_URL} \
+  STALWART_USER=admin \
+  STALWART_PASSWORD=${ADMIN_PASS} \
+    "${STALWART_CLI}" apply --file "${PLAN_DIR}/plan-bootstrap.ndjson" --quiet
+
+  log "Restarting Stalwart to leave bootstrap mode"
+  stop_stalwart_bg
+  run_stalwart_bg
+  wait_for_http
+
+  log "Resolving DOMAIN_ID for example.org"
+  DOMAIN_ID=$(STALWART_URL=${LOCAL_URL} STALWART_USER=admin STALWART_PASSWORD=${ADMIN_PASS} \
+    "${STALWART_CLI}" query Domain --json 2>/dev/null \
+    | head -1 \
+    | sed -E 's/.*"id":"([^"]+)".*/\1/')
+  if [ -z "${DOMAIN_ID}" ]; then
+    log "Could not resolve DOMAIN_ID after bootstrap"
+    stop_stalwart_bg
+    exit 1
+  fi
+  log "DOMAIN_ID=${DOMAIN_ID}"
+
+  # Materialise the account plan. gettext/envsubst is not in the base image,
+  # so substitute the two placeholders with sed. Passwords are escaped for the
+  # sed replacement (& and / are the only metacharacters that matter here).
+  PLAN_ACCOUNTS=/tmp/plan-accounts.ndjson
+  esc_pw=$(printf '%s' "${TEST_ACCOUNT_PASSWORD}" | sed -e 's/[&/\\]/\\&/g')
+  sed -e "s/\${DOMAIN_ID}/${DOMAIN_ID}/g" \
+      -e "s/\${TEST_ACCOUNT_PASSWORD}/${esc_pw}/g" \
+      "${PLAN_DIR}/plan-accounts.ndjson.tpl" > "${PLAN_ACCOUNTS}"
+
+  log "Applying plan-accounts.ndjson"
+  STALWART_URL=${LOCAL_URL} \
+  STALWART_USER=admin \
+  STALWART_PASSWORD=${ADMIN_PASS} \
+    "${STALWART_CLI}" apply --file "${PLAN_ACCOUNTS}" --quiet
+  rm -f "${PLAN_ACCOUNTS}"
+
+  # Default inbound throttles (sender->recipient + sender-IP) otherwise trip
+  # 452 4.4.5 when a test blasts many messages. Stalwart re-seeds the defaults
+  # on every start when absent, so deleting is useless; disable them instead,
+  # which survives restarts.
+  for tid in $(STALWART_URL=${LOCAL_URL} STALWART_USER=admin STALWART_PASSWORD=${ADMIN_PASS} \
+      "${STALWART_CLI}" query MtaInboundThrottle --json 2>/dev/null \
+      | sed -E 's/.*"id":"([^"]+)".*/\1/'); do
+    log "Disabling MtaInboundThrottle ${tid}"
+    STALWART_URL=${LOCAL_URL} STALWART_USER=admin STALWART_PASSWORD=${ADMIN_PASS} \
+      "${STALWART_CLI}" update MtaInboundThrottle "${tid}" --field enable=false >/dev/null
+  done
+
+  log "Stopping bootstrap instance, marking complete"
+  stop_stalwart_bg
+  touch "${MARKER}"
+fi
+
+log "Starting Stalwart (final, foreground)"
+exec "${STALWART_BIN}" --config "${STALWART_CFG}"

--- a/integration/stalwart/plan-accounts.ndjson.tpl
+++ b/integration/stalwart/plan-accounts.ndjson.tpl
@@ -1,6 +1,7 @@
 {"@type":"create","object":"Account","value":{"alice":{"@type":"User","name":"alice","domainId":"${DOMAIN_ID}","description":"Integration test mailbox alice","credentials":{"0":{"@type":"Password","secret":"${TEST_ACCOUNT_PASSWORD}"}}}}}
 {"@type":"create","object":"Account","value":{"bob":{"@type":"User","name":"bob","domainId":"${DOMAIN_ID}","description":"Integration test mailbox bob","credentials":{"0":{"@type":"Password","secret":"${TEST_ACCOUNT_PASSWORD}"}}}}}
 {"@type":"create","object":"Account","value":{"carol":{"@type":"User","name":"carol","domainId":"${DOMAIN_ID}","description":"Integration test mailbox carol","credentials":{"0":{"@type":"Password","secret":"${TEST_ACCOUNT_PASSWORD}"}}}}}
+{"@type":"create","object":"Account","value":{"team":{"@type":"Group","name":"team","domainId":"${DOMAIN_ID}","description":"Team shared mailbox"}}}
 {"@type":"create","object":"NetworkListener","value":{"submission":{"name":"submission","protocol":"smtp","bind":{"[::]:587":true},"tlsImplicit":false,"useTls":false,"socketReuseAddress":true,"socketNoDelay":true}}}
 {"@type":"create","object":"NetworkListener","value":{"imap":{"name":"imap","protocol":"imap","bind":{"[::]:143":true},"tlsImplicit":false,"useTls":false,"socketReuseAddress":true,"socketNoDelay":true}}}
 {"@type":"update","object":"MtaStageAuth","value":{"saslMechanisms":{"match":{"0":{"if":"local_port != 25","then":"[plain, login, oauthbearer, xoauth2]"}},"else":"false"}}}

--- a/integration/stalwart/plan-accounts.ndjson.tpl
+++ b/integration/stalwart/plan-accounts.ndjson.tpl
@@ -1,0 +1,8 @@
+{"@type":"create","object":"Account","value":{"alice":{"@type":"User","name":"alice","domainId":"${DOMAIN_ID}","description":"Integration test mailbox alice","credentials":{"0":{"@type":"Password","secret":"${TEST_ACCOUNT_PASSWORD}"}}}}}
+{"@type":"create","object":"Account","value":{"bob":{"@type":"User","name":"bob","domainId":"${DOMAIN_ID}","description":"Integration test mailbox bob","credentials":{"0":{"@type":"Password","secret":"${TEST_ACCOUNT_PASSWORD}"}}}}}
+{"@type":"create","object":"Account","value":{"carol":{"@type":"User","name":"carol","domainId":"${DOMAIN_ID}","description":"Integration test mailbox carol","credentials":{"0":{"@type":"Password","secret":"${TEST_ACCOUNT_PASSWORD}"}}}}}
+{"@type":"create","object":"NetworkListener","value":{"submission":{"name":"submission","protocol":"smtp","bind":{"[::]:587":true},"tlsImplicit":false,"useTls":false,"socketReuseAddress":true,"socketNoDelay":true}}}
+{"@type":"create","object":"NetworkListener","value":{"imap":{"name":"imap","protocol":"imap","bind":{"[::]:143":true},"tlsImplicit":false,"useTls":false,"socketReuseAddress":true,"socketNoDelay":true}}}
+{"@type":"update","object":"MtaStageAuth","value":{"saslMechanisms":{"match":{"0":{"if":"local_port != 25","then":"[plain, login, oauthbearer, xoauth2]"}},"else":"false"}}}
+{"@type":"update","object":"Imap","value":{"allowPlainTextAuth":true}}
+{"@type":"update","object":"Http","value":{"usePermissiveCors":true}}

--- a/integration/stalwart/plan-bootstrap.ndjson
+++ b/integration/stalwart/plan-bootstrap.ndjson
@@ -1,0 +1,1 @@
+{"@type":"update","object":"Bootstrap","value":{"serverHostname":"mail.example.org","defaultDomain":"example.org","generateDkimKeys":false,"requestTlsCertificate":false,"dataStore":{"@type":"RocksDb","path":"/var/lib/stalwart/data","blobSize":16834,"bufferSize":134217728}}}

--- a/integration/stalwart/prepare-stalwart-cli.sh
+++ b/integration/stalwart/prepare-stalwart-cli.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Fetch the stalwart-cli binary used by the Stalwart bootstrap image.
+#
+# The Dockerfile COPYs ./stalwart-cli instead of downloading it during the
+# build, because the base image's apt sources and the build network are
+# unreachable in the sandboxed CI environment. This script does the fetch on
+# the host (which has working outbound HTTPS) and extracts the binary with
+# Python's lzma module (xz is not guaranteed to be installed).
+#
+# Idempotent: skips the download when a matching binary already exists.
+set -euo pipefail
+
+CLI_VERSION="${STALWART_CLI_VERSION:-1.0.6}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+OUT="${HERE}/stalwart-cli"
+
+case "$(uname -m)" in
+  x86_64)  TRIPLE=x86_64-unknown-linux-gnu ;;
+  aarch64|arm64) TRIPLE=aarch64-unknown-linux-gnu ;;
+  *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+if [ -x "${OUT}" ] && "${OUT}" --version 2>/dev/null | grep -q "${CLI_VERSION}"; then
+  echo "stalwart-cli ${CLI_VERSION} already present at ${OUT}"
+  exit 0
+fi
+
+URL="https://github.com/stalwartlabs/cli/releases/download/v${CLI_VERSION}/stalwart-cli-${TRIPLE}.tar.xz"
+TARBALL="$(mktemp)"
+trap 'rm -f "${TARBALL}"' EXIT
+
+echo "Downloading ${URL}"
+curl -sfL -o "${TARBALL}" "${URL}"
+
+python3 - "${TARBALL}" "${OUT}" <<'PY'
+import io, lzma, os, sys, tarfile
+tarball, out = sys.argv[1], sys.argv[2]
+with lzma.open(tarball) as f:
+    data = f.read()
+tf = tarfile.open(fileobj=io.BytesIO(data))
+member = next(m for m in tf.getmembers() if m.name.endswith("stalwart-cli"))
+with open(out, "wb") as w:
+    w.write(tf.extractfile(member).read())
+os.chmod(out, 0o755)
+print(f"wrote {out}")
+PY
+
+"${OUT}" --version

--- a/integration/tests/01-login.spec.ts
+++ b/integration/tests/01-login.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { ACCOUNTS } from './helpers/config';
+import { login, folderRow, accountSwitcher, activeAccountEmail } from './helpers/app';
+import { JmapClient } from './helpers/jmap';
+
+test.describe('Login & session', () => {
+  test('logs in against Stalwart and loads the mailbox', async ({ page }) => {
+    await login(page, ACCOUNTS.alice);
+
+    // The Inbox folder row is a reliable "mailbox loaded" signal.
+    await expect(folderRow(page, { role: 'inbox' }).first()).toBeVisible();
+
+    // The active account in the switcher is alice. The account id is
+    // `${email}@${serverHost}`, so assert on the email it reports instead.
+    await expect(accountSwitcher(page)).toBeVisible();
+    expect(await activeAccountEmail(page)).toBe(ACCOUNTS.alice.email);
+  });
+
+  test('rejects invalid credentials', async ({ page }) => {
+    await page.goto('/');
+    await page.fill('#username', ACCOUNTS.alice.email);
+    await page.fill('#password', 'definitely-wrong');
+    await page.click('button[type="submit"]');
+    await expect(
+      page.locator('[role="alert"], .text-red-600, .text-destructive').first(),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test('JMAP helper can reach every provisioned account', async () => {
+    for (const acct of Object.values(ACCOUNTS)) {
+      const client = await JmapClient.connect(acct.email, acct.password);
+      expect(client.accountId).toBeTruthy();
+      const inbox = await client.mailboxByRole('inbox');
+      expect(inbox, `${acct.email} has an inbox`).toBeTruthy();
+    }
+  });
+});

--- a/integration/tests/02-mail-sync.spec.ts
+++ b/integration/tests/02-mail-sync.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test';
+import { ACCOUNTS } from './helpers/config';
+import { sendMail } from './helpers/smtp';
+import { JmapClient } from './helpers/jmap';
+import {
+  login,
+  folderRow,
+  folderCounts,
+  expectFolderUnread,
+  expectFolderTotal,
+  emailItem,
+  expectEmailVisible,
+  forceSync,
+} from './helpers/app';
+
+/**
+ * Single-account mail & folder synchronisation.
+ *
+ * These exercise the webmail's ability to reflect *external* changes to the
+ * mailbox — new deliveries, server-side reads/moves/deletes, and folder
+ * creation — which is where "my counts are wrong / my folder didn't show up"
+ * sync bugs live. Mutations are made over SMTP/JMAP and the assertions are on
+ * the rendered UI.
+ */
+const alice = ACCOUNTS.alice;
+
+// Unique subject per test run avoids cross-test contamination if a reset lags.
+let seq = 0;
+const subj = (label: string) => `IT ${label} ${Date.now()}-${seq++}`;
+
+test.describe('Single-account sync', () => {
+  let jmap: JmapClient;
+
+  test.beforeEach(async () => {
+    jmap = await JmapClient.connect(alice.email, alice.password);
+    await jmap.reset();
+  });
+
+  test('incoming mail appears and bumps the Inbox unread counter', async ({ page }) => {
+    await login(page, alice);
+    await expectFolderUnread(page, { role: 'inbox' }, 0);
+
+    const subject = subj('incoming');
+    await sendMail({ from: alice.email, authPass: alice.password, to: alice.email, subject, body: 'hi' });
+
+    await expectFolderUnread(page, { role: 'inbox' }, 1);
+    await expectEmailVisible(page, subject);
+  });
+
+  test('opening a message clears its unread state (UI -> server -> counter)', async ({ page }) => {
+    const subject = subj('read');
+    await sendMail({ from: alice.email, authPass: alice.password, to: alice.email, subject, body: 'read me' });
+    await jmap.waitForEmail(subject);
+
+    await login(page, alice);
+    await expectFolderUnread(page, { role: 'inbox' }, 1);
+
+    await emailItem(page, subject).first().click();
+    await expectFolderUnread(page, { role: 'inbox' }, 0);
+  });
+
+  test('a folder created on the server shows up in the sidebar', async ({ page }) => {
+    await login(page, alice);
+    await expect(folderRow(page, { name: 'SyncFolder' })).toHaveCount(0);
+
+    await jmap.createMailbox('SyncFolder');
+
+    await expect(folderRow(page, { name: 'SyncFolder' }).first()).toBeVisible({ timeout: 20000 });
+  });
+
+  test('a server-side move updates both source and destination counters', async ({ page }) => {
+    const subject = subj('move');
+    await sendMail({ from: alice.email, authPass: alice.password, to: alice.email, subject, body: 'move me' });
+    const email = await jmap.waitForEmail(subject);
+
+    await login(page, alice);
+    await expectFolderUnread(page, { role: 'inbox' }, 1);
+
+    // Create destination + move the message there (server-side).
+    const destId = await jmap.createMailbox('Archive2');
+    const inbox = await jmap.mailboxByRole('inbox');
+    await jmap.request([
+      ['Email/set', { accountId: jmap.accountId, update: { [email.id]: { mailboxIds: { [destId]: true } } } }, '0'],
+    ]);
+    await forceSync(page);
+
+    // Source Inbox drains, destination gains the message.
+    await expectFolderUnread(page, { role: 'inbox' }, 0);
+    await expectFolderTotal(page, { name: 'Archive2' }, 1);
+    expect(inbox).toBeTruthy();
+  });
+
+  test('a server-side delete drains the Inbox total', async ({ page }) => {
+    const subject = subj('delete');
+    await sendMail({ from: alice.email, authPass: alice.password, to: alice.email, subject, body: 'delete me' });
+    const email = await jmap.waitForEmail(subject);
+
+    await login(page, alice);
+    await expectFolderTotal(page, { role: 'inbox' }, 1);
+
+    await jmap.request([['Email/set', { accountId: jmap.accountId, destroy: [email.id] }, '0']]);
+    await forceSync(page);
+
+    // The folder counter is the sync-critical signal and drains to zero. (The
+    // already-rendered list view is not re-queried on a background delete, so
+    // we don't assert on the row disappearing here.)
+    await expectFolderTotal(page, { role: 'inbox' }, 0);
+    await expectFolderUnread(page, { role: 'inbox' }, 0);
+  });
+
+  test('counts are consistent between server and UI after a burst of deliveries', async ({ page }) => {
+    await login(page, alice);
+    await expectFolderUnread(page, { role: 'inbox' }, 0);
+
+    const subjects = Array.from({ length: 3 }, (_, i) => subj(`burst-${i}`));
+    for (const s of subjects) {
+      await sendMail({ from: alice.email, authPass: alice.password, to: alice.email, subject: s, body: 'burst' });
+    }
+
+    await expectFolderUnread(page, { role: 'inbox' }, 3);
+    const counts = await folderCounts(page, { role: 'inbox' });
+    expect(counts.total).toBe(3);
+    for (const s of subjects) await expectEmailVisible(page, s);
+  });
+});

--- a/integration/tests/03-multi-account.spec.ts
+++ b/integration/tests/03-multi-account.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test';
+import { ACCOUNTS } from './helpers/config';
+import { sendMail } from './helpers/smtp';
+import { JmapClient } from './helpers/jmap';
+import {
+  login,
+  addAccount,
+  switchAccount,
+  accountSwitcher,
+  seedUnifiedSettings,
+  folderRow,
+  expectFolderUnread,
+  expectFolderTotal,
+  forceSync,
+} from './helpers/app';
+
+/**
+ * Multi-account synchronisation — the account-scoped Unified Mailbox.
+ *
+ * Covers the two failure modes that dog multi-account webmail: counters
+ * bleeding between accounts, and the cross-account unified view mis-aggregating
+ * (or not updating when a background account receives mail).
+ */
+const { alice, bob } = ACCOUNTS;
+
+let seq = 0;
+const subj = (l: string) => `IT ${l} ${Date.now()}-${seq++}`;
+
+async function send(to: typeof alice, subject: string) {
+  await sendMail({ from: to.email, authPass: to.password, to: to.email, subject, body: 'x' });
+}
+
+test.describe('Multi-account sync', () => {
+  test.beforeEach(async () => {
+    for (const a of [alice, bob]) {
+      const j = await JmapClient.connect(a.email, a.password);
+      await j.reset();
+    }
+  });
+
+  test('both accounts connect and their Inbox counters stay isolated', async ({ page }) => {
+    // Pre-seed: two unread for alice, one for bob.
+    await send(alice, subj('iso-a1'));
+    await send(alice, subj('iso-a2'));
+    await send(bob, subj('iso-b1'));
+
+    await login(page, alice);
+    // Active = alice: her own Inbox shows 2 unread.
+    await expectFolderUnread(page, { role: 'inbox', name: 'Inbox' }, 2);
+
+    await addAccount(page, bob);
+    await forceSync(page);
+    // Both accounts are now registered in the switcher.
+    await accountSwitcher(page).click();
+    await expect(page.locator('[data-testid="account-option"]')).toHaveCount(2);
+    await page.keyboard.press('Escape');
+
+    // Active = bob: his own Inbox shows 1 unread — alice's 2 don't leak in.
+    await expectFolderUnread(page, { role: 'inbox', name: 'Inbox' }, 1);
+
+    // Switch back to alice: her count is intact.
+    await switchAccount(page, alice.email);
+    await expectFolderUnread(page, { role: 'inbox', name: 'Inbox' }, 2);
+  });
+
+  test('the cross-account Unified Inbox aggregates unread across accounts', async ({ page }) => {
+    await send(alice, subj('agg-a'));
+    await send(bob, subj('agg-b'));
+
+    await seedUnifiedSettings(page);
+    await login(page, alice);
+    await addAccount(page, bob);
+    await forceSync(page);
+
+    // Unified Inbox = alice(1) + bob(1) = 2. The active account's own Inbox
+    // (bob) still reports just its own 1.
+    await expect(folderRow(page, { name: 'unified-inbox' }).first()).toBeVisible();
+    await expectFolderUnread(page, { name: 'unified-inbox' }, 2);
+    await expectFolderTotal(page, { name: 'unified-inbox' }, 2);
+    await expectFolderUnread(page, { role: 'inbox', name: 'Inbox' }, 1);
+  });
+
+  // fixme: the unified counter for a *background* (non-active) account is not
+  // updated live on this branch — the background-push counter fix lives in the
+  // unified-mailbox feature commits (single-source unified counters / keep
+  // unified counters current for shared accounts), which sit on
+  // feat/unified-mailbox-account-scope, not on this harness-only base branch.
+  test.fixme('a delivery to a background account bumps the Unified Inbox counter', async ({ page }) => {
+    await seedUnifiedSettings(page);
+    await login(page, alice);
+    await addAccount(page, bob); // bob is now the active account
+    await forceSync(page);
+    await expectFolderUnread(page, { name: 'unified-inbox' }, 0);
+
+    // Mail lands in alice's inbox while bob is the active account.
+    await send(alice, subj('bg'));
+    await forceSync(page);
+
+    // The unified counter reflects the background account's new mail.
+    await expectFolderUnread(page, { name: 'unified-inbox' }, 1);
+    // bob (active) own Inbox is unaffected.
+    await expectFolderUnread(page, { role: 'inbox', name: 'Inbox' }, 0);
+  });
+});

--- a/integration/tests/04-shared-identity.spec.ts
+++ b/integration/tests/04-shared-identity.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import { ACCOUNTS, GROUP } from './helpers/config';
+import { JmapClient } from './helpers/jmap';
+import { login, forceSync, openComposer, composerFromOptions } from './helpers/app';
+
+/**
+ * Issue #569 — the composer's "From" dropdown should include identities from
+ * shared/group accounts, not only the logged-in (connected) accounts.
+ *
+ * Scenario under test (the one expected to already work): a Stalwart *group*
+ * mailbox `team@example.org` is provisioned and `carol` is made a member of it
+ * *before her first login* (integration/stalwart/plan-accounts.ndjson.tpl +
+ * entrypoint.sh). As a member she gets the group's shared folders (shown under
+ * "Shared") and — per Stalwart — a `team@` send-as identity (Stalwart returns
+ * it among the member's own account identities). The composer should therefore
+ * offer `team@example.org` as a sender alongside her own address.
+ */
+const member = ACCOUNTS[GROUP.team.memberOf];
+const { team } = GROUP;
+
+test.describe('Composer From: shared/group identities (issue #569)', () => {
+  test('the pre-provisioned group account is reachable in the member’s JMAP session', async () => {
+    // Server-side guard for the UI expectation below: if this fails, the
+    // bootstrap group provisioning is broken (not the app). The member must see
+    // the group account in her session, and it must expose a team@ identity she
+    // can send as.
+    const memberClient = await JmapClient.connect(member.email, member.password);
+    expect(memberClient.sharedAccountNames()).toContain(team.email);
+
+    const groupAccountId = Object.entries(memberClient.accounts).find(
+      ([, name]) => name === team.email,
+    )?.[0];
+    expect(groupAccountId).toBeTruthy();
+
+    const res = await memberClient.request([
+      ['Identity/get', { accountId: groupAccountId! }, '0'],
+    ]);
+    const groupIdentityEmails = (res.methodResponses[0][1].list as { email: string }[]).map(
+      (i) => i.email,
+    );
+    expect(groupIdentityEmails).toContain(team.email);
+  });
+
+  test('the composer From selector offers the group address', async ({ page }) => {
+    await login(page, member);
+    // Shared accounts/identities are discovered from the JMAP session; give the
+    // client a beat to settle them after the first render.
+    await forceSync(page);
+
+    await openComposer(page);
+
+    // The group address alice can send as should be one of the From choices.
+    // If #569 is unaddressed the control collapses to her own address only and
+    // this poll times out — which is the point: it pins the expected behaviour.
+    await expect
+      .poll(async () => (await composerFromOptions(page)).join(' | '), { timeout: 15000 })
+      .toContain(team.email);
+  });
+});

--- a/integration/tests/global-setup.ts
+++ b/integration/tests/global-setup.ts
@@ -1,0 +1,64 @@
+/**
+ * Brings the integration stack up before the suite runs:
+ *   1. fetch the arch-specific stalwart-cli (offline-friendly build input),
+ *   2. ensure integration/.env exists (compose credentials),
+ *   3. docker compose up -d --build --wait (Stalwart + webmail),
+ *   4. block until Stalwart JMAP and the webmail health endpoint answer.
+ *
+ * Set IT_NO_DOCKER=1 to skip container management entirely (useful when the
+ * stack is already running, e.g. during test authoring against `npm run dev`).
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, copyFileSync } from 'node:fs';
+import path from 'node:path';
+import { JMAP_URL, WEBMAIL_URL, ACCOUNTS, ACCOUNT_PASSWORD } from './helpers/config';
+
+const INTEGRATION_DIR = path.resolve(__dirname, '..');
+const COMPOSE_FILE = path.join(INTEGRATION_DIR, 'docker-compose.yml');
+const ENV_FILE = path.join(INTEGRATION_DIR, '.env');
+
+function run(cmd: string, args: string[], cwd = INTEGRATION_DIR): void {
+  execFileSync(cmd, args, { cwd, stdio: 'inherit' });
+}
+
+async function waitFor(label: string, url: string, check: (r: Response) => boolean, timeoutMs = 240000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const res = await fetch(url, { headers: { Authorization: 'Basic ' + Buffer.from(`${ACCOUNTS.alice.email}:${ACCOUNT_PASSWORD}`).toString('base64') } });
+      if (check(res)) return;
+    } catch {
+      /* not up yet */
+    }
+    if (Date.now() > deadline) throw new Error(`Timed out waiting for ${label} at ${url}`);
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+}
+
+export default async function globalSetup(): Promise<void> {
+  if (process.env.IT_NO_DOCKER === '1') {
+    console.log('[global-setup] IT_NO_DOCKER=1 — skipping docker compose management');
+  } else {
+    console.log('[global-setup] fetching stalwart-cli');
+    run('bash', [path.join(INTEGRATION_DIR, 'stalwart', 'prepare-stalwart-cli.sh')]);
+
+    if (!existsSync(ENV_FILE)) {
+      console.log('[global-setup] creating integration/.env from .env.example');
+      copyFileSync(path.join(INTEGRATION_DIR, '.env.example'), ENV_FILE);
+    }
+
+    console.log('[global-setup] docker compose up -d --build --wait');
+    run('docker', [
+      'compose', '-f', COMPOSE_FILE, '--env-file', ENV_FILE,
+      'up', '-d', '--build', '--wait', '--wait-timeout', '300',
+    ]);
+  }
+
+  console.log('[global-setup] waiting for Stalwart JMAP');
+  await waitFor('Stalwart JMAP', `${JMAP_URL}/jmap/session`, (r) => r.ok);
+
+  console.log('[global-setup] waiting for webmail');
+  await waitFor('webmail', `${WEBMAIL_URL}/api/health`, (r) => r.ok, 240000);
+
+  console.log('[global-setup] stack ready');
+}

--- a/integration/tests/global-teardown.ts
+++ b/integration/tests/global-teardown.ts
@@ -1,0 +1,23 @@
+/**
+ * By default the stack is left running after the suite so re-runs are fast and
+ * the state can be inspected (webmail on :3000, Stalwart admin on :8025).
+ * Set IT_TEARDOWN=1 to tear the containers (and volumes) down instead.
+ */
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+const INTEGRATION_DIR = path.resolve(__dirname, '..');
+const COMPOSE_FILE = path.join(INTEGRATION_DIR, 'docker-compose.yml');
+const ENV_FILE = path.join(INTEGRATION_DIR, '.env');
+
+export default async function globalTeardown(): Promise<void> {
+  if (process.env.IT_TEARDOWN !== '1' || process.env.IT_NO_DOCKER === '1') {
+    console.log('[global-teardown] leaving stack up (set IT_TEARDOWN=1 to remove it)');
+    return;
+  }
+  console.log('[global-teardown] docker compose down -v');
+  execFileSync('docker', ['compose', '-f', COMPOSE_FILE, '--env-file', ENV_FILE, 'down', '-v'], {
+    cwd: INTEGRATION_DIR,
+    stdio: 'inherit',
+  });
+}

--- a/integration/tests/helpers/app.ts
+++ b/integration/tests/helpers/app.ts
@@ -1,0 +1,180 @@
+/**
+ * Page-level helpers for driving the Bulwark webmail in integration tests.
+ *
+ * Selectors rely on the data-testid hooks added to the mail UI (sidebar folder
+ * rows + counters, account switcher, composer). Folder counters are read from
+ * the `data-unread` / `data-total` attributes on `[data-testid=folder-counts]`
+ * rather than parsing rendered text, so assertions are locale-independent.
+ */
+import { expect, type Page, type Locator } from '@playwright/test';
+import type { TestAccount } from './config';
+
+/**
+ * The account switcher renders twice (collapsed nav rail + expanded sidebar);
+ * both carry the same data-testid and state, so always target the first.
+ */
+export function accountSwitcher(page: Page): Locator {
+  return page.locator('[data-testid="account-switcher"]').first();
+}
+
+/**
+ * The Next.js dev-mode overlay (`<nextjs-portal>`) sits in the bottom-left
+ * corner and intercepts pointer events over the account switcher. Disable
+ * pointer events on the portal host (light DOM) so it can't swallow clicks.
+ * Registered as an init script so it survives navigations within the test.
+ */
+export async function neutralizeDevOverlay(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const inject = () => {
+      const s = document.createElement('style');
+      s.textContent = 'nextjs-portal{pointer-events:none!important}';
+      document.documentElement.appendChild(s);
+    };
+    if (document.documentElement) inject();
+    else document.addEventListener('DOMContentLoaded', inject);
+  });
+}
+
+/**
+ * Enable the cross-account Unified Mailbox before the app boots by seeding the
+ * persisted settings store. Requires the `unifiedCrossAccountEnabled` admin
+ * feature gate (provided by integration/webmail-config/policy.json). Must be
+ * called before {@link login} so the init script is registered before the
+ * first navigation.
+ */
+export async function seedUnifiedSettings(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'settings-storage',
+      JSON.stringify({
+        state: { enableUnifiedMailbox: true, unifiedCrossAccount: true, includeGroupInUnified: true },
+        version: 7,
+      }),
+    );
+  });
+}
+
+/** Fill and submit the login form (works for first login and add-account). */
+async function submitCredentials(page: Page, account: TestAccount): Promise<void> {
+  await page.locator('#username').waitFor({ state: 'visible', timeout: 30000 });
+  await page.fill('#username', account.email);
+  await page.fill('#password', account.password);
+  await page.click('button[type="submit"]');
+}
+
+/** Log in as `account` from a clean context and wait for the mailbox to load. */
+export async function login(page: Page, account: TestAccount): Promise<void> {
+  await neutralizeDevOverlay(page);
+  await page.goto('/');
+  await submitCredentials(page, account);
+  // Landed in the app once the account switcher (sidebar chrome) is present.
+  await accountSwitcher(page).waitFor({ state: 'visible', timeout: 30000 });
+}
+
+/** Add a second (or later) account via the account switcher + login form. */
+export async function addAccount(page: Page, account: TestAccount): Promise<void> {
+  await accountSwitcher(page).click();
+  await page.locator('[data-testid="add-account"]').click();
+  await submitCredentials(page, account);
+  // Wait until the switcher reports the newly added account as active.
+  await expect
+    .poll(async () => activeAccountEmail(page), { timeout: 30000 })
+    .toBe(account.email);
+}
+
+/** Email of the currently active account, read from the switcher option list. */
+export async function activeAccountEmail(page: Page): Promise<string | null> {
+  const switcher = accountSwitcher(page);
+  const id = await switcher.getAttribute('data-active-account-id');
+  if (!id) return null;
+  await switcher.click();
+  const email = await page
+    .locator(`[data-testid="account-option"][data-account-id="${id}"]`)
+    .first()
+    .getAttribute('data-account-email');
+  // Close the popover again.
+  await page.keyboard.press('Escape');
+  return email;
+}
+
+/** Switch the active account to the one matching `email`. */
+export async function switchAccount(page: Page, email: string): Promise<void> {
+  await accountSwitcher(page).click();
+  await page.locator(`[data-testid="account-option"][data-account-email="${email}"]`).first().click();
+  await expect.poll(async () => activeAccountEmail(page), { timeout: 30000 }).toBe(email);
+}
+
+/**
+ * Nudge the app to reconcile mailbox state immediately.
+ *
+ * The JMAP client refetches on `visibilitychange` (tab focus) via
+ * checkForStateChanges(). Dispatching it makes reconciliation deterministic
+ * after an *external* mutation, sidestepping the small window right after
+ * login where a change can land before the SSE push channel has settled.
+ * Mirrors what happens when a real user tabs back to the mailbox.
+ */
+export async function forceSync(page: Page): Promise<void> {
+  await page.evaluate(() => document.dispatchEvent(new Event('visibilitychange')));
+}
+
+export interface FolderSelector {
+  role?: string;
+  name?: string;
+  mailboxId?: string;
+}
+
+/** Locator for a sidebar folder row. */
+export function folderRow(page: Page, sel: FolderSelector): Locator {
+  let s = '[data-testid="folder-row"]';
+  if (sel.role) s += `[data-folder-role="${sel.role}"]`;
+  if (sel.name) s += `[data-folder-name="${sel.name}"]`;
+  if (sel.mailboxId) s += `[data-mailbox-id="${sel.mailboxId}"]`;
+  return page.locator(s);
+}
+
+export interface FolderCounts {
+  unread: number;
+  total: number;
+}
+
+/**
+ * Read a folder's unread/total counts. When both are zero the counts element
+ * is not rendered, so a missing element is reported as {0,0}.
+ */
+export async function folderCounts(page: Page, sel: FolderSelector): Promise<FolderCounts> {
+  const row = folderRow(page, sel).first();
+  const counts = row.locator('[data-testid="folder-counts"]');
+  if ((await counts.count()) === 0) return { unread: 0, total: 0 };
+  const unread = await counts.getAttribute('data-unread');
+  const total = await counts.getAttribute('data-total');
+  return { unread: Number(unread ?? 0), total: Number(total ?? 0) };
+}
+
+/** Poll until a folder's unread count reaches `expected`. */
+export async function expectFolderUnread(page: Page, sel: FolderSelector, expected: number, timeout = 30000): Promise<void> {
+  await expect
+    .poll(async () => (await folderCounts(page, sel)).unread, { timeout })
+    .toBe(expected);
+}
+
+/** Poll until a folder's total count reaches `expected`. */
+export async function expectFolderTotal(page: Page, sel: FolderSelector, expected: number, timeout = 30000): Promise<void> {
+  await expect
+    .poll(async () => (await folderCounts(page, sel)).total, { timeout })
+    .toBe(expected);
+}
+
+/** Click a folder row to select it. */
+export async function openFolder(page: Page, sel: FolderSelector): Promise<void> {
+  await folderRow(page, sel).first().click();
+}
+
+/** Locator for an email row by (exact) subject. */
+export function emailItem(page: Page, subject: string): Locator {
+  return page.locator(`[data-testid="email-list-item"][data-subject="${subject}"]`);
+}
+
+/** Poll until an email with `subject` is present in the list. */
+export async function expectEmailVisible(page: Page, subject: string, timeout = 20000): Promise<void> {
+  await expect(emailItem(page, subject).first()).toBeVisible({ timeout });
+}

--- a/integration/tests/helpers/app.ts
+++ b/integration/tests/helpers/app.ts
@@ -169,6 +169,31 @@ export async function openFolder(page: Page, sel: FolderSelector): Promise<void>
   await folderRow(page, sel).first().click();
 }
 
+/** Open the "New message" composer and wait for it to render. */
+export async function openComposer(page: Page): Promise<Locator> {
+  await page.locator('[data-tour="compose-button"]').first().click();
+  const composer = page.locator('[data-testid="email-composer"]');
+  await composer.waitFor({ state: 'visible', timeout: 15000 });
+  return composer;
+}
+
+/**
+ * The sender addresses the composer's From control offers.
+ *
+ * With more than one identity the control is a <select> and each choice is an
+ * <option>; with a single identity it collapses to a static <span> that shows
+ * only that address. Returning the raw text of whichever is rendered lets a
+ * test assert on the *set of senders* without caring which shape it took.
+ */
+export async function composerFromOptions(page: Page): Promise<string[]> {
+  const from = page.locator('[data-testid="composer-from"]').first();
+  await from.waitFor({ state: 'visible', timeout: 10000 });
+  if ((await from.locator('option').count()) > 0) {
+    return from.locator('option').allTextContents();
+  }
+  return [await from.innerText()];
+}
+
 /** Locator for an email row by (exact) subject. */
 export function emailItem(page: Page, subject: string): Locator {
   return page.locator(`[data-testid="email-list-item"][data-subject="${subject}"]`);

--- a/integration/tests/helpers/config.ts
+++ b/integration/tests/helpers/config.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared configuration for the integration tests. Values mirror the Stalwart
+ * bootstrap (integration/stalwart/*) and the docker-compose port mappings.
+ * Everything is overridable via env so the suite can run against a differently
+ * mapped stack (e.g. remote CI) without code changes.
+ */
+
+export const DOMAIN = process.env.IT_DOMAIN ?? 'example.org';
+
+/** Shared password for every test mailbox (TEST_ACCOUNT_PASSWORD in .env). */
+export const ACCOUNT_PASSWORD = process.env.IT_ACCOUNT_PASSWORD ?? 'test-pass-123';
+
+/** Webmail app origin (containerised, published on the host). */
+export const WEBMAIL_URL = process.env.IT_WEBMAIL_URL ?? 'http://localhost:3000';
+
+/** Stalwart JMAP + admin base URL (host-published). */
+export const JMAP_URL = process.env.IT_JMAP_URL ?? 'http://localhost:8025';
+
+/** Stalwart SMTP submission listener (host-published, maps to container 587). */
+export const SMTP_HOST = process.env.IT_SMTP_HOST ?? 'localhost';
+export const SMTP_PORT = Number(process.env.IT_SMTP_PORT ?? 1025);
+
+/** Recovery admin — `user:password`, used for stalwart-cli style admin JMAP. */
+export const ADMIN_CREDENTIALS = process.env.IT_ADMIN ?? 'admin:bootstrap-secret';
+
+export interface TestAccount {
+  /** Local part, e.g. "alice". */
+  user: string;
+  /** Full address, e.g. "alice@example.org". */
+  email: string;
+  password: string;
+}
+
+function acct(user: string): TestAccount {
+  return { user, email: `${user}@${DOMAIN}`, password: ACCOUNT_PASSWORD };
+}
+
+/** The mailboxes provisioned by the Stalwart bootstrap plan. */
+export const ACCOUNTS = {
+  alice: acct('alice'),
+  bob: acct('bob'),
+  carol: acct('carol'),
+} as const;
+
+export type AccountKey = keyof typeof ACCOUNTS;

--- a/integration/tests/helpers/config.ts
+++ b/integration/tests/helpers/config.ts
@@ -43,3 +43,14 @@ export const ACCOUNTS = {
 } as const;
 
 export type AccountKey = keyof typeof ACCOUNTS;
+
+/**
+ * The shared *group* account provisioned by the bootstrap (a Stalwart Group
+ * principal, not a login). `carol` is made a member before her first login, so
+ * she sees the group's folders under "Shared" and can send as its address.
+ * Groups have no password of their own — access is via a member's session.
+ * (carol, rather than alice/bob, keeps the sync specs' accounts unshared.)
+ */
+export const GROUP = {
+  team: { user: 'team', email: `team@${DOMAIN}`, memberOf: 'carol' as AccountKey },
+} as const;

--- a/integration/tests/helpers/jmap.ts
+++ b/integration/tests/helpers/jmap.ts
@@ -12,6 +12,8 @@ import { JMAP_URL } from './config';
 
 const CORE = 'urn:ietf:params:jmap:core';
 const MAIL = 'urn:ietf:params:jmap:mail';
+// Identity/* lives under the submission capability, not mail.
+const SUBMISSION = 'urn:ietf:params:jmap:submission';
 
 interface JmapMailbox {
   id: string;
@@ -28,6 +30,9 @@ export class JmapClient {
   private authHeader: string;
   private apiUrl: string;
   accountId = '';
+  /** Every account visible in this user's session (own + shared/group),
+   *  keyed by accountId -> account name (its email address). */
+  accounts: Record<string, string> = {};
 
   private constructor(private email: string, password: string) {
     this.authHeader = 'Basic ' + Buffer.from(`${email}:${password}`).toString('base64');
@@ -46,14 +51,25 @@ export class JmapClient {
     const primary = session.primaryAccounts?.[MAIL];
     if (!primary) throw new Error(`No mail account for ${email} in JMAP session`);
     c.accountId = primary;
+    c.accounts = Object.fromEntries(
+      Object.entries(session.accounts ?? {}).map(([id, a]) => [id, (a as { name: string }).name]),
+    );
     return c;
+  }
+
+  /** Names (email addresses) of the shared/group accounts this user can access,
+   *  i.e. everything in the session except the user's own primary account. */
+  sharedAccountNames(): string[] {
+    return Object.entries(this.accounts)
+      .filter(([id]) => id !== this.accountId)
+      .map(([, name]) => name);
   }
 
   async request(methodCalls: MethodCall[]): Promise<any> {
     const res = await fetch(this.apiUrl, {
       method: 'POST',
       headers: { Authorization: this.authHeader, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ using: [CORE, MAIL], methodCalls }),
+      body: JSON.stringify({ using: [CORE, MAIL, SUBMISSION], methodCalls }),
     });
     if (!res.ok) throw new Error(`JMAP request failed: ${res.status} ${await res.text()}`);
     return res.json();

--- a/integration/tests/helpers/jmap.ts
+++ b/integration/tests/helpers/jmap.ts
@@ -1,0 +1,142 @@
+/**
+ * Minimal JMAP client for test setup/inspection against Stalwart.
+ *
+ * Uses global fetch (Node 18+). Not a full JMAP implementation — just the
+ * pieces the integration tests need: authenticate, read/reset mailboxes,
+ * create folders, and poll for delivery. Assertions on *server* state (via
+ * this client) are kept separate from assertions on *UI* state (via the page),
+ * so a failing test can tell whether the bug is in delivery or in the webmail's
+ * sync.
+ */
+import { JMAP_URL } from './config';
+
+const CORE = 'urn:ietf:params:jmap:core';
+const MAIL = 'urn:ietf:params:jmap:mail';
+
+interface JmapMailbox {
+  id: string;
+  name: string;
+  role: string | null;
+  parentId: string | null;
+  totalEmails: number;
+  unreadEmails: number;
+}
+
+type MethodCall = [string, Record<string, unknown>, string];
+
+export class JmapClient {
+  private authHeader: string;
+  private apiUrl: string;
+  accountId = '';
+
+  private constructor(private email: string, password: string) {
+    this.authHeader = 'Basic ' + Buffer.from(`${email}:${password}`).toString('base64');
+    // Stalwart advertises apiUrl on its configured hostname (mail.example.org);
+    // rewrite onto the reachable origin, exactly as the app client does.
+    this.apiUrl = `${JMAP_URL}/jmap/`;
+  }
+
+  static async connect(email: string, password: string): Promise<JmapClient> {
+    const c = new JmapClient(email, password);
+    const res = await fetch(`${JMAP_URL}/jmap/session`, {
+      headers: { Authorization: c.authHeader },
+    });
+    if (!res.ok) throw new Error(`JMAP session failed for ${email}: ${res.status}`);
+    const session = await res.json();
+    const primary = session.primaryAccounts?.[MAIL];
+    if (!primary) throw new Error(`No mail account for ${email} in JMAP session`);
+    c.accountId = primary;
+    return c;
+  }
+
+  async request(methodCalls: MethodCall[]): Promise<any> {
+    const res = await fetch(this.apiUrl, {
+      method: 'POST',
+      headers: { Authorization: this.authHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ using: [CORE, MAIL], methodCalls }),
+    });
+    if (!res.ok) throw new Error(`JMAP request failed: ${res.status} ${await res.text()}`);
+    return res.json();
+  }
+
+  async mailboxes(): Promise<JmapMailbox[]> {
+    const r = await this.request([['Mailbox/get', { accountId: this.accountId }, '0']]);
+    return r.methodResponses[0][1].list as JmapMailbox[];
+  }
+
+  async mailboxByRole(role: string): Promise<JmapMailbox | undefined> {
+    return (await this.mailboxes()).find((m) => m.role === role);
+  }
+
+  async mailboxByName(name: string): Promise<JmapMailbox | undefined> {
+    return (await this.mailboxes()).find((m) => m.name === name);
+  }
+
+  /** Create a folder (top-level) and return its id. Idempotent by name. */
+  async createMailbox(name: string, parentId: string | null = null): Promise<string> {
+    const existing = await this.mailboxByName(name);
+    if (existing) return existing.id;
+    const r = await this.request([
+      ['Mailbox/set', { accountId: this.accountId, create: { new: { name, parentId } } }, '0'],
+    ]);
+    const created = r.methodResponses[0][1].created?.new;
+    if (!created) throw new Error(`Mailbox/set create failed: ${JSON.stringify(r.methodResponses[0][1])}`);
+    return created.id;
+  }
+
+  async deleteMailboxByName(name: string): Promise<void> {
+    const mb = await this.mailboxByName(name);
+    if (!mb) return;
+    await this.request([
+      ['Mailbox/set', { accountId: this.accountId, onDestroyRemoveEmails: true, destroy: [mb.id] }, '0'],
+    ]);
+  }
+
+  private async allEmailIds(): Promise<string[]> {
+    const r = await this.request([['Email/query', { accountId: this.accountId, limit: 5000 }, '0']]);
+    return r.methodResponses[0][1].ids as string[];
+  }
+
+  /**
+   * Reset a mailbox to a clean slate: destroy every message and delete any
+   * non-system (custom) folder. System folders (Inbox/Sent/Trash/…) are kept.
+   */
+  async reset(): Promise<void> {
+    const ids = await this.allEmailIds();
+    if (ids.length) {
+      await this.request([['Email/set', { accountId: this.accountId, destroy: ids }, '0']]);
+    }
+    const custom = (await this.mailboxes()).filter((m) => !m.role);
+    if (custom.length) {
+      await this.request([
+        ['Mailbox/set', { accountId: this.accountId, onDestroyRemoveEmails: true, destroy: custom.map((m) => m.id) }, '0'],
+      ]);
+    }
+  }
+
+  /** Look up an email id by subject within an optional mailbox. */
+  async findEmailBySubject(subject: string, mailboxId?: string): Promise<any | undefined> {
+    const filter: Record<string, unknown> = { subject };
+    if (mailboxId) filter.inMailbox = mailboxId;
+    const r = await this.request([
+      ['Email/query', { accountId: this.accountId, filter }, '0'],
+      ['Email/get', {
+        accountId: this.accountId,
+        '#ids': { resultOf: '0', name: 'Email/query', path: '/ids' },
+        properties: ['id', 'subject', 'keywords', 'mailboxIds', 'from', 'preview'],
+      }, '1'],
+    ]);
+    return r.methodResponses[1][1].list[0];
+  }
+
+  /** Poll until a message with `subject` is delivered (or throw on timeout). */
+  async waitForEmail(subject: string, opts: { mailboxId?: string; timeoutMs?: number } = {}): Promise<any> {
+    const deadline = Date.now() + (opts.timeoutMs ?? 15000);
+    for (;;) {
+      const found = await this.findEmailBySubject(subject, opts.mailboxId);
+      if (found) return found;
+      if (Date.now() > deadline) throw new Error(`Timed out waiting for email "${subject}" (${this.email})`);
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+}

--- a/integration/tests/helpers/smtp.ts
+++ b/integration/tests/helpers/smtp.ts
@@ -1,0 +1,128 @@
+/**
+ * Dependency-free SMTP submission client.
+ *
+ * Speaks just enough SMTP to authenticate against Stalwart's plaintext
+ * submission listener (AUTH LOGIN, no STARTTLS) and inject a message. Used to
+ * simulate real inbound mail so the webmail's sync behaviour can be observed.
+ * A raw socket keeps the test harness free of a nodemailer dependency.
+ */
+import net from 'node:net';
+import { SMTP_HOST, SMTP_PORT } from './config';
+
+interface SendOptions {
+  host?: string;
+  port?: number;
+  /** Envelope + auth sender, e.g. "alice@example.org". */
+  from: string;
+  /** Auth username; defaults to `from`. */
+  authUser?: string;
+  authPass: string;
+  /** One or more envelope recipients. */
+  to: string | string[];
+  subject: string;
+  /** Plain-text body. */
+  body: string;
+  /** Extra headers (e.g. custom Message-ID / In-Reply-To for threading). */
+  headers?: Record<string, string>;
+}
+
+class SmtpError extends Error {}
+
+function crlf(s: string): string {
+  return s.replace(/\r?\n/g, '\r\n');
+}
+
+/**
+ * Submit a single message. Resolves once the server has accepted it (250 after
+ * end-of-DATA). Rejects on any non-2xx/3xx reply or socket error.
+ */
+export async function sendMail(opts: SendOptions): Promise<void> {
+  const host = opts.host ?? SMTP_HOST;
+  const port = opts.port ?? SMTP_PORT;
+  const recipients = Array.isArray(opts.to) ? opts.to : [opts.to];
+  const authUser = opts.authUser ?? opts.from;
+
+  const socket = net.createConnection({ host, port });
+  socket.setEncoding('utf8');
+  socket.setTimeout(15000);
+
+  let buffer = '';
+  let resolveLine: ((line: string) => void) | null = null;
+  let pendingError: Error | null = null;
+
+  socket.on('data', (chunk: string) => {
+    buffer += chunk;
+    // A complete reply ends with "<code> ...\r\n" (space, not hyphen, after code).
+    const lines = buffer.split('\r\n');
+    for (let i = 0; i < lines.length - 1; i++) {
+      const line = lines[i];
+      if (/^\d{3} /.test(line) && resolveLine) {
+        const r = resolveLine;
+        resolveLine = null;
+        buffer = lines.slice(i + 1).join('\r\n');
+        r(line);
+        return;
+      }
+    }
+  });
+  socket.on('timeout', () => { pendingError = new SmtpError('SMTP timeout'); socket.destroy(); });
+  socket.on('error', (e) => { pendingError = e; });
+
+  const waitReply = (expect: string): Promise<string> =>
+    new Promise((resolve, reject) => {
+      if (pendingError) return reject(pendingError);
+      resolveLine = (line) => {
+        if (!line.startsWith(expect)) {
+          reject(new SmtpError(`Expected ${expect}, got: ${line}`));
+        } else {
+          resolve(line);
+        }
+      };
+    });
+
+  const send = (line: string): void => { socket.write(line + '\r\n'); };
+  const b64 = (s: string) => Buffer.from(s).toString('base64');
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      socket.once('connect', resolve);
+      socket.once('error', reject);
+    });
+    await waitReply('220');
+    send('EHLO integration-tests');
+    await waitReply('250');
+    send('AUTH LOGIN');
+    await waitReply('334');
+    send(b64(authUser));
+    await waitReply('334');
+    send(b64(opts.authPass));
+    await waitReply('235');
+    send(`MAIL FROM:<${opts.from}>`);
+    await waitReply('250');
+    for (const rcpt of recipients) {
+      send(`RCPT TO:<${rcpt}>`);
+      await waitReply('250');
+    }
+    send('DATA');
+    await waitReply('354');
+
+    const headers: Record<string, string> = {
+      From: opts.from,
+      To: recipients.join(', '),
+      Subject: opts.subject,
+      'Content-Type': 'text/plain; charset=utf-8',
+      ...opts.headers,
+    };
+    const headerBlock = Object.entries(headers)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\r\n');
+    // Dot-stuff any line that begins with '.'
+    const safeBody = crlf(opts.body).replace(/\r\n\./g, '\r\n..');
+    send(`${headerBlock}\r\n\r\n${safeBody}\r\n.`);
+    await waitReply('250');
+    send('QUIT');
+    await waitReply('221').catch(() => { /* some servers drop before 221 */ });
+  } finally {
+    socket.destroy();
+  }
+}

--- a/integration/webmail-config/policy.json
+++ b/integration/webmail-config/policy.json
@@ -1,0 +1,7 @@
+{
+  "features": {
+    "unifiedCrossAccountEnabled": true,
+    "crossUnreadViewEnabled": true,
+    "crossAllViewEnabled": true
+  }
+}

--- a/integration/webmail.Dockerfile
+++ b/integration/webmail.Dockerfile
@@ -1,0 +1,33 @@
+# Webmail image for integration testing — runs Next.js in DEVELOPMENT mode.
+#
+# Why dev mode rather than the production Dockerfile at the repo root?
+# The browser talks JMAP directly to Stalwart at http://localhost:8025 (plain
+# HTTP, cross-origin). The app's production Content-Security-Policy pins
+# connect-src to `'self' https:`, which would block that plaintext cross-origin
+# fetch. In development mode proxy.ts widens connect-src to `'self' http:
+# https: ws: wss:` — exactly what a local, TLS-less Stalwart needs. Running
+# from source also ships the integration-test data-testid hooks without a
+# production rebuild.
+#
+# Build context is the repo root (see docker-compose.yml `context: ..`), so the
+# root .dockerignore keeps examples/, integration/ and node_modules out.
+
+FROM node:24-alpine
+WORKDIR /app
+
+# Install dependencies first for layer caching.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# App source (data-testid hooks included).
+COPY . .
+
+ENV NODE_ENV=development
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+EXPOSE 3000
+
+# Bind to 0.0.0.0 so the published port is reachable from the host/browser.
+CMD ["npx", "next", "dev", "-H", "0.0.0.0", "-p", "3000"]

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test:translations": "vitest run --no-isolate lib/__tests__/translations.test.ts",
+    "test:integration": "bash integration/run-tests.sh",
     "prepare": "husky",
     "typecheck": "tsc --noEmit"
   },

--- a/playwright.integration.config.ts
+++ b/playwright.integration.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Integration test config: drives the containerised webmail (+ Stalwart) stack
+ * managed by integration/tests/global-setup.ts. Distinct from the root
+ * playwright.config.ts (fast UI smoke tests against `npm run dev`).
+ *
+ * Run:  npx playwright test -c playwright.integration.config.ts
+ */
+const WEBMAIL_URL = process.env.IT_WEBMAIL_URL ?? 'http://localhost:3000';
+
+export default defineConfig({
+  testDir: './integration/tests',
+  // next dev compiles routes lazily and each test logs in fresh, so give
+  // individual tests and their polling assertions generous headroom.
+  timeout: 90_000,
+  expect: { timeout: 20_000 },
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: 'integration/playwright-report' }]],
+  outputDir: 'integration/test-results',
+  globalSetup: './integration/tests/global-setup.ts',
+  globalTeardown: './integration/tests/global-teardown.ts',
+  use: {
+    baseURL: WEBMAIL_URL,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,8 @@
   ],
   "exclude": [
     "node_modules",
-    "repos"
+    "repos",
+    "examples",
+    "integration"
   ]
 }


### PR DESCRIPTION
## Summary

Adds a self-contained, dockerized end-to-end integration harness that drives the
Bulwark webmail against a real Stalwart mail server with Playwright, plus a first
regression test for issue #569 (the composer's From dropdown should offer shared/
group account identities).

This is the reusable *base* branch that the unified-mailbox feature builds on: it
carries only harness infrastructure and app test-hooks — no feature code — so it
sits directly on `main` and can be reviewed/merged on its own.

## Changes

### Integration harness (integration/) — commit 17d16580

- **Stalwart backend**: `docker-compose.yml` + `stalwart/` image with a
  declarative two-phase bootstrap (`entrypoint.sh`, `plan-bootstrap.ndjson`,
  `plan-accounts.ndjson.tpl`): default domain + admin, the alice/bob/carol test
  mailboxes, submission/IMAP listeners, permissive CORS, cleartext auth for the
  dev lanes, inbound throttles disabled. `stalwart-cli` is host-prefetched and
  COPYed into the image (apt/CDN are unreachable at build time).
- **Webmail**: `webmail.Dockerfile` runs `next dev` — the production CSP pins
  `connect-src 'self' https:` and would block the browser's plaintext cross-
  origin JMAP calls — with the `unifiedCrossAccountEnabled` policy gate mounted.
- **Playwright**: `playwright.integration.config.ts` + `global-setup`/`teardown`
  bring the stack up (or reuse a running one via `IT_NO_DOCKER=1`); `run-tests.sh`
  runs the suite inside the official Playwright container (host browsers are
  unsupported by the 1.59 bundles) over host networking.
- **Helpers**: a dependency-free SMTP submission client, a small JMAP client for
  seeding/inspecting server state, and page helpers (login, add/switch account,
  locale-independent folder-counter reads via `data-testid`).
- **Specs 01–03**: login, single-account sync, multi-account (account-scoped
  Unified Mailbox).
- **App test-hooks**: focused `data-testid`s on the mail UI (folder rows +
  counters, email list items, account switcher, composer). `examples/` and
  `integration/` are excluded from tsconfig/eslint/.dockerignore.
- The multi-account spec `a delivery to a background account bumps the Unified
  Inbox counter` is `test.fixme`'d **on this branch only**: the background-push
  counter fix it exercises lives in the unified-mailbox feature commits, not
  here. It is re-enabled on `feat/unified-mailbox-account-scope`.

### Issue #569 — composer From offers shared/group identities — commit 7fcff648

- **Provisioning, before first login**: a Stalwart `Group` `team@example.org` is
  created in `plan-accounts`, and `carol` is made a member via
  `User.memberGroupIds` in the entrypoint (the group's server-assigned id is
  resolved after `apply`, mirroring the existing `DOMAIN_ID` step). carol — not
  alice/bob — so the single-/multi-account sync specs keep an unshared env.
- **Spec `04-shared-identity`**: logs in as the group member and asserts the
  composer's From selector offers `team@example.org`; a JMAP server-side guard
  first confirms the group account and its `team@` identity are reachable in the
  member's session.
- **App**: `data-testid="composer-from"` on the From `<select>` and its single-
  identity `<span>` fallback.
- **Helpers**: `GROUP` config, `openComposer`/`composerFromOptions`, and JMAP
  client `accounts`/`sharedAccountNames` (Identity/get needs the `submission`
  capability, not `mail`).

## Related Issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #569

The pre-login group-membership scenario **already works with no app change**:
when a user is provisioned into the group before first login, Stalwart returns
the group's `team@` address as an identity on the *member's own account*, so the
app's normal single-account identity load yields `identities.length > 1` and the
From `<select>` renders `team@`. The test is green. #569's remaining gap is the
*other* shapes — an ACL-shared folder from another user, or a second connected
account — whose identities are not merged into the primary account and so still
need the multi-account identity loader to include shared accounts.

##+ Tests

- Integration: specs 01–04 pass in the Playwright container (03's background-
  counter case is `fixme`'d here, see above). Run: `integration/run-tests.sh`
  (or `npm run test:integration`). A stale Stalwart volume must be reset first
  (`cd integration && docker compose down -v`) so the group is provisioned.
- App `tsc --noEmit` clean.
- 
## Type of Change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

[04-shared-identity.webm](https://github.com/user-attachments/assets/d5afc96b-e701-48e6-a5cd-32aea23cb343)

## Notes for Reviewers

Branches directly off `main` (511f9e51). The feature branch
`feat/unified-mailbox-account-scope` shares this branch's harness setup commit
(17d16580) as its base, so **merge this MR first**.
