### PR TITLE
feat(templates): add support for HTML templates

### DIFF
--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -1088,7 +1088,7 @@ export function EmailComposer({
       : template.body;
 
     // In plain text mode, use template body as-is; otherwise convert to HTML
-    const bodyContent = plainTextMode
+    const bodyContent = plainTextMode || template.isHTML
       ? filledBody
       : `<p>${filledBody.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '<br>')}</p>`;
 

--- a/components/templates/placeholder-fill-modal.tsx
+++ b/components/templates/placeholder-fill-modal.tsx
@@ -94,7 +94,7 @@ export function PlaceholderFillModal({
             <div className="mt-4 pt-4 border-t border-border">
               <p className="text-xs font-medium text-muted-foreground mb-2">{t('preview')}</p>
               <div className="text-sm text-foreground whitespace-pre-wrap p-3 rounded-md bg-muted/50 border border-border max-h-32 overflow-y-auto">
-                {preview}
+                {template.isHTML ? <div dangerouslySetInnerHTML={{ __html: preview }}></div> : preview}
               </div>
             </div>
           )}

--- a/components/templates/template-form.tsx
+++ b/components/templates/template-form.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Star, Plus } from 'lucide-react';
+import { Star, Plus, Square, CheckSquare } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { validateTemplateName } from '@/lib/template-utils';
 import { BUILT_IN_PLACEHOLDERS } from '@/lib/template-types';
@@ -38,6 +38,7 @@ export function TemplateForm({ template, initialData, onSave, onCancel }: Templa
   const [category, setCategory] = useState(template?.category || '');
   const [subject, setSubject] = useState(template?.subject || initialData?.subject || '');
   const [body, setBody] = useState(template?.body || initialData?.body || '');
+  const [isHTML, setIsHTML] = useState(template?.isHTML || false);
   const [toRecipients, setToRecipients] = useState(
     template?.defaultRecipients?.to?.join(', ') || initialData?.to?.join(', ') || ''
   );
@@ -76,6 +77,7 @@ export function TemplateForm({ template, initialData, onSave, onCancel }: Templa
       name: name.trim(),
       subject,
       body,
+      isHTML,
       category: category.trim(),
       defaultRecipients: to.length || cc.length || bcc.length
         ? { to: to.length ? to : undefined, cc: cc.length ? cc : undefined, bcc: bcc.length ? bcc : undefined }
@@ -190,6 +192,14 @@ export function TemplateForm({ template, initialData, onSave, onCancel }: Templa
           rows={6}
           className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary resize-y"
         />
+        <button
+          type="button"
+          onClick={() => setIsHTML(!isHTML)}
+          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {isHTML ? <CheckSquare className={cn('w-4 h-4')}></CheckSquare> : <Square className={cn('w-4 h-4')}></Square>}
+          HTML
+        </button>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">

--- a/lib/__tests__/template-utils.test.ts
+++ b/lib/__tests__/template-utils.test.ts
@@ -20,6 +20,7 @@ function makeTemplate(overrides: Partial<EmailTemplate> = {}): EmailTemplate {
     name: 'Test Template',
     subject: '',
     body: '',
+    isHTML: false,
     category: '',
     isFavorite: false,
     createdAt: '2026-01-01T00:00:00Z',

--- a/lib/template-types.ts
+++ b/lib/template-types.ts
@@ -3,6 +3,7 @@ export interface EmailTemplate {
   name: string;
   subject: string;
   body: string;
+  isHTML?: boolean;
   category: string;
   defaultRecipients?: {
     to?: string[];

--- a/lib/template-utils.ts
+++ b/lib/template-utils.ts
@@ -173,7 +173,8 @@ export function importTemplates(json: string): ImportResult {
       id: generateUUID(),
       name: sanitizeText(t.name),
       subject: sanitizeText(t.subject),
-      body: sanitizeText(t.body),
+      body: t.isHTML ? String(t.body || '') : sanitizeText(t.body),
+      isHTML: Boolean(t.isHTML),
       category: sanitizeText(t.category),
       defaultRecipients: recipients && typeof recipients === 'object'
         ? {


### PR DESCRIPTION
## Summary

Adds a `isHTML?: boolean;` field to `EmailTemplate`, deciding if the `body: string` should be escaped before template use or not. The `TemplateForm` has an additional button to select between plaintext mode and HTML mode.

## Changes

- `EmailTemplate` has new `isHTML?: boolean` field (since it's optional, it should be backwards compatible)
- `TemplateForm` has new "HTML" checkbox to indicate the body is HTML
- `EmailComposer` only escapes template body if `isHTML` is falsy
- `PlaceholderFillModal` uses `dangerouslySetInnerHTML` if `isHTML` is true
- `importTemplates` does not sanitize (_at all!_) template body if `isHTML` is true

## Related Issues

Closes #620

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

Before:
<img width="611" height="495" alt="before-create" src="https://github.com/user-attachments/assets/a723e7b1-b13b-44bc-a9a6-b26855c8aaf6" />
<img width="611" height="495" alt="before-use" src="https://github.com/user-attachments/assets/6f11674b-dd41-42b0-89f1-f693507128fe" />

After:
<img width="611" height="495" alt="after-create" src="https://github.com/user-attachments/assets/7ff6a725-20f0-471b-867d-da5c2ebc4596" />
<img width="611" height="495" alt="after-use" src="https://github.com/user-attachments/assets/f9fd74ea-e3ad-4676-a30c-06d800ff5c7e" />


## Notes for Reviewers

I'm getting lint warnings from other parts of the code and a Next.js runtime error `Failed to create address book`. None of those are caused by the changes.

The button label (currently just "HTML") should ideally be changed to "Is HTML" (or similar), but that would require translations.

### Security concerns

No sanitization is performed on the templates. This shouldn't be too much of an issue since the templates are written by the user and not downloaded from any other source. Still, however, users may copy HTML from unknown sources or, even worse, import templates without even seeing them. Those templates may contain arbitrary code and lead to Self-XSS.

Ideally, the templates should be sanitized the same way emails are in `EmailViewer` (at least using `DOMPurify`). Isolating them in an iframe likely won't be an option since that would require changes to the `RichTextEditor`.

For now, at least when importing templates, a confirmation modal with a warning should show up for templates written in HTML.