### PR TITLE
feat(composer): auto-detect paragraph text direction by default

### DIFF
--- a/components/email/text-direction.ts
+++ b/components/email/text-direction.ts
@@ -13,7 +13,12 @@ declare module "@tiptap/core" {
 
 /**
  * Adds a `dir` attribute to block nodes so the composer can mark individual
- * paragraphs/headings as LTR or RTL (Gmail-style right-to-left editing). The
+ * paragraphs/headings as LTR or RTL (Gmail-style right-to-left editing).
+ *
+ * The default is `"auto"`: each block detects its own direction from its first
+ * strong character, so a paragraph typed in English renders LTR and one typed
+ * in Hebrew renders RTL, per block, as you type. The toolbar toggle still pins
+ * an explicit `ltr`/`rtl` when you want to override the auto-detection, and the
  * attribute round-trips to HTML so the direction is preserved in the sent mail.
  */
 export const TextDirection = Extension.create({
@@ -29,10 +34,10 @@ export const TextDirection = Extension.create({
         types: this.options.types,
         attributes: {
           dir: {
-            default: null,
-            parseHTML: (element) => element.getAttribute("dir") || null,
+            default: "auto",
+            parseHTML: (element) => element.getAttribute("dir") || "auto",
             renderHTML: (attributes) =>
-              attributes.dir ? { dir: attributes.dir } : {},
+              attributes.dir ? { dir: attributes.dir } : { dir: "auto" },
           },
         },
       },


### PR DESCRIPTION
## Problem
Composer blocks default to the editor's base direction, so with an RTL UI an English paragraph renders right-aligned (and vice-versa). Users have to hit the direction toggle on every paragraph.

## Change
Default the block `dir` attribute to `"auto"` (was `null`). Each paragraph/heading now detects its own direction from its first strong character — type English → LTR, type Hebrew → RTL — per block, live as you type. The #492 toolbar toggle still pins an explicit `ltr`/`rtl` when you want to override, and the attribute round-trips into the sent HTML so recipients see each block correctly.

One-line change to the existing `TextDirection` extension; no new deps.

## Testing
- Empty composer → type "hello" → block is LTR/left-aligned
- New block → type Hebrew → RTL/right-aligned
- Toolbar toggle still forces a fixed direction and persists
- Sent HTML carries `dir="auto"` (or the pinned dir) per block
- `tsc` clean; lint clean

Follow-up to #492; covers the auto-direction ask from #469.
