### PR TITLE
feat: add new plugin ui.rerenderFetchedEmails method

### DIFF
--- a/lib/plugin-sandbox/host-api.ts
+++ b/lib/plugin-sandbox/host-api.ts
@@ -63,6 +63,7 @@ const PERM_PER_METHOD: Record<string, Permission | null> = {
   'ui.alert': null,
   'ui.prompt': null,
   'ui.rerenderEmail': null,
+  'ui.rerenderFetchedEmails': null,
   'ui.openExternalUrl': null,
   'ui.downloadFile': 'ui:download-file'
 };
@@ -651,6 +652,13 @@ export async function dispatchApiCall(
       // was just unlocked) so the body re-decrypts without a full reload — which
       // would wipe the in-memory session keys.
       window.dispatchEvent(new CustomEvent('plugin:rerender-email'));
+      return undefined;
+    }
+    case 'ui.rerenderFetchedEmails': {
+      // Re-run the onEmailsFetched hook for the currently shown message list. 
+      // Used by crypto plugins after they change decryption state s
+      // so the preview or others properties re-decrypts without a full reload.
+      window.dispatchEvent(new CustomEvent('plugin:rerender-fetched-emails'));
       return undefined;
     }
     case 'ui.openExternalUrl': {

--- a/lib/plugin-sandbox/protocol.ts
+++ b/lib/plugin-sandbox/protocol.ts
@@ -246,7 +246,7 @@ export const API_METHODS = [
   'upfiles.get', 'upfiles.save',
   'admin.getConfig', 'admin.getAllConfig', 'admin.setConfig', 'admin.deleteConfig',
   'toast.success', 'toast.error', 'toast.info', 'toast.warning',
-  'ui.confirm', 'ui.alert', 'ui.prompt', 'ui.rerenderEmail', 'ui.openExternalUrl', 'ui.downloadFile'
+  'ui.confirm', 'ui.alert', 'ui.prompt', 'ui.rerenderEmail', 'ui.rerenderFetchedEmails', 'ui.openExternalUrl', 'ui.downloadFile'
 ] as const;
 
 export type ApiMethod = (typeof API_METHODS)[number];

--- a/lib/plugin-sandbox/runtime.tsx
+++ b/lib/plugin-sandbox/runtime.tsx
@@ -241,6 +241,7 @@ function buildPluginApi(manifest: PluginManifest) {
       /** Re-runs the onRenderEmailBody hook for the open message (e.g. after a
        *  crypto plugin unlocks a key) so its body re-renders without a reload. */
       rerenderEmail: () => callApi('ui.rerenderEmail', []) as Promise<void>,
+      rerenderFetchedEmails: () => callApi('ui.rerenderFetchedEmails', []) as Promise<void>,
       /** Opens an http/https URL in a new tab via host `window.open`. */
       openExternalUrl: (url: string, target?: string) =>
         callApi('ui.openExternalUrl', [url, target]) as Promise<void>,

--- a/stores/email-store.ts
+++ b/stores/email-store.ts
@@ -757,6 +757,18 @@ function findTrashMailbox(
   });
 }
 
+// Plugin re-render for already fetched emails.
+// Plugins can trigger: window.dispatchEvent(new Event('plugin:rerender-fetched-emails'))
+if (typeof window !== 'undefined') {
+  window.addEventListener('plugin:rerender-fetched-emails', async () => {
+    const state = useEmailStore.getState();
+    const transformed = await emailHooks.onEmailsFetched.transform(state.emails);
+    useEmailStore.setState({
+      emails: annotateScheduledEmails(transformed, state.scheduledSubmissionByEmailId),
+    });
+  });
+}
+
 export const useEmailStore = create<EmailStore>((set, get) => ({
   emails: [],
   mailboxes: [],


### PR DESCRIPTION
## Summary

Add `ui.rerenderFetchedEmails` plugin ui API based on the existing `ui.rerenderEmail` method. It allows plugins to enrich emails without refetch them from server once their S/MIME or PGP key is unlocked.

## Changes

<!-- A bulleted list of the key changes made. -->

- add `rerenderFetchedEmails` ui API method
- add `plugin:rerender-fetched-emails` listener on email-store.ts



## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
