### PR TITLE
feat(settings): always show the Unified Mailbox switch in Layout sett…

### DIFF
--- a/components/settings/layout-settings.tsx
+++ b/components/settings/layout-settings.tsx
@@ -245,7 +245,7 @@ export function LayoutSettings() {
         />
       </SettingItem>
 
-      {(accounts.length > 1 || hasGroupInboxes) && !isSettingHidden('enableUnifiedMailbox') && (
+      {!isSettingHidden('enableUnifiedMailbox') && (
         <SettingItem
           label={t('unified_mailbox.label')}
           description={t('unified_mailbox.description')}


### PR DESCRIPTION
## Summary

The "Unified Mailbox" toggle in Settings → Layout was hidden for single-account users with no visible shared folder, so they had no way to turn the feature on.

## Changes

Drop the `accounts.length > 1 || hasGroupInboxes` gate that hid the Unified Mailbox toggle for single-account users with no visible shared folder. The admin `isSettingHidden('enableUnifiedMailbox')` policy gate is preserved, so admins can still hide it.
- 

## Related Issues

Related to #497

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [ X] I have tested my changes locally
- [X] I have added or updated documentation if needed
- [X] I have updated translations (`locales/`) if my changes affect user-facing text
- [X] I have included screenshots or a screen recording for UI changes

## Screenshots / Demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for Reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
