### PR TITLE
feat(email-list): add bulk Not-Spam action to selection toolbar in junk

### DIFF
--- a/components/email/email-list.tsx
+++ b/components/email/email-list.tsx
@@ -4,7 +4,7 @@ import { Email, ThreadGroup } from "@/lib/jmap/types";
 import { ThreadListItem } from "./thread-list-item";
 import { EmailContextMenu } from "./email-context-menu";
 import { cn } from "@/lib/utils";
-import { Trash2, Mail, MailX, MailOpen, Loader2, SearchX, AlertTriangle, CalendarClock } from "lucide-react";
+import { Trash2, Mail, MailX, MailOpen, Loader2, SearchX, AlertTriangle, CalendarClock, ShieldCheck } from "lucide-react";
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -191,6 +191,22 @@ export function EmailList({
     }
   };
 
+  const handleBatchUndoSpam = async () => {
+    if (!client || isProcessing) return;
+    setIsProcessing(true);
+    try {
+      const emailIds = Array.from(selectedEmailIds);
+      await batchUndoSpam(client, emailIds);
+      const { toast } = await import('sonner');
+      toast.success(t('../email_viewer.spam.toast_not_spam_batch', { count: emailIds.length }));
+    } catch {
+      const { toast } = await import('sonner');
+      toast.error(t('../email_viewer.spam.error_not_spam'));
+    } finally {
+      setTimeout(() => setIsProcessing(false), 500);
+    }
+  };
+
   const handleBatchDelete = async () => {
     if (!client || isProcessing) return;
 
@@ -357,6 +373,22 @@ export function EmailList({
                 <Mail className="w-4 h-4" />
               )}
             </Button>
+            {effectiveMailboxRole === 'junk' && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleBatchUndoSpam}
+                title={t('../context_menu.not_spam')}
+                disabled={isProcessing}
+                className="text-emerald-600 dark:text-emerald-400 hover:bg-emerald-100/50 dark:hover:bg-emerald-950/30 transition-colors disabled:opacity-50"
+              >
+                {isProcessing ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <ShieldCheck className="w-4 h-4" />
+                )}
+              </Button>
+            )}
             <Button
               variant="ghost"
               size="sm"


### PR DESCRIPTION
## What
Adds a **Not spam** button to the bulk-selection toolbar, shown only when viewing a **junk** folder — alongside the existing mark-read / mark-unread / delete actions. Selecting spam messages and clicking it un-junks them in one shot, instead of having to open the context menu.

## Why
The batch un-spam action already exists (`onBatchUndoSpam` in the context menu); this just surfaces it as a first-class toolbar icon where it's most useful. Matches the discoverability of the other bulk actions.

## Implementation
- New `handleBatchUndoSpam` handler in `email-list.tsx`, reusing the existing `batchUndoSpam` store action and the same success/error toasts as the context-menu path.
- Junk-only toolbar button (`ShieldCheck` icon), gated on `effectiveMailboxRole === 'junk'` (works for the aggregate "All Junk" view too).
- Reuses the existing `context_menu.not_spam` label — **no new i18n keys** (already translated in all locales).

## Testing
- In Junk: select messages → **Not spam** appears → click → messages leave Junk, success toast
- In Inbox/other folders: button not shown
- `tsc` clean; lint clean (no new warnings)
