### PR TITLE
feat(plugins) : add onRecipientChipsChange hook

### DIFF
--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -3255,7 +3255,16 @@ function RecipientChipInput({
               onContextMenu={isEditing ? undefined : (e) => handleContextMenu(e, i, chip)}
             >
               {IconComponent ? (
-                <IconComponent className={`w-4 h-4 text-${customColor}`} />
+                                <IconComponent
+                   className={cn(
+                     "w-4 h-4",
+                     customColor === "success"
+                       ? "text-success"
+                       : customColor === "warning"
+                         ? "text-warning"
+                         : "text-destructive"
+                   )}
+                 />
               ) : null}
 
               {isEditing ? (

--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -49,6 +49,8 @@ import {
   waitForPendingUploads,
   extractUserAuthoredText,
   type Recipient,
+  enrichChipsWithColorsAndIcons,
+  ICON_MAP,
 } from "@/lib/email-composer-utils";
 import { isValidEmail } from "@/lib/validation";
 import { RichTextEditor } from "@/components/email/rich-text-editor";
@@ -825,6 +827,26 @@ export function EmailComposer({
     // object identity churn from parent renders shouldn't refetch.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [composerClient, plainTextMode, mode]);
+
+    const processEnrichment = async (
+      recipients: Recipient[],
+      setRecipients: (items: Recipient[]) => void
+    ) => {
+      const hasUnenriched = recipients.some((r) => !r.extra?.enriched);
+      if (!hasUnenriched) return;
+
+        const newChips = await enrichChipsWithColorsAndIcons(recipients);
+        const fullyEnriched = newChips.map((chip) => ({
+          ...chip,
+          extra: { ...chip.extra, enriched: true },
+        }));
+        setRecipients(fullyEnriched);
+    };
+
+
+    useEffect(() => { processEnrichment(to, setTo); }, [to]);
+    useEffect(() => { processEnrichment(cc, setCc); }, [cc]);
+    useEffect(() => { processEnrichment(bcc, setBcc); }, [bcc]);
 
   const composerSignatureHtml = signatureIdentity?.htmlSignature
     ? `<div>${sanitizeSignatureHtmlForDisplay(signatureIdentity.htmlSignature)}</div>`
@@ -3169,6 +3191,11 @@ function RecipientChipInput({
   const handleContainerDrop = (e: React.DragEvent) => {
     performDrop(e, dropIndex ?? chips.length);
   };
+  const colorStyles: Record<'success' | 'destructive' | 'warning', string> = {
+    success: "bg-success/15 text-secondary-foreground hover:bg-success/30 !border-success",
+    destructive: "bg-destructive/15 text-secondary-foreground hover:bg-destructive/30 !border-destructive",
+    warning: "bg-warning/15 text-secondary-foreground hover:bg-warning/30 !border-warning",
+  };
 
   return (
     <div className="flex-1 relative min-w-0">
@@ -3186,6 +3213,12 @@ function RecipientChipInput({
         {chips.map((chip, i) => {
           const isEditing = editingChip?.index === i;
           const chipDisplay = formatChipDisplay(chip);
+          let IconComponent = null;
+          if(chip.extra?.icon){
+             IconComponent = ICON_MAP[chip.extra?.icon];
+          }
+          const customColor = chip.extra?.color;
+
           return (
             <React.Fragment key={`${chip.email}-${i}`}>
             {dropIndex === i && (
@@ -3214,11 +3247,17 @@ function RecipientChipInput({
                 "inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-sm border border-border transition-colors",
                 isEditing
                   ? "bg-background ring-1 ring-ring"
-                  : "bg-secondary text-secondary-foreground hover:bg-accent cursor-grab active:cursor-grabbing",
+                  : ( customColor && colorStyles[customColor]
+                      ? `${colorStyles[customColor]} cursor-grab active:cursor-grabbing`
+                      :  "bg-secondary text-secondary-foreground hover:bg-accent cursor-grab active:cursor-grabbing"),
                 !isEditing && draggingIndex === i && "opacity-50"
               )}
               onContextMenu={isEditing ? undefined : (e) => handleContextMenu(e, i, chip)}
             >
+              {IconComponent ? (
+                <IconComponent className={`w-4 h-4 text-${customColor}`} />
+              ) : null}
+
               {isEditing ? (
                 <input
                   ref={editInputRef}

--- a/lib/email-composer-utils.ts
+++ b/lib/email-composer-utils.ts
@@ -1,6 +1,6 @@
 import { isValidEmail } from "@/lib/validation";
 import { htmlToPlainText } from "@/lib/html-to-text";
-import { emailHooks } from "./plugin-hooks";
+import { emailHooks } from "@/lib/plugin-hooks";
 import { Ellipsis, Lock, TriangleAlert } from "lucide-react";
 
 const HTML_ESCAPE_MAP = {

--- a/lib/email-composer-utils.ts
+++ b/lib/email-composer-utils.ts
@@ -1,5 +1,7 @@
 import { isValidEmail } from "@/lib/validation";
 import { htmlToPlainText } from "@/lib/html-to-text";
+import { emailHooks } from "./plugin-hooks";
+import { Ellipsis, Lock, TriangleAlert } from "lucide-react";
 
 const HTML_ESCAPE_MAP = {
   "&": "&amp;",
@@ -110,6 +112,17 @@ export function extractUserAuthoredText(
 }
 
 /**
+ * Used for hook to let plugins enrich recipient chips with colors and icons. 
+ * The icon is a key into ICON_MAP, which maps to a lucide-react component.
+ */
+export const ICON_MAP = {
+  'lock': Lock,
+  'triangle-alert': TriangleAlert,
+  'ellipsis': Ellipsis,
+};
+type IconName = keyof typeof ICON_MAP;
+
+/**
  * A composer recipient. Display name is optional; email is required - except
  * for contact-group chips, which carry their already-resolved members and an
  * empty email. Group chips are expanded into their members when the message
@@ -119,6 +132,16 @@ export type Recipient = {
   name?: string;
   email: string;
   group?: { members: Array<{ name?: string; email: string }> };
+  extra?: {
+    color?: "success" | "destructive" | "warning"; // optional color for display purposes. May be populated by plugins via the onRecipientChipsChange hook.
+    icon?: IconName; // optional icon for display purposes. May be populated by plugins via the onRecipientChipsChange hook.
+    enriched?: boolean; // optional flag to indicate if the recipient has been enriched by plugins via the onRecipientChipsChange hook.
+  };
+};
+
+/** Enriches recipient chips with colors and icons. */
+export async function enrichChipsWithColorsAndIcons(chips: Recipient[]): Promise<Recipient[]> {
+  return await emailHooks.onRecipientChipsChange.transform(chips);
 };
 
 /**

--- a/lib/plugin-hooks.ts
+++ b/lib/plugin-hooks.ts
@@ -276,6 +276,10 @@ export const emailHooks = {
   // lets plugin edit emails before they are shown in row. Used to populate preview 
   // field for encryption plugins.
   onEmailsFetched: new HookBus(),
+  // Transform hook - lets plugins edit the recipient chips in composer fields.
+  // They can add, remove, or modify chips (e.g. rewrite addresses, add colors/icons).
+  // Take Recipient[] as argument.
+  onRecipientChipsChange: new HookBus(),
 };
 
 // §7.2 Calendar Hooks


### PR DESCRIPTION
## Summary

Add a new transformer hook : `onRecipientChipsChange`. It takes Recipient[] and allow plugins to edits the recipients list and the look of their chips with two new fields added to Recipient list : color and icon.
- The color field can be populated with success, warning or destructive.
- The icon is a string corresponding to the name of the available lucide icon. For now, only three icons are available : Lock, Ellipsis and TriangleAlert. We cannot use all the icon we want because we would have to import them all.

Of course, the list of available icons and colors can be allonged

See screenshots for real world use case.

## Changes
- introduce new transformer hook  `onRecipientChipsChange`
- add 3 new useEffects for the 3 fields to, cc and bcc to call the hook on change.

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo
For demo, this how an encryption plugin would use it to show the user the contact has a public key and the sending will be secure. In this example, we used the "lock" icon and the "success" color.
<img width="219" height="49" alt="Screenshot 2026-07-20 at 17-55-45 New Message - Bulwark Webmail" src="https://github.com/user-attachments/assets/7ee596b5-dba3-48d3-9dd5-5a4fd294c521" />

This could also be used by `External Recipient Warning` plugin when user add a mail from non safe domain in recipients with "warning" color and TriangleAlert icon.

## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
