### PR TITLE
fix(impersonation): reconcile stale account chip after handoff

### DIFF
--- a/app/(main)/[locale]/layout.tsx
+++ b/app/(main)/[locale]/layout.tsx
@@ -7,6 +7,7 @@ import { RateLimitToastProvider } from "@/components/providers/rate-limit-toast-
 import { TourProvider } from "@/components/tour/tour-provider";
 import { ProtocolLaunchHandlerProvider } from "@/components/protocol/protocol-launch-handler-provider";
 import { ProInterfaceRedirect } from "@/components/pro/pro-interface-redirect";
+import { ImpersonationReconciler } from "@/components/impersonation/impersonation-reconciler";
 import { PluginDialogHost } from "@/components/plugins/plugin-dialog-host";
 import { PluginConsentDialog } from "@/components/plugins/plugin-consent-dialog";
 import { PWAInstallPrompt } from "@/components/pwa-install-prompt";
@@ -39,6 +40,7 @@ export default async function LocaleLayout({
               <TourProvider>
                 <ProtocolLaunchHandlerProvider>
                   <ProInterfaceRedirect />
+                  <ImpersonationReconciler />
                   {children}
                   <PluginDialogHost />
                   <PluginConsentDialog />

--- a/app/api/auth/impersonate/route.ts
+++ b/app/api/auth/impersonate/route.ts
@@ -39,7 +39,8 @@ function impersonationCookieOptions() {
  * Master-user impersonation via signed JWT. The token carries the target
  * mailbox; Bulwark verifies the signature, resolves the configured Stalwart
  * master credentials from env, then mints the same session cookies the
- * password-login path produces. The browser is redirected to "/" and the
+ * password-login path produces. The browser is redirected to "/?impersonated=1" (see
+ * ImpersonationReconciler, GH #646) and the
  * SPA hydrates as if the user had just logged in with master@target%master.
  *
  * Returns 404 when the feature is not configured so an unconfigured
@@ -136,6 +137,6 @@ export async function GET(request: NextRequest) {
   // when running behind a reverse proxy that doesn't set X-Forwarded-Host.
   return new NextResponse(null, {
     status: 303,
-    headers: { Location: '/' },
+    headers: { Location: '/?impersonated=1' },
   });
 }

--- a/components/impersonation/impersonation-reconciler.tsx
+++ b/components/impersonation/impersonation-reconciler.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { evictAll } from '@/lib/account-state-manager';
+
+/**
+ * After a master-user impersonation handoff (`GET /api/auth/impersonate`), the
+ * server swaps the slot-0 session cookie but the client's *persisted* account
+ * registry still lists the PREVIOUS account — so the top-left account chip keeps
+ * showing the old mailbox even though the message list is correctly the new one.
+ * Only a manual sign-out (which clears `account-registry` / `auth-storage`) fixes
+ * it, because that state lives in localStorage and the impersonation redirect
+ * never reconciles it. (Reported downstream: jabali-panel #646.)
+ *
+ * The impersonate route now redirects to `/?impersonated=1`. Here we drop the
+ * stale persisted account + auth state (and the server-derived caches) and
+ * reload to a clean URL, so the app rehydrates empty and re-derives the single
+ * account from the fresh session cookie — the same result as the manual
+ * sign-out-then-reopen, done automatically. Cookies are untouched, so the
+ * just-granted impersonation session survives the reload.
+ */
+const STALE_KEYS = [
+  'account-registry',
+  'auth-storage',
+  'identity-storage',
+  'contact-storage',
+  'calendar-storage',
+  'calendar-notification-storage',
+];
+
+export function ImpersonationReconciler() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('impersonated') !== '1') return;
+
+    try {
+      evictAll();
+    } catch {
+      /* in-memory snapshots are best-effort */
+    }
+    for (const key of STALE_KEYS) {
+      try {
+        window.localStorage.removeItem(key);
+      } catch {
+        /* ignore storage access errors */
+      }
+    }
+
+    // Reload to a clean URL (drop the marker) so the now-empty persisted stores
+    // rehydrate and the app reconnects + re-derives the impersonated account
+    // from the session cookie. The marker is gone on the second load, so this
+    // runs exactly once.
+    params.delete('impersonated');
+    const query = params.toString();
+    window.location.replace(window.location.pathname + (query ? `?${query}` : ''));
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Problem
After a master-user impersonation handoff (`GET /api/auth/impersonate`), the top-left account chip keeps showing the **previous** account until a manual sign-out — even though the message list is correctly the newly-impersonated mailbox. Reproduced on 1.7.8. (Downstream report: shukiv/jabali-panel#646.)

## Root cause
The route swaps the slot-0 **session cookie** server-side and redirects to `/`, but the client's **persisted account registry** (`account-registry` / `auth-storage` in `localStorage`) still lists the previous account, and the SPA renders that cached entry. Signing out clears those keys, which is why re-opening then works.

## Fix
- Redirect impersonation to `/?impersonated=1`.
- New headless `ImpersonationReconciler`: on that marker, evict in-memory snapshots + drop the stale persisted `account-registry` / `auth-storage` (and server-derived caches), then reload to a clean URL. Cookies are untouched, so the just-granted session survives, the app rehydrates empty and **re-derives the single correct account from the session** — the working sign-out-then-reopen, automated (runs exactly once).

## Notes
Contributed from downstream (jabali-panel bundles Bulwark as its webmail). **Not yet build-tested in this repo** — please run CI/build. Happy to rework into a pre-hydration variant if you'd rather avoid the one-shot reload. Supersedes #696.
