### PR TITLE
feat: cleanup all css urls for anti tracking

### DIFF
--- a/lib/__tests__/email-sanitization.test.ts
+++ b/lib/__tests__/email-sanitization.test.ts
@@ -14,6 +14,7 @@ import {
   decodeCssEscapes,
   styleHasExternalUrl,
   stripExternalCssUrls,
+  stripExternalStyleSheetCss,
   blockExternalResourcesOnNode,
   TRANSPARENT_BLOCKED_PIXEL,
 } from '../email-sanitization';
@@ -393,6 +394,42 @@ describe('email-sanitization', () => {
       const style = "background:url('data:image/png;base64,AAAA')";
       expect(styleHasExternalUrl(style)).toBe(false);
       expect(stripExternalCssUrls(style)).toBe(style);
+    });
+  });
+
+  describe('stripExternalStyleSheetCss (<style> block defence-in-depth, #457)', () => {
+    it('strips external url() inside a style rule', () => {
+      expect(stripExternalStyleSheetCss("#x{background:url('http://tracker.example/y')}"))
+        .toBe('#x{background:url()}');
+    });
+
+    it('strips the CSS-escaped url() keyword (\\75\\72\\6C()', () => {
+      expect(stripExternalStyleSheetCss("#x{background:\\75\\72\\6C('http://tracker.example/y')}"))
+        .toBe('#x{background:url()}');
+    });
+
+    it('removes a remote @import (bare-string form)', () => {
+      expect(stripExternalStyleSheetCss('@import "http://tracker.example/s.css";\n#x{color:red}'))
+        .toBe('\n#x{color:red}');
+      expect(stripExternalStyleSheetCss("@import '//tracker.example/s.css';")).toBe('');
+    });
+
+    it('neutralises a remote @import url() form', () => {
+      expect(stripExternalStyleSheetCss('@import url(http://tracker.example/s.css);'))
+        .toBe('@import url();');
+    });
+
+    it('leaves a stylesheet with no external refs unchanged (escapes intact)', () => {
+      const css = '#x{content:"\\2014";background:url(data:image/png;base64,AAAA)}';
+      expect(stripExternalStyleSheetCss(css)).toBe(css);
+    });
+
+    it('blockExternalResourcesOnNode strips a <style> block and reports blocked', () => {
+      const style = parseHtmlSafely(
+        '<body><style>#x{background:url(http://tracker.example/y)}</style></body>',
+      ).body.firstElementChild!;
+      expect(blockExternalResourcesOnNode(style)).toBe(true);
+      expect(style.textContent).toBe('#x{background:url()}');
     });
   });
 

--- a/lib/email-sanitization.ts
+++ b/lib/email-sanitization.ts
@@ -243,6 +243,43 @@ export function stripExternalCssUrls(style: string): string {
   );
 }
 
+/**
+ * Neutralise external references in a full stylesheet (a kept `<style>` block).
+ * The iframe sanitiser keeps `<style>`, so its CSS can auto-load remote
+ * resources (background `url()`, `@font-face`, `@import`) that the per-node
+ * attribute walk in `blockExternalResourcesOnNode` never sees. The strict
+ * iframe CSP already blocks those fetches at the network level; this strips the
+ * references from the CSS text itself as defence-in-depth.
+ *
+ * Escapes are decoded on the WHOLE block first because the "css escape" tracker
+ * escapes the `url` keyword itself (`\75\72\6C(` -> `url(`) - a literal `url(`
+ * match would miss it. Returns the original (escapes intact) when nothing
+ * external is present, so callers can detect a change by identity. (#457)
+ */
+export function stripExternalStyleSheetCss(css: string): string {
+  if (!css) return css;
+  const decoded = decodeCssEscapes(css);
+  if (!/url\(|@import/i.test(decoded)) return css;
+  let changed = false;
+  // External url(...) anywhere in the sheet (also covers `@import url(...)`).
+  let result = decoded.replace(CSS_URL_PATTERN, (full, _q, inner: string) => {
+    if (isExternalResourceUrl(inner)) {
+      changed = true;
+      return 'url()';
+    }
+    return full;
+  });
+  // Bare-string remote import: `@import "http://…"` / `@import '//…'`.
+  result = result.replace(
+    /@import\s+(['"])\s*(?:https?:)?\/\/[^'"]*\1[^;]*;?/gi,
+    () => {
+      changed = true;
+      return '';
+    },
+  );
+  return changed ? result : css;
+}
+
 /** True if a srcset attribute lists at least one external candidate URL. */
 function srcsetHasExternalUrl(srcset: string): boolean {
   return srcset
@@ -331,6 +368,19 @@ export function blockExternalResourcesOnNode(node: Element): boolean {
     node.setAttribute('data-blocked-style', styleAttr);
     node.setAttribute('style', stripExternalCssUrls(styleAttr));
     blocked = true;
+  }
+
+  // <style> block CSS: the iframe sanitiser keeps these, so url()/@font-face/
+  // @import inside them can auto-load remote resources the attribute walk above
+  // never sees. Strip external refs from the stylesheet text (the strict iframe
+  // CSP is the network backstop; this is defence-in-depth). (#457)
+  if (tag === 'STYLE') {
+    const css = node.textContent || '';
+    const cleaned = stripExternalStyleSheetCss(css);
+    if (cleaned !== css) {
+      node.textContent = cleaned;
+      blocked = true;
+    }
   }
 
   return blocked;


### PR DESCRIPTION
## Summary

Defence-in-depth against tracking pixels hidden in `<style>` blocks of rendered
emails. The strict iframe `img-src`/`media-src`/`font-src` CSP already blocks
`<style>`-tag fetches at the network level, but the per-node DOM walk in
`blockExternalResourcesOnNode` only inspects element *attributes* — a tracker
smuggled into a kept `<style>` block (`background: url()`, `@font-face`,
`@import`) never passed through it.

## Changes

- **lib/email-sanitization.ts**
  - `stripExternalStyleSheetCss()` — removes remote `url(...)` and `@import`
    (both `url()` and bare-string forms) from CSS text. Decodes CSS escapes over
    the whole block first, so the escaped-keyword form `\75\72\6C(` → `url(` is
    caught (a literal `url(` match would miss it).
  - Wired into `blockExternalResourcesOnNode` for `STYLE` nodes, gated on
    `shouldBlockExternal` so it drives the blocked-content banner like every
    other external-resource vector.

## Related Issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Related  to #457 

## Type of Change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
