### PR TITLE
fix: admin default theme not applied for new users; force LTR on login inputs

### DIFF
--- a/app/(main)/[locale]/login/page.tsx
+++ b/app/(main)/[locale]/login/page.tsx
@@ -1056,6 +1056,7 @@ export default function LoginPage() {
                       <Input
                         id="jmap-endpoint"
                         type="url"
+                        dir="ltr"
                         value={jmapEndpoint}
                         onChange={(e) => setJmapEndpoint(e.target.value)}
                         className="h-11 px-3.5 bg-muted/40 border-border/60 rounded-xl focus:bg-background focus:border-primary/50 transition-all duration-200"
@@ -1078,6 +1079,7 @@ export default function LoginPage() {
                         ref={inputRef}
                         id="username"
                         type="text"
+                        dir="ltr"
                         value={formData.username}
                         onChange={handleUsernameChange}
                         onFocus={handleUsernameFocus}
@@ -1131,6 +1133,7 @@ export default function LoginPage() {
                       <Input
                         id="password"
                         type={showPassword ? "text" : "password"}
+                        dir="ltr"
                         value={formData.password}
                         onChange={(e) => setFormData({ ...formData, password: e.target.value })}
                         className="h-11 px-3.5 pe-11 bg-muted/40 border-border/60 rounded-xl focus:bg-background focus:border-primary/50 transition-all duration-200"
@@ -1181,6 +1184,7 @@ export default function LoginPage() {
                         ref={totpInputRef}
                         id="totp"
                         type="text"
+                        dir="ltr"
                         inputMode="numeric"
                         maxLength={6}
                         value={totpCode}

--- a/app/(main)/admin/login/page.tsx
+++ b/app/(main)/admin/login/page.tsx
@@ -66,6 +66,7 @@ export default function AdminLoginPage() {
             <input
               id="password"
               type="password"
+              dir="ltr"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground transition-all duration-200 placeholder:text-muted-foreground hover:border-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:border-ring"

--- a/stores/theme-store.ts
+++ b/stores/theme-store.ts
@@ -37,6 +37,11 @@ interface ThemeState {
   // Custom theme system
   installedThemes: InstalledTheme[];
   activeThemeId: string | null; // null = built-in default
+  // Whether the user has ever explicitly picked a theme (including "Default")
+  // via activateTheme(). Distinguishes "chose Default on purpose" from "never
+  // decided yet" - both look like activeThemeId === null - so the admin's
+  // policy default can be applied to the latter without stomping the former.
+  themeChoiceMade: boolean;
 
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
@@ -83,6 +88,7 @@ export const useThemeStore = create<ThemeState>()(
       hydrated: false,
       installedThemes: [...BUILTIN_THEMES],
       activeThemeId: null,
+      themeChoiceMade: false,
 
       setTheme: (theme) => {
         const resolvedTheme = theme === 'system' ? getSystemTheme() : theme;
@@ -105,7 +111,7 @@ export const useThemeStore = create<ThemeState>()(
       },
 
       initializeTheme: () => {
-        const { theme, activeThemeId, installedThemes } = get();
+        const { theme, activeThemeId, installedThemes, themeChoiceMade } = get();
         const resolvedTheme = theme === 'system' ? getSystemTheme() : theme;
         applyTheme(resolvedTheme);
         set({ resolvedTheme, hydrated: true });
@@ -113,7 +119,7 @@ export const useThemeStore = create<ThemeState>()(
         // Determine effective theme: forced theme > user choice > policy default > none
         const forcedThemeId = getForcedThemeId(installedThemes);
         let effectiveThemeId = forcedThemeId ?? activeThemeId;
-        if (!effectiveThemeId) {
+        if (!effectiveThemeId && !themeChoiceMade) {
           const policyState = usePolicyStore.getState();
           const tp = policyState.policy.themePolicy;
           if (tp?.defaultThemeId) {
@@ -146,6 +152,49 @@ export const useThemeStore = create<ThemeState>()(
               });
             }
           }
+        }
+
+        // The admin's policy default (themePolicy.defaultThemeId) almost
+        // always loses the race above: /api/admin/policy is only fetched
+        // after /api/config resolves (see hooks/use-config.ts), so a
+        // brand-new user (activeThemeId still null, themeChoiceMade still
+        // false) boots into the built-in look every time, and that "no
+        // theme" state then gets persisted, making it permanent instead of
+        // self-correcting on the next load. Re-check once policy actually
+        // arrives, but only if the user still hasn't made their own choice
+        // in the meantime.
+        const applyPolicyDefaultIfPending = () => {
+          if (get().themeChoiceMade) return;
+          const current = get().installedThemes;
+          if (getForcedThemeId(current)) return;
+          const defaultId = usePolicyStore.getState().policy.themePolicy?.defaultThemeId;
+          if (!defaultId || get().activeThemeId === defaultId) return;
+          const t = current.find(it => it.id === defaultId);
+          if (!t) return;
+          if (t.css) {
+            applyCustomThemeCSS(t, get().resolvedTheme);
+            set({ activeThemeId: defaultId });
+          } else {
+            pluginStorage.getThemeCSS(defaultId).then(css => {
+              if (!css || get().themeChoiceMade) return;
+              const hydrated = { ...t, css };
+              applyCustomThemeCSS(hydrated, get().resolvedTheme);
+              set(state => ({
+                activeThemeId: defaultId,
+                installedThemes: state.installedThemes.map(it => it.id === defaultId ? hydrated : it),
+              }));
+            });
+          }
+        };
+
+        if (usePolicyStore.getState().loaded) {
+          applyPolicyDefaultIfPending();
+        } else {
+          const unsubscribe = usePolicyStore.subscribe((state) => {
+            if (!state.loaded) return;
+            unsubscribe();
+            applyPolicyDefaultIfPending();
+          });
         }
 
         // Clean up previous listener if any
@@ -297,7 +346,7 @@ export const useThemeStore = create<ThemeState>()(
         if (id === null) {
           removeThemeCSS();
           removeThemeSkinCSS();
-          set({ activeThemeId: null });
+          set({ activeThemeId: null, themeChoiceMade: true });
           return;
         }
 
@@ -317,12 +366,12 @@ export const useThemeStore = create<ThemeState>()(
               ),
             }));
           });
-          set({ activeThemeId: id });
+          set({ activeThemeId: id, themeChoiceMade: true });
           return;
         }
 
         applyCustomThemeCSS(theme, resolvedTheme);
-        set({ activeThemeId: id });
+        set({ activeThemeId: id, themeChoiceMade: true });
       },
 
       syncServerThemes: async () => {
@@ -440,6 +489,7 @@ export const useThemeStore = create<ThemeState>()(
       partialize: (state) => ({
         theme: state.theme,
         activeThemeId: state.activeThemeId,
+        themeChoiceMade: state.themeChoiceMade,
         // Store theme metadata but NOT full CSS / skin (those go in IndexedDB)
         installedThemes: state.installedThemes.map(t => ({
           ...t,


### PR DESCRIPTION
## Summary

Two separate bugs found while testing the RTL/Arabic work in #661 / #664.

**1. Admin-configured default theme never reached new user sessions**

`initializeTheme()` (`stores/theme-store.ts`) determines the effective theme synchronously on mount, including a fallback to `usePolicyStore.getState().policy.themePolicy?.defaultThemeId`. But `/api/admin/policy` is only fetched *after* `/api/config` resolves (`hooks/use-config.ts`, explicitly commented "non-blocking") — a minimum of two chained network round-trips. A brand-new user's theme init (pure sync/localStorage) always wins that race, so the policy-default branch always sees an empty policy and falls back to `activeThemeId: null` — which then gets **persisted**, making the miss permanent instead of self-correcting on the next reload. New accounts were stuck on the built-in look regardless of what the admin configured as default.

Fix: added a `themeChoiceMade` flag (persisted) to distinguish "user explicitly picked Default" from "never decided yet" — both currently look identical as `activeThemeId === null`. Added a one-shot subscription to the policy store that retroactively applies `themePolicy.defaultThemeId` once policy actually loads, but only when the user hasn't made their own choice (neither before boot nor in the interim while waiting for policy).

**2. Login inputs right-aligned in RTL locales**

The JMAP endpoint, username, password, and TOTP inputs on the login page (plus the admin password input) inherit `dir="rtl"` from `<html>` when an RTL locale (ar/he/fa) is active, right-aligning fields that must always read left-to-right regardless of UI language — same category of bug as #664, just not covered there since it's plain `dir` inheritance rather than bidi character mirroring. Set `dir="ltr"` explicitly on each.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — same result as a clean `main` (one pre-existing, unrelated failure: the newly-merged `ca` locale is missing `email_composer.toolbar.*` keys added in a later commit than when Catalan was added — reproduces identically on `main`, not touched by this PR)
- [x] Manual verification: fresh account against a server with `themePolicy.defaultThemeId` set boots into that theme; login fields stay LTR in `ar`/`he`/`fa`