### PR TITLE
Feat/integration test setup

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -145,6 +145,13 @@ because the UI behaviour is currently incomplete. Worth a look:
 | `IT_WEBMAIL_URL`| `http://localhost:3000` | Webmail origin                                        |
 | `IT_JMAP_URL`   | `http://localhost:8025` | Stalwart JMAP/admin base URL                          |
 | `IT_SMTP_PORT`  | `1025`             | Stalwart submission port                                   |
+| `IT_VIDEO`      | `retain-on-failure`| Video capture: `on` records a `.webm` for **every** test; also `off` / `on-first-retry`. Videos land at `integration/test-results/<test>/video.webm` |
+
+Record videos for a whole run (passing tests included):
+
+```bash
+IT_VIDEO=on integration/run-tests.sh          # or a single spec: IT_VIDEO=on integration/run-tests.sh 01-login
+```
 
 By default the stack is **left running** after the suite so re-runs are fast and
 you can poke around (webmail on :3000, Stalwart admin on :8025). Tear it down

--- a/integration/run-tests.sh
+++ b/integration/run-tests.sh
@@ -12,6 +12,11 @@
 # Usage:
 #   integration/run-tests.sh                 # whole suite
 #   integration/run-tests.sh 01-login        # a single spec (grep on file name)
+#
+# Env:
+#   IT_VIDEO=on   record a video.webm for every test (not just failures);
+#                 also: off | retain-on-failure (default) | on-first-retry.
+#                 e.g. IT_VIDEO=on integration/run-tests.sh 01-login
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -32,5 +37,6 @@ docker run --rm --network host \
   -v "${REPO_ROOT}":/work -w /work \
   -e IT_NO_DOCKER=1 \
   -e HOME=/tmp \
+  -e IT_VIDEO="${IT_VIDEO:-}" \
   "${PW_IMAGE}" \
   npx playwright test -c playwright.integration.config.ts ${FILTER:+"$FILTER"}

--- a/integration/tests/04-shared-identity.spec.ts
+++ b/integration/tests/04-shared-identity.spec.ts
@@ -1,7 +1,14 @@
 import { test, expect } from '@playwright/test';
 import { ACCOUNTS, GROUP } from './helpers/config';
 import { JmapClient } from './helpers/jmap';
-import { login, forceSync, openComposer, composerFromOptions } from './helpers/app';
+import {
+  login,
+  forceSync,
+  openComposer,
+  composerFromOptions,
+  selectComposerFrom,
+  selectedComposerFrom,
+} from './helpers/app';
 
 /**
  * Issue #569 — the composer's "From" dropdown should include identities from
@@ -41,7 +48,7 @@ test.describe('Composer From: shared/group identities (issue #569)', () => {
     expect(groupIdentityEmails).toContain(team.email);
   });
 
-  test('the composer From selector offers the group address', async ({ page }) => {
+  test('the composer From selector offers and can select the group address', async ({ page }) => {
     await login(page, member);
     // Shared accounts/identities are discovered from the JMAP session; give the
     // client a beat to settle them after the first render.
@@ -49,11 +56,21 @@ test.describe('Composer From: shared/group identities (issue #569)', () => {
 
     await openComposer(page);
 
-    // The group address alice can send as should be one of the From choices.
-    // If #569 is unaddressed the control collapses to her own address only and
-    // this poll times out — which is the point: it pins the expected behaviour.
+    // The group address the member can send as should be one of the From
+    // choices. If #569 were unaddressed the control would collapse to her own
+    // address only and this poll would time out — which is the point: it pins
+    // the expected behaviour.
     await expect
       .poll(async () => (await composerFromOptions(page)).join(' | '), { timeout: 15000 })
       .toContain(team.email);
+
+    // Pick the group address as the sender and confirm it becomes the selected
+    // From identity (not just a listed option).
+    await selectComposerFrom(page, team.email);
+    await expect.poll(() => selectedComposerFrom(page), { timeout: 5000 }).toContain(team.email);
+
+    // Hold on the composer so the final video frames clearly show the group
+    // address selected in the From field.
+    await page.waitForTimeout(2000);
   });
 });

--- a/integration/tests/helpers/app.ts
+++ b/integration/tests/helpers/app.ts
@@ -322,6 +322,24 @@ export async function openFolder(page: Page, sel: FolderSelector): Promise<void>
   await folderRow(page, sel).first().click();
 }
 
+/**
+ * Select the composer's From sender whose option text contains `emailNeedle`
+ * (e.g. a shared/group address). Requires the multi-identity <select> to be
+ * rendered. Scrolls it into view first so the change is captured on video.
+ */
+export async function selectComposerFrom(page: Page, emailNeedle: string): Promise<void> {
+  const from = page.locator('[data-testid="composer-from"]').first();
+  await from.scrollIntoViewIfNeeded();
+  const value = await from.locator('option', { hasText: emailNeedle }).first().getAttribute('value');
+  if (!value) throw new Error(`No composer From option matching "${emailNeedle}"`);
+  await from.selectOption(value);
+}
+
+/** The display text of the currently selected From sender. */
+export async function selectedComposerFrom(page: Page): Promise<string> {
+  const from = page.locator('[data-testid="composer-from"]').first();
+  return (await from.locator('option:checked').first().textContent())?.trim() ?? '';
+}
 /** Locator for an email row by (exact) subject. */
 export function emailItem(page: Page, subject: string): Locator {
   return page.locator(`[data-testid="email-list-item"][data-subject="${subject}"]`);

--- a/playwright.integration.config.ts
+++ b/playwright.integration.config.ts
@@ -9,6 +9,19 @@ import { defineConfig } from '@playwright/test';
  */
 const WEBMAIL_URL = process.env.IT_WEBMAIL_URL ?? 'http://localhost:3000';
 
+/**
+ * Video capture mode, overridable via IT_VIDEO. Default `retain-on-failure`
+ * keeps a .webm only for tests that fail. Set `IT_VIDEO=on` to record every
+ * test (e.g. for a demo or to inspect a passing flow), `off` to disable, or
+ * `on-first-retry` to record only when a test is retried. Videos land next to
+ * the other artefacts under `integration/test-results/<test>/video.webm`.
+ */
+type VideoMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry';
+const VIDEO_MODES: VideoMode[] = ['off', 'on', 'retain-on-failure', 'on-first-retry'];
+const VIDEO: VideoMode = VIDEO_MODES.includes(process.env.IT_VIDEO as VideoMode)
+  ? (process.env.IT_VIDEO as VideoMode)
+  : 'retain-on-failure';
+
 export default defineConfig({
   testDir: './integration/tests',
   // next dev compiles routes lazily and each test logs in fresh, so give
@@ -26,7 +39,7 @@ export default defineConfig({
     baseURL: WEBMAIL_URL,
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
-    video: 'retain-on-failure',
+    video: VIDEO,
   },
   projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
 });


### PR DESCRIPTION
## Summary

The dockerized webmail⇆Stalwart harness and the #569 shared-identity test are
now on main. This branch adds two test-only increments on top — no app changes.

## Changes

- **IT_VIDEO option** — Playwright video capture is configurable via `IT_VIDEO`
  (`on` | `off` | `retain-on-failure` [default] | `on-first-retry`), forwarded
  through the Playwright container in `run-tests.sh` and documented in the README.
  `IT_VIDEO=on` records a `.webm` per test (e.g. for a demo), not just on failure.
- **Extend 04-shared-identity** — the #569 spec now also *selects* `team@` as the
  sender and asserts it becomes the active From (not just that it's offered), then
  holds briefly so the recorded video shows it. Adds `selectComposerFrom` /
  `selectedComposerFrom` helpers.

## Related Issues

Closes #569

## Type of Change


- [] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [X] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

## Notes for Reviewers

