### PR TITLE
fix(rtl): auto-detect text direction in read, print and plain-text views

### DIFF
--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -2294,7 +2294,7 @@ export function EmailViewer({
   pre { white-space: pre-wrap; word-wrap: break-word; }
   ${wordHtmlCSS}
   ${darkModeCSS}
-</style></head><body>${effectiveEmailContent.html}<style>html,body{height:auto!important;min-height:0!important;max-height:none!important}</style></body></html>`;
+</style></head><body dir="auto">${effectiveEmailContent.html}<style>html,body{height:auto!important;min-height:0!important;max-height:none!important}</style></body></html>`;
   }, [effectiveEmailContent.html, effectiveEmailContent.isHtml, effectiveEmailContent.hasStyleTag, effectiveEmailContent.externalBlocked, isDark, emailHasNativeDarkMode, messageSpacing]);
 
   // Unblocking external content is handled by rebuilding the iframe srcDoc:
@@ -2669,7 +2669,7 @@ export function EmailViewer({
   .body { font-size: 14px; line-height: 1.6; }
   .body img { max-width: 100% !important; height: auto !important; }
   @media print { body { margin: 20px; } }
-</style></head><body>
+</style></head><body dir="auto">
 <div class="header">
   <div class="subject">${escapeHtml(subjectText)}</div>
   <div class="meta">
@@ -5145,6 +5145,7 @@ export function EmailViewer({
             ) : (
               <div
                 className="email-content-text text-foreground"
+                dir="auto"
                 dangerouslySetInnerHTML={{ __html: sanitizePlainTextRenderedHtml(effectiveEmailContent.html) }}
                 style={{
                   ...(plainTextFont === 'mono' && { fontFamily: 'ui-monospace, "SF Mono", Consolas, monospace' }),

--- a/components/email/thread-conversation-view.tsx
+++ b/components/email/thread-conversation-view.tsx
@@ -460,7 +460,7 @@ function EmailCard({
   table { max-width: 100% !important; table-layout: auto; overflow-wrap: break-word; }
   td, th { word-break: break-word; padding: 0.5rem; }
   pre { white-space: pre-wrap; word-wrap: break-word; }
-</style></head><body>${emailContent.html}</body></html>`;
+</style></head><body dir="auto">${emailContent.html}</body></html>`;
   }, [emailContent.isHtml, emailContent.html]);
 
   const handleIframeLoad = useCallback(() => {

--- a/components/files/eml-preview.tsx
+++ b/components/files/eml-preview.tsx
@@ -41,10 +41,14 @@ function escapeHtml(s: string): string {
 export function EmlPreview({ message }: { message: ParsedEml }) {
   const t = useTranslations("email_viewer");
 
+  // srcDoc gets a fragment, not a document, so the iframe's implicit <body>
+  // is the browser's - left-to-right regardless of what the mail is written
+  // in. dir="auto" on a wrapper we do control lets the first strong character
+  // pick the direction, matching the main viewer.
   const bodyDoc = message.html
-    ? sanitizeEmailHtmlForIframe(message.html)
+    ? `<div dir="auto">${sanitizeEmailHtmlForIframe(message.html)}</div>`
     : message.text
-      ? `<pre style="white-space:pre-wrap;word-break:break-word;font-family:ui-monospace,monospace;margin:0;padding:8px">${escapeHtml(message.text)}</pre>`
+      ? `<pre dir="auto" style="white-space:pre-wrap;word-break:break-word;font-family:ui-monospace,monospace;margin:0;padding:8px">${escapeHtml(message.text)}</pre>`
       : "";
 
   const downloadAttachment = (att: NonNullable<ParsedEml["attachments"]>[number]) => {


### PR DESCRIPTION
## Problem
The reader renders message bodies with the **UI's** direction, not the **message's**. With an RTL UI (Hebrew/Arabic/Persian), an English email is right-aligned; with an LTR UI, a Hebrew email is left-aligned. Mixed-language mail is wrong either way.

## Fix
Add `dir="auto"` in the three places a message body is rendered:
- the sandboxed HTML iframe body
- the print view body
- the plain-text render container

`auto` resolves direction **per block** from its first strong character, so each paragraph aligns by its own content — an English paragraph stays LTR even inside an RTL UI, and vice-versa. Mixed-language messages render each block correctly.

Three attributes, no logic or dependency changes; LTR-only mail is unaffected (`auto` resolves to LTR).

## Testing
- Hebrew email in an English UI → right-aligned ✅
- English email in a Hebrew UI → left-aligned ✅
- Mixed Hebrew/English message → each paragraph aligned by its own content ✅
- Plain-text and print views match the HTML view ✅
- `tsc` clean; lint clean (no new warnings)
