### PR TITLE
feat: add contact-cryptokeys plugin UI slot

### DIFF
--- a/components/contacts/contact-detail.tsx
+++ b/components/contacts/contact-detail.tsx
@@ -12,6 +12,8 @@ import { ContactActivity } from "./contact-activity";
 import { toast } from "@/stores/toast-store";
 import { exportContact } from "./contact-export";
 import { printContact } from "./contact-print";
+import { usePluginSlotOffers } from "@/hooks/use-plugin-slot-offers";
+import { PluginSlot } from "@/components/plugins/plugin-slot";
 
 type MoreItem =
   | {
@@ -118,6 +120,7 @@ export function ContactDetail({ contact, onEdit, onDelete, onAddToGroup, onDupli
   const t = useTranslations("contacts");
 
   const cryptoKeys = contact?.cryptoKeys ? Object.values(contact.cryptoKeys) : [];
+  const hasCryptoKeysSlotOffers = usePluginSlotOffers('contact-cryptokeys').length > 0;
 
   if (!contact) {
     return (
@@ -426,7 +429,12 @@ export function ContactDetail({ contact, onEdit, onDelete, onAddToGroup, onDupli
         {cryptoKeys.length > 0 && (
           <Section title={t("detail.crypto_keys")}>
             <div className="space-y-3">
-              {cryptoKeys.map((key, i) => (
+
+             {hasCryptoKeysSlotOffers && (
+              <PluginSlot name="contact-cryptokeys" extraProps={{ cryptoKeys }} />
+              )}
+
+              {!hasCryptoKeysSlotOffers &&cryptoKeys.map((key, i) => (
                 <div key={i} className="rounded-md border border-border/60 bg-muted/30 p-3 space-y-1">
                   <div className="flex items-start gap-2 text-sm break-all">
                     <KeyRound className="w-4 h-4 text-muted-foreground mt-0.5 flex-shrink-0" />

--- a/lib/__tests__/plugin-types.test.ts
+++ b/lib/__tests__/plugin-types.test.ts
@@ -39,6 +39,7 @@ describe('plugin-types constants', () => {
       expect(ALL_PERMISSIONS).toContain('ui:toolbar');
       expect(ALL_PERMISSIONS).toContain('ui:email-banner');
       expect(ALL_PERMISSIONS).toContain('ui:email-footer');
+      expect(ALL_PERMISSIONS).toContain('ui:contact-cryptokeys');
       expect(ALL_PERMISSIONS).toContain('ui:composer-toolbar');
       expect(ALL_PERMISSIONS).toContain('ui:sidebar-widget');
       expect(ALL_PERMISSIONS).toContain('ui:settings-section');

--- a/lib/plugin-types.ts
+++ b/lib/plugin-types.ts
@@ -287,7 +287,8 @@ export type SlotName =
   | 'context-menu-email'
   | 'navigation-rail-bottom'
   | 'calendar-event-actions'
-  | 'admin-plugin-page';
+  | 'admin-plugin-page'
+  | 'contact-cryptokeys';
 
 export interface SlotRegistration {
   pluginId: string;
@@ -1036,7 +1037,7 @@ export const ALL_PERMISSIONS = [
   'security:read',
   'auth:observe',
   'http:post', 'http:fetch',
-  'ui:observe', 'ui:toolbar', 'ui:app-top-banner', 'ui:email-banner', 'ui:email-footer',
+  'ui:observe', 'ui:toolbar', 'ui:app-top-banner', 'ui:email-banner', 'ui:email-footer', 'ui:contact-cryptokeys',
   'ui:email-details',
   'ui:download-file',
   // Register native message-list category tabs (Gmail-style inbox tabs).


### PR DESCRIPTION
## Summary

In contact card, we add new UI slot to allow plugins to take cryptokeys and render them. See example in last section. If no plugins is available, we use the former UI where we see the dataURI. Of course, the slot or the former UI is shown only if there are keys.

## Changes

- add `contact-cryptokeys` UI slot
- add `ui:contact-cryptokeys` permission

## Related Issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo
Example of how a crypto plugin could use this slot to decrypt the cryptokeys dataURI and show relevant info.
<!-- For UI changes, add before/after screenshots or a screen recording. -->
<img width="953" height="152" alt="Screenshot 2026-07-24 at 17-57-45 Aurion Webmail" src="https://github.com/user-attachments/assets/4e504269-198c-4967-969a-1bca2bb4786c" />


## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
