### PR TITLE
Use OIDC profile avatars for account switcher

### DIFF
--- a/app/(main)/[locale]/files/page.tsx
+++ b/app/(main)/[locale]/files/page.tsx
@@ -422,6 +422,7 @@ export default function FilesPage() {
           label: a.label || a.email,
           email: a.email,
           avatarColor: a.avatarColor,
+          avatarUrl: a.avatarUrl,
         }))
     : [];
   const isAccountPicker = isEmbedded && currentFilesAccountId === null;

--- a/app/api/auth/sso/complete/route.ts
+++ b/app/api/auth/sso/complete/route.ts
@@ -4,6 +4,7 @@ import { logger } from '@/lib/logger';
 import { decryptPayload } from '@/lib/auth/crypto';
 import {
   exchangeCodeForTokens,
+  fetchUserInfoAvatar,
   getRequiredConfig,
   getTokenEndpoint,
 } from '@/lib/oauth/token-exchange';
@@ -73,6 +74,8 @@ export async function POST(request: NextRequest) {
     // Exchange code for tokens
     const tokens = await exchangeCodeForTokens(code, codeVerifier, redirectUri, pendingServerId);
 
+    const avatarUrl = await fetchUserInfoAvatar(tokens.access_token, pendingServerId).catch(() => undefined);
+
     // For the mobile handoff flow the tokens are handed back to the app
     // verbatim - we deliberately don't write any cookies on the webmail
     // origin (the mobile browser tab disposes of the session after the
@@ -110,12 +113,14 @@ export async function POST(request: NextRequest) {
         server_url: serverUrl,
         mobile_redirect_uri: mobileRedirectUri,
         mobile_state: mobileState,
+        ...(avatarUrl ? { avatar_url: avatarUrl } : {}),
       });
     }
 
     return NextResponse.json({
       access_token: tokens.access_token,
       expires_in: tokens.expires_in,
+      ...(avatarUrl ? { avatar_url: avatarUrl } : {}),
     });
   } catch (error) {
     // Clean up pending cookie on any error

--- a/app/api/auth/token/route.ts
+++ b/app/api/auth/token/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { logger } from '@/lib/logger';
 import { refreshTokenCookieName, refreshTokenServerCookieName } from '@/lib/oauth/tokens';
-import { exchangeCodeForTokens, buildOAuthParams, getMetadata, getTokenEndpoint } from '@/lib/oauth/token-exchange';
+import { exchangeCodeForTokens, buildOAuthParams, fetchUserInfoAvatar, getMetadata, getTokenEndpoint } from '@/lib/oauth/token-exchange';
 import { getCookieOptions } from '@/lib/oauth/cookie-config';
 import { MAX_ACCOUNT_SLOTS } from '@/lib/account-utils';
 
@@ -27,9 +27,12 @@ export async function POST(request: NextRequest) {
 
     const tokens = await exchangeCodeForTokens(code, code_verifier, redirect_uri, serverId);
 
+    const avatarUrl = await fetchUserInfoAvatar(tokens.access_token, serverId).catch(() => undefined);
+
     const response = NextResponse.json({
       access_token: tokens.access_token,
       expires_in: tokens.expires_in,
+      ...(avatarUrl ? { avatar_url: avatarUrl } : {}),
     });
 
     const cookieStore = await cookies();

--- a/components/layout/account-switcher.tsx
+++ b/components/layout/account-switcher.tsx
@@ -25,6 +25,7 @@ function AccountAvatar({ account, size = "sm" }: { account: AccountEntry; size?:
       size="sm"
       className={cn("flex-shrink-0", size === "md" && "w-9 h-9 text-sm")}
       disableFavicon
+      contactPhotoUri={account.avatarUrl}
       fallbackColor={account.avatarColor}
     />
   );

--- a/components/layout/navigation-rail.tsx
+++ b/components/layout/navigation-rail.tsx
@@ -668,6 +668,7 @@ export function NavigationRail({
                     email={account.email || account.username}
                     size="sm"
                     disableFavicon
+                    contactPhotoUri={account.avatarUrl}
                     fallbackColor={account.avatarColor}
                   />
                   {isActive && (

--- a/components/protocol/protocol-account-picker.tsx
+++ b/components/protocol/protocol-account-picker.tsx
@@ -117,6 +117,7 @@ export function ProtocolAccountPicker({
                   size="md"
                   className="shrink-0"
                   disableFavicon
+                  contactPhotoUri={account.avatarUrl}
                   fallbackColor={account.avatarColor}
                 />
 

--- a/components/settings/account-settings.tsx
+++ b/components/settings/account-settings.tsx
@@ -342,6 +342,7 @@ function AccountRow({
           size="sm"
           className="w-9 h-9 text-sm"
           disableFavicon
+          contactPhotoUri={account.avatarUrl}
           fallbackColor={account.avatarColor}
         />
         {isActive && (

--- a/lib/oauth/discovery.ts
+++ b/lib/oauth/discovery.ts
@@ -2,6 +2,7 @@ export interface OAuthMetadata {
   issuer: string;
   authorization_endpoint: string;
   token_endpoint: string;
+  userinfo_endpoint?: string;
   revocation_endpoint?: string;
   end_session_endpoint?: string;
 }
@@ -80,6 +81,7 @@ export async function discoverOAuth(
         const allPublic = await endpointsArePublic([
           data.authorization_endpoint,
           data.token_endpoint,
+          data.userinfo_endpoint,
           data.revocation_endpoint,
           data.end_session_endpoint,
         ], options?.validateEndpoint);
@@ -91,6 +93,7 @@ export async function discoverOAuth(
           issuer: data.issuer,
           authorization_endpoint: data.authorization_endpoint,
           token_endpoint: data.token_endpoint,
+          userinfo_endpoint: data.userinfo_endpoint,
           revocation_endpoint: data.revocation_endpoint,
           end_session_endpoint: data.end_session_endpoint,
         };

--- a/lib/oauth/token-exchange.ts
+++ b/lib/oauth/token-exchange.ts
@@ -91,6 +91,45 @@ export interface TokenResult {
   refresh_token?: string;
 }
 
+export interface UserInfoResult {
+  picture?: string;
+  avatar?: string;
+  avatar_url?: string;
+}
+
+function avatarFromUserInfo(data: unknown): string | undefined {
+  if (!data || typeof data !== 'object') return undefined;
+  const record = data as Record<string, unknown>;
+  const value = record.picture || record.avatar || record.avatar_url;
+  if (typeof value !== 'string') return undefined;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'https:') return undefined;
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+export async function fetchUserInfoAvatar(
+  accessToken: string,
+  serverId?: string | null,
+): Promise<string | undefined> {
+  const metadata = await getMetadata(serverId);
+  if (!metadata?.userinfo_endpoint) return undefined;
+
+  const response = await fetch(metadata.userinfo_endpoint, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    logger.warn('Userinfo request failed', { status: response.status });
+    return undefined;
+  }
+
+  return avatarFromUserInfo(await response.json());
+}
+
 export async function exchangeCodeForTokens(
   code: string,
   codeVerifier: string,

--- a/stores/account-store.ts
+++ b/stores/account-store.ts
@@ -21,6 +21,7 @@ export interface AccountEntry {
   displayName: string;
   email: string;
   avatarColor: string;
+  avatarUrl?: string;
   /** Timestamp of last successful login */
   lastLoginAt: number;
   /** Whether this account is currently connected */
@@ -74,6 +75,7 @@ export const useAccountStore = create<AccountState>()(
                     errorMessage: undefined,
                     lastLoginAt: entry.lastLoginAt,
                     authMode: entry.authMode,
+                    avatarUrl: entry.avatarUrl,
                   }
                 : a
             ),

--- a/stores/auth-store.ts
+++ b/stores/auth-store.ts
@@ -796,7 +796,7 @@ export const useAuthStore = create<AuthState>()(
             throw new Error('token_exchange_failed');
           }
 
-          const { access_token, expires_in } = await tokenRes.json();
+          const { access_token, expires_in, avatar_url } = await tokenRes.json();
 
           const refreshFn = get().refreshAccessToken;
           const client = JMAPClient.withBearer(serverUrl, access_token, '', () => refreshFn());
@@ -832,6 +832,7 @@ export const useAuthStore = create<AuthState>()(
             rememberMe: true,
             displayName: primaryIdentity?.name || username,
             email: primaryIdentity?.email || username,
+            avatarUrl: typeof avatar_url === 'string' ? avatar_url : undefined,
             lastLoginAt: Date.now(),
             isConnected: true,
             hasError: false,
@@ -934,7 +935,7 @@ export const useAuthStore = create<AuthState>()(
             throw new Error(errorData.error || 'token_exchange_failed');
           }
 
-          const { access_token, expires_in } = await ssoRes.json();
+          const { access_token, expires_in, avatar_url } = await ssoRes.json();
 
           const ssoServerUrl = config.jmapServerUrl;
 
@@ -973,6 +974,7 @@ export const useAuthStore = create<AuthState>()(
             rememberMe: true,
             displayName: primaryIdentity?.name || username,
             email: primaryIdentity?.email || username,
+            avatarUrl: typeof avatar_url === 'string' ? avatar_url : undefined,
             lastLoginAt: Date.now(),
             isConnected: true,
             hasError: false,


### PR DESCRIPTION
Adds optional OIDC userinfo avatar support for OAuth/SSO logins.

- Discovers and validates the `userinfo_endpoint`
- Fetches `picture` / `avatar` / `avatar_url` after token exchange
- Stores the avatar URL on account entries
- Uses it for account switcher/account UI avatars, falling back to existing initials/colors

Tested with:
- `bun run typecheck`
- `bun run lint` (existing warnings only)
