### PR TITLE
fix(email-composer): hide template buttons when templates are disabled

### DIFF
--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -55,6 +55,7 @@ import { RichTextEditor } from "@/components/email/rich-text-editor";
 import type { Editor } from "@tiptap/react";
 import { htmlToPlainText as htmlToPlainTextShared } from "@/lib/html-to-text";
 import { fileStorage } from "@/lib/plugin-storage";
+import { usePolicyStore } from "@/stores/policy-store";
 
 /**
  * Derives the text/plain alternative from the composer's HTML body, preserving
@@ -289,6 +290,9 @@ export function EmailComposer({
     ? multiAccountIdentities.groups
     : [];
   const primaryIdentity = activeIdentities[0] ?? null;
+
+  const { isFeatureEnabled } = usePolicyStore();
+  const templatesEnabled = isFeatureEnabled('templatesEnabled');
 
   // The signature identity used when embedding the signature into the initial
   // body for "above quote" mode. Mirrors the signatureIdentity derivation
@@ -1132,6 +1136,7 @@ export function EmailComposer({
       const tag = target?.tagName?.toLowerCase();
       if (tag === 'input' || tag === 'textarea' || tag === 'select') return;
       if (target?.getAttribute('contenteditable') === 'true') return;
+      if (!templatesEnabled) return;
       if (e.key === 't' && !e.ctrlKey && !e.metaKey && !e.altKey) {
         e.preventDefault();
         setShowTemplatePicker(true);
@@ -1139,7 +1144,7 @@ export function EmailComposer({
     };
     window.addEventListener('keydown', handleTemplateKey);
     return () => window.removeEventListener('keydown', handleTemplateKey);
-  }, []);
+  }, [templatesEnabled]);
 
   const addFiles = useCallback(async (files: File[]) => {
     if (!client || files.length === 0) return;
@@ -2562,24 +2567,26 @@ export function EmailComposer({
             >
               <Paperclip className="w-4 h-4" />
             </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setShowTemplatePicker(true)}
-              title={t('use_template')}
-              className="h-9 w-9"
-            >
-              <FileText className="w-4 h-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setShowSaveAsTemplate(true)}
-              title={t('save_as_template')}
-              className="h-9 w-9"
-            >
-              <BookmarkPlus className="w-4 h-4" />
-            </Button>
+            {templatesEnabled && <>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setShowTemplatePicker(true)}
+                title={t('use_template')}
+                className="h-9 w-9"
+              >
+                <FileText className="w-4 h-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setShowSaveAsTemplate(true)}
+                title={t('save_as_template')}
+                className="h-9 w-9"
+              >
+                <BookmarkPlus className="w-4 h-4" />
+              </Button>
+            </>}
             {/* Sign/encrypt controls are contributed by crypto plugins via the
                 composer-toolbar slot (rendered below). */}
 


### PR DESCRIPTION
## Summary

Removes the template buttons and keyboard shortcut from `EmailComposer` when the `templatesEnabled` feature gate is disabled. See #639 for more information.

## Changes

- `Use Template` & `Save as Template` buttons are only rendered when `templatesEnabled` is true.
- Templates keyboard shortcut is disabled when `templatesEnabled` is false.

## Related Issues

Fixes #639

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

Before (template buttons visible in composer bottom bar):
<img width="603" height="494" alt="before" src="https://github.com/user-attachments/assets/9af2aa1b-e1e7-4c73-b7c5-5cd149472d5a" />

After (template buttons removed):
<img width="603" height="494" alt="after" src="https://github.com/user-attachments/assets/2da517d8-436b-4783-b60e-29f2db436240" />

## Notes for Reviewers

I'm getting lint warnings from other parts of the code and a Next.js runtime error `Failed to create address book`. None of those are caused by the changes.
