### PR TITLE
feat: add contact methods in plugin API

### DIFF
--- a/lib/plugin-sandbox/host-api.ts
+++ b/lib/plugin-sandbox/host-api.ts
@@ -14,6 +14,7 @@ import { apiFetch } from '../browser-navigation';
 import { awaitDialog, awaitPrompt, type PromptField } from './host-dialog';
 import { fileStorage } from '../plugin-storage';
 import { generateUUID } from '../utils';
+import { ContactCard } from '../jmap/types';
 
 /**
  * Methods only callable from the privileged (same-origin) tier. These expose
@@ -56,6 +57,11 @@ const PERM_PER_METHOD: Record<string, Permission | null> = {
   'upfiles.get' : 'email:blob-write',
   'upfiles.save' : 'email:blob-write',
   'webauthn.getOrCreate': 'crypto:full',
+  // contact
+  'contact.get': 'contacts:read',
+  'contact.update': 'contacts:write',
+  'contact.create': 'contacts:write',
+  'contact.search': 'contacts:read',
   // admin
   'admin.getConfig': 'admin:config',
   'admin.getAllConfig': 'admin:config',
@@ -388,6 +394,40 @@ async function doJmapImportRaw(
   );
 }
 
+async function doContactSearch(query: string): Promise<ContactCard[]> {
+    const { client } = useAuthStore.getState();
+  if (!client) {
+    throw new Error('jmap.importRaw: no active session');
+  }
+  return await client.searchContacts(query);
+}
+
+async function doContactGet(contactId: string): Promise<ContactCard | null> {
+    const { client } = useAuthStore.getState();
+  if (!client) {
+    throw new Error('jmap.importRaw: no active session');
+  }
+  return await client.getContact(contactId);
+}
+
+async function doContactUpdate(id: string, contact: Partial<ContactCard>): Promise<void> {
+    const { client } = useAuthStore.getState();
+  if (!client) {
+    throw new Error('jmap.importRaw: no active session');
+  }
+
+  await client.updateContact(id, contact);
+}
+
+async function doContactCreate(contact: ContactCard): Promise<ContactCard> {
+    const { client } = useAuthStore.getState();
+      if (!client) {
+    throw new Error('jmap.importRaw: no active session');
+  }
+
+  return await client.createContact(contact);
+}
+
 // ─── WebAuthn (privileged tier) ─────────────────────────────────────────────
 
 // This salt acts as a constant context identifier for key derivation.
@@ -699,6 +739,11 @@ export async function dispatchApiCall(
     case 'upfiles.get' : return getFile(args[0] as string);
     case 'upfiles.save' : return saveFile(args[0] as string, args[1] as File);
     case 'webauthn.getOrCreate': return doGetOrCreatePRF(args[0] as number[] | undefined, args[1] as string | undefined, args[2] as string | undefined);
+    
+    case 'contact.get': return doContactGet(args[0] as string);
+    case 'contact.update': return doContactUpdate(args[0] as string, args[1] as Partial<ContactCard>);
+    case 'contact.create': return doContactCreate(args[0] as ContactCard);
+    case 'contact.search': return doContactSearch(args[0] as string);
 
     case 'admin.getConfig':    return adminGet(plugin.id, args[0] as string);
     case 'admin.getAllConfig': return adminGetAll(plugin.id);

--- a/lib/plugin-sandbox/host-api.ts
+++ b/lib/plugin-sandbox/host-api.ts
@@ -397,7 +397,7 @@ async function doJmapImportRaw(
 async function doContactSearch(query: string): Promise<ContactCard[]> {
     const { client } = useAuthStore.getState();
   if (!client) {
-    throw new Error('jmap.importRaw: no active session');
+    throw new Error('contact.search: no active session');
   }
   return await client.searchContacts(query);
 }
@@ -405,7 +405,7 @@ async function doContactSearch(query: string): Promise<ContactCard[]> {
 async function doContactGet(contactId: string): Promise<ContactCard | null> {
     const { client } = useAuthStore.getState();
   if (!client) {
-    throw new Error('jmap.importRaw: no active session');
+    throw new Error('contact.get: no active session');
   }
   return await client.getContact(contactId);
 }
@@ -413,7 +413,7 @@ async function doContactGet(contactId: string): Promise<ContactCard | null> {
 async function doContactUpdate(id: string, contact: Partial<ContactCard>): Promise<void> {
     const { client } = useAuthStore.getState();
   if (!client) {
-    throw new Error('jmap.importRaw: no active session');
+    throw new Error('contact.update: no active session');
   }
 
   await client.updateContact(id, contact);
@@ -422,7 +422,7 @@ async function doContactUpdate(id: string, contact: Partial<ContactCard>): Promi
 async function doContactCreate(contact: ContactCard): Promise<ContactCard> {
     const { client } = useAuthStore.getState();
       if (!client) {
-    throw new Error('jmap.importRaw: no active session');
+    throw new Error('contact.create: no active session');
   }
 
   return await client.createContact(contact);

--- a/lib/plugin-sandbox/protocol.ts
+++ b/lib/plugin-sandbox/protocol.ts
@@ -244,6 +244,7 @@ export const API_METHODS = [
   'webauthn.getOrCreate',
   'jmap.fetchBlob', 'jmap.sendRaw',
   'upfiles.get', 'upfiles.save',
+  'contact.get', 'contact.update', 'contact.create', 'contact.search',
   'admin.getConfig', 'admin.getAllConfig', 'admin.setConfig', 'admin.deleteConfig',
   'toast.success', 'toast.error', 'toast.info', 'toast.warning',
   'ui.confirm', 'ui.alert', 'ui.prompt', 'ui.rerenderEmail', 'ui.rerenderFetchedEmails', 'ui.openExternalUrl', 'ui.downloadFile',

--- a/lib/plugin-sandbox/runtime.tsx
+++ b/lib/plugin-sandbox/runtime.tsx
@@ -29,6 +29,7 @@ import type {
 } from './protocol';
 import { themeSnapshotToCSS, type ThemeSnapshot } from './host-theme';
 import type { SlotName } from '../plugin-types';
+import { ContactCard } from '../jmap/types';
 
 // ─── Module-scope state ──────────────────────────────────────
 
@@ -203,6 +204,12 @@ function buildPluginApi(manifest: PluginManifest) {
         mailboxRoles: string[],
         opts?:  { keywords?: Record<string, boolean>; accountId?: string },
       ) => callApi('jmap.importRaw', [rawBytes, mailboxRoles, opts]),
+    },
+    contacts: {
+      get: (contactId: string) => callApi('contact.get', [contactId]) as Promise<ContactCard>,
+      update: (contactId: string, updates: Partial<ContactCard>) => callApi('contact.update', [contactId, updates]),
+      create: (contact: ContactCard) => callApi('contact.create', [contact]) as Promise<string>,
+      search: (query: string) => callApi('contact.search', [query]) as Promise<ContactCard[]>,
     },
     /**
      * Used to alterate files before they are uploaded to server.


### PR DESCRIPTION
## Summary
Add contact plugin API endpoints.
- search
- edit
- create
- get

It could be used by a plugin to add an pgp public key in contact data for example.
## Changes
- new **unprivileged** contact endpoint
```
contacts: {
      get: (contactId: string) => callApi('contact.get', [contactId]) as Promise<ContactCard>,
      update: (contactId: string, updates: Partial<ContactCard>) => callApi('contact.update', [contactId, updates]),
      create: (contact: ContactCard) => callApi('contact.create', [contact]) as Promise<string>,
      search: (query: string) => callApi('contact.search', [query]) as Promise<ContactCard[]>,
    },
```
- We use the permissions which already exist : `contacts:read` and `contacts:write`

## Related Issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
