### PR TITLE
fix(i18n): resolve cross-namespace keys via root translator (../ never worked)

### DIFF
--- a/components/email/email-list.tsx
+++ b/components/email/email-list.tsx
@@ -80,6 +80,9 @@ export function EmailList({
   onRescheduleScheduled,
 }: EmailListProps) {
   const t = useTranslations('email_list');
+  // next-intl has no relative ("../") namespace navigation; cross-namespace keys
+  // must be absolute paths resolved from a root translator.
+  const tRoot = useTranslations();
   const { client } = useAuthStore();
   const {
     selectedEmailIds,
@@ -198,10 +201,10 @@ export function EmailList({
       const emailIds = Array.from(selectedEmailIds);
       await batchUndoSpam(client, emailIds);
       const { toast } = await import('sonner');
-      toast.success(t('../email_viewer.spam.toast_not_spam_batch', { count: emailIds.length }));
+      toast.success(tRoot('email_viewer.spam.toast_not_spam_batch', { count: emailIds.length }));
     } catch {
       const { toast } = await import('sonner');
-      toast.error(t('../email_viewer.spam.error_not_spam'));
+      toast.error(tRoot('email_viewer.spam.error_not_spam'));
     } finally {
       setTimeout(() => setIsProcessing(false), 500);
     }
@@ -378,7 +381,7 @@ export function EmailList({
                 variant="ghost"
                 size="sm"
                 onClick={handleBatchUndoSpam}
-                title={t('../context_menu.not_spam')}
+                title={tRoot('context_menu.not_spam')}
                 disabled={isProcessing}
                 className="text-emerald-600 dark:text-emerald-400 hover:bg-emerald-100/50 dark:hover:bg-emerald-950/30 transition-colors disabled:opacity-50"
               >
@@ -614,11 +617,11 @@ export function EmailList({
                 await batchMarkAsSpam(client, emailIds);
                 const { toast } = await import('sonner');
                 toast.success(
-                  t('../email_viewer.spam.toast_batch', { count: emailIds.length })
+                  tRoot('email_viewer.spam.toast_batch', { count: emailIds.length })
                 );
               } catch {
                 const { toast } = await import('sonner');
-                toast.error(t('../email_viewer.spam.error'));
+                toast.error(tRoot('email_viewer.spam.error'));
               }
             }
           }}
@@ -629,11 +632,11 @@ export function EmailList({
                 await batchUndoSpam(client, emailIds);
                 const { toast } = await import('sonner');
                 toast.success(
-                  t('../email_viewer.spam.toast_not_spam_batch', { count: emailIds.length })
+                  tRoot('email_viewer.spam.toast_not_spam_batch', { count: emailIds.length })
                 );
               } catch {
                 const { toast } = await import('sonner');
-                toast.error(t('../email_viewer.spam.error_not_spam'));
+                toast.error(tRoot('email_viewer.spam.error_not_spam'));
               }
             }
           }}

--- a/components/settings/about-data-settings.tsx
+++ b/components/settings/about-data-settings.tsx
@@ -51,6 +51,7 @@ function VersionUpdateTag() {
 export function AboutDataSettings() {
   const t = useTranslations('settings.advanced');
   const tCommon = useTranslations('common');
+  const tRoot = useTranslations();
   const { settingsSyncDisabled, updateSetting, resetToDefaults, exportSettings, importSettings } =
     useSettingsStore();
   const { settingsSyncEnabled } = useConfig();
@@ -99,9 +100,9 @@ export function AboutDataSettings() {
       const json = event.target?.result as string;
       const success = importSettings(json);
       if (success) {
-        alert(t('../../settings.import_success'));
+        alert(tRoot('settings.import_success'));
       } else {
-        alert(t('../../settings.import_error'));
+        alert(tRoot('settings.import_error'));
       }
     };
     reader.readAsText(file);
@@ -120,7 +121,7 @@ export function AboutDataSettings() {
     if (showResetConfirm) {
       resetToDefaults();
       setShowResetConfirm(false);
-      alert(t('../../settings.save_success'));
+      alert(tRoot('settings.save_success'));
     } else {
       setShowResetConfirm(true);
       setTimeout(() => setShowResetConfirm(false), 5000);

--- a/components/settings/account-settings.tsx
+++ b/components/settings/account-settings.tsx
@@ -31,6 +31,7 @@ function firstScopedTab(caps: SharedAccount['capabilities']): string | null {
 
 export function AccountSettings() {
   const t = useTranslations('settings.account');
+  const tRoot = useTranslations();
   const router = useRouter();
   const { username, serverUrl, isDemoMode, primaryIdentity, authMode, client } = useAuthStore();
   const activeAccountId = useAuthStore((s) => s.activeAccountId);
@@ -117,12 +118,12 @@ export function AccountSettings() {
       <SettingsSection title={t('title')} description={t('description')}>
         {/* Display Name */}
         <SettingItem label={t('name_label')}>
-          <span className="text-sm text-foreground">{displayName || t('../../common.unknown')}</span>
+          <span className="text-sm text-foreground">{displayName || tRoot('common.unknown')}</span>
         </SettingItem>
 
         {/* Email Address */}
         <SettingItem label={t('email.label')}>
-          <span className="text-sm text-foreground">{email || t('../../common.unknown')}</span>
+          <span className="text-sm text-foreground">{email || tRoot('common.unknown')}</span>
         </SettingItem>
 
         {/* Username / Login (show when it differs from email) */}
@@ -142,7 +143,7 @@ export function AccountSettings() {
         {/* Server */}
         <SettingItem label={t('server.label')}>
           <span className="text-sm text-foreground truncate max-w-xs">
-            {serverUrl || t('../../common.unknown')}
+            {serverUrl || tRoot('common.unknown')}
           </span>
         </SettingItem>
 


### PR DESCRIPTION
## Bug
Several components call `t('../namespace.key')` (or `t('../../namespace.key')`) to reach a key in a **different** top-level namespace. next-intl has **no relative (`../`) namespace navigation** — the string is treated as a literal key inside the current namespace, isn't found, and next-intl returns the raw fallback.

Most visible case: the bulk **Not spam** toolbar button in the junk folder shows a tooltip of literally `email_list.../context_menu.not_spam` instead of the translated label. The batch spam/undo-spam toasts and a few settings strings hit the same bug (less visible because they're transient or English-only fallbacks that happen to read fine).

## Fix
Resolve cross-namespace keys through a **root translator** (`useTranslations()` with no namespace) and reference the key by its **absolute** path — no `../`.

Affected call sites:
- `components/email/email-list.tsx` — `context_menu.not_spam` (button title) + 5 `email_viewer.spam.*` toasts
- `components/settings/account-settings.tsx` — 3× `common.unknown`
- `components/settings/about-data-settings.tsx` — `settings.import_success` / `import_error` / `save_success`

No string/key changes; every target key already exists at its absolute path.

## Testing
- Junk folder → select messages → **Not spam** tooltip now shows the translated label (e.g. Hebrew "לא ספאם") instead of the raw key
- Batch mark-as-spam / not-spam toasts show real text
- Settings → Account "Unknown" placeholders and About → import/reset alerts localize correctly
- `tsc` clean; lint clean (no new warnings)
