### PR TITLE
fix(i18n): Hebrew Drafts label says 'checkers' (דמקה) instead of טיוטות

### DIFF
--- a/locales/he/common.json
+++ b/locales/he/common.json
@@ -1519,7 +1519,7 @@
       "standard_roles": "תפקידי תיקייה סטנדרטיים",
       "standard_roles_description": "הקצה אילו תיקיות משמשות לתפקידי תיבת דואר סטנדרטיים כמו Inbox, Sent, Trash וכו׳.",
       "role_inbox": "תיבת דואר נכנס",
-      "role_drafts": "דַמקָה",
+      "role_drafts": "טיוטות",
       "role_sent": "נשלח",
       "role_trash": "אַשׁפָּה",
       "role_junk": "ספאם / זבל",


### PR DESCRIPTION
The Hebrew label for the **Drafts** standard folder role is `דַמקָה` — which means *draughts/checkers*, the board game. A machine-translation slip of "drafts".

Correct word is **טיוטות** (drafts, plural).

Visible in Settings → Folders → Standard Folder Roles, and on the Drafts folder's role badge.

One-line locale fix; no code changes.
