### PR TITLE
feat: add "Forward as attachment" next to Export as .eml

### DIFF
--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -77,6 +77,7 @@ import { appLifecycleHooks, uiHooks, routerHooks, toastHooks, emailHooks } from 
 import { emailToReadView } from "@/lib/plugin-projection";
 import { buildQuoteHeader } from "@/lib/quote-header";
 import { buildReplySubject, buildForwardSubject } from "@/lib/subject-prefix";
+import { buildForwardAsAttachmentPayload } from "@/lib/forward-as-attachment";
 import { getEffectiveLocale } from '@/i18n/detect-locale';
 import type { QuoteHeader } from "@/lib/plugin-types";
 
@@ -1534,6 +1535,52 @@ export default function Home() {
       setComposerQuoteHeader(null);
     }
     startFreshComposerSession();
+    setComposerMode('forward');
+    setShowComposer(true);
+    if (isMobile) setActiveView('viewer');
+  };
+
+  // Forward the original message as a message/rfc822 attachment instead of
+  // inline-quoted text - e.g. for reporting spam to an upstream gateway
+  // that expects the raw original as an attachment, or preserving exact
+  // formatting/headers the recipient needs to see untouched. Reuses the
+  // same attachment-carry-forward mechanism native Forward already uses
+  // for a forwarded message's own attachments (see the `attachments`
+  // useState initializer in email-composer.tsx) - we just add one more
+  // synthetic entry representing the whole original message, referenced
+  // by its existing blobId (no re-fetch/re-upload needed - JMAP blobs are
+  // account-scoped, not per-email). Skips prepareComposerQuoteHeader
+  // entirely, so the body starts blank instead of quoting the original.
+  const handleForwardAsAttachment = async () => {
+    if (!selectedEmail) return;
+    const payload = buildForwardAsAttachmentPayload(selectedEmail, t('email_composer.prefix.forward'));
+    if (!payload) return;
+
+    const ok = await emailHooks.onBeforeForward.intercept({
+      originalEmailId: selectedEmail.id,
+      originalEmail: emailToReadView(selectedEmail),
+      mode: 'forward' as const,
+    });
+    if (!ok) return;
+
+    startFreshComposerSession();
+    setPendingDraft({
+      to: "",
+      cc: "",
+      bcc: "",
+      subject: payload.subject,
+      body: "",
+      showCc: false,
+      showBcc: false,
+      selectedIdentityId: null,
+      subAddressTag: "",
+      mode: "forward",
+      draftId: null,
+      replyTo: {
+        subject: selectedEmail.subject,
+        attachments: [payload.attachment],
+      },
+    });
     setComposerMode('forward');
     setShowComposer(true);
     if (isMobile) setActiveView('viewer');
@@ -3436,6 +3483,7 @@ export default function Home() {
                     onReply={handleReply}
                     onReplyAll={handleReplyAll}
                     onForward={handleForward}
+                    onForwardAsAttachment={handleForwardAsAttachment}
                     onDelete={() => {
                       // Deleting the open message returns to the list (Gmail-style),
                       // not the next email — unless the user turned the setting off.

--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -1559,8 +1559,16 @@ export default function Home() {
   // by its existing blobId (no re-fetch/re-upload needed - JMAP blobs are
   // account-scoped, not per-email). Skips prepareComposerQuoteHeader
   // entirely, so the body starts blank instead of quoting the original.
-  const handleForwardAsAttachment = async () => {
-    if (!selectedEmail) return;
+  // Takes an explicit `email` (defaulting to selectedEmail), same pattern
+  // handleDelete uses just below, rather than always reading selectedEmail
+  // from this closure - callers that just called selectEmail(email) and
+  // invoke this synchronously in the same tick would otherwise see the
+  // PRE-update value (the Zustand store updates immediately, but this
+  // render's selectedEmail closure doesn't until the next render),
+  // forwarding the previously selected message or no-op'ing on an
+  // unselected row. See the list context-menu wiring below.
+  const handleForwardAsAttachment = async (email: Email | null = selectedEmail) => {
+    if (!email) return;
     // Same filename options "Export as .eml" uses (see emailFilenameOptions
     // in email-viewer.tsx), so the two actions produce consistent filenames
     // for the same message rather than the synthetic attachment silently
@@ -1572,7 +1580,7 @@ export default function Home() {
       filenameStripDiacritics,
       filenameCollapseSeparators,
     } = useSettingsStore.getState();
-    const payload = buildForwardAsAttachmentPayload(selectedEmail, t('email_composer.prefix.forward'), {
+    const payload = buildForwardAsAttachmentPayload(email, t('email_composer.prefix.forward'), {
       template: emailDownloadTemplate,
       spaceReplacement: filenameSpaceReplacement,
       lowercase: filenameLowercase,
@@ -1582,8 +1590,8 @@ export default function Home() {
     if (!payload) return;
 
     const ok = await emailHooks.onBeforeForward.intercept({
-      originalEmailId: selectedEmail.id,
-      originalEmail: emailToReadView(selectedEmail),
+      originalEmailId: email.id,
+      originalEmail: emailToReadView(email),
       mode: 'forward' as const,
     });
     if (!ok) return;
@@ -1602,7 +1610,7 @@ export default function Home() {
       mode: "forward",
       draftId: null,
       replyTo: {
-        subject: selectedEmail.subject,
+        subject: email.subject,
         attachments: [payload.attachment],
       },
     });
@@ -3280,7 +3288,7 @@ export default function Home() {
                 }}
                 onForwardAsAttachment={(email) => {
                   selectEmail(email);
-                  handleForwardAsAttachment();
+                  handleForwardAsAttachment(email);
                 }}
                 onMarkAsRead={async (email, read) => {
                   if (client) {

--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -785,7 +785,15 @@ export default function Home() {
   // This makes the Pro composer behave like Thunderbird's pop-out window.
   useEffect(() => {
     if (!isEmbedded || !showComposer) return;
-    const replyTo = selectedEmail ? {
+    // pendingDraft.replyTo, when set, was built by the opener (e.g.
+    // handleForwardAsAttachment) with intent that must survive the hop into
+    // the Pro tab - mirrors the same precedence the non-embedded render path
+    // uses just below (`replyTo={pendingDraft !== null ? pendingDraft.replyTo
+    // : ...}`). Building fresh from selectedEmail unconditionally here would
+    // silently drop that intent (e.g. the synthetic message/rfc822
+    // attachment "Forward as attachment" stages), falling back to a normal
+    // quoted forward instead.
+    const replyTo = pendingDraft?.replyTo ?? (selectedEmail ? {
       from: selectedEmail.from,
       replyToAddresses: selectedEmail.replyTo,
       to: selectedEmail.to,
@@ -801,7 +809,7 @@ export default function Home() {
       quoteHeaderHtml: composerQuoteHeader?.html,
       quoteHeaderText: composerQuoteHeader?.text,
       quoteWrapInBlockquote: composerQuoteHeader?.wrapInBlockquote,
-    } : undefined;
+    } : undefined);
 
     const effectiveMode = pendingDraft?.mode ?? composerMode;
     const baseSubject = (pendingDraft?.subject?.trim() || selectedEmail?.subject?.trim()) ?? '';

--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -3261,6 +3261,10 @@ export default function Home() {
                   selectEmail(email);
                   handleForward();
                 }}
+                onForwardAsAttachment={(email) => {
+                  selectEmail(email);
+                  handleForwardAsAttachment();
+                }}
                 onMarkAsRead={async (email, read) => {
                   if (client) {
                     await markAsRead(client, email.id, read);

--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -1561,7 +1561,24 @@ export default function Home() {
   // entirely, so the body starts blank instead of quoting the original.
   const handleForwardAsAttachment = async () => {
     if (!selectedEmail) return;
-    const payload = buildForwardAsAttachmentPayload(selectedEmail, t('email_composer.prefix.forward'));
+    // Same filename options "Export as .eml" uses (see emailFilenameOptions
+    // in email-viewer.tsx), so the two actions produce consistent filenames
+    // for the same message rather than the synthetic attachment silently
+    // ignoring the user's configured naming template.
+    const {
+      emailDownloadTemplate,
+      filenameSpaceReplacement,
+      filenameLowercase,
+      filenameStripDiacritics,
+      filenameCollapseSeparators,
+    } = useSettingsStore.getState();
+    const payload = buildForwardAsAttachmentPayload(selectedEmail, t('email_composer.prefix.forward'), {
+      template: emailDownloadTemplate,
+      spaceReplacement: filenameSpaceReplacement,
+      lowercase: filenameLowercase,
+      stripDiacritics: filenameStripDiacritics,
+      collapseSeparators: filenameCollapseSeparators,
+    });
     if (!payload) return;
 
     const ok = await emailHooks.onBeforeForward.intercept({

--- a/components/email/email-context-menu.tsx
+++ b/components/email/email-context-menu.tsx
@@ -34,6 +34,7 @@ import {
   EditIcon,
   CalendarClock,
   XCircle,
+  Paperclip,
 } from "lucide-react";
 import { cn, buildMailboxTree, MailboxNode } from "@/lib/utils";
 import { localizeMailboxName } from "@/lib/mailbox-label";
@@ -59,6 +60,7 @@ interface EmailContextMenuProps {
   onReply?: () => void;
   onReplyAll?: () => void;
   onForward?: () => void;
+  onForwardAsAttachment?: () => void;
   onMarkAsRead?: (read: boolean) => void;
   onToggleStar?: () => void;
   onTogglePinned?: () => void;
@@ -127,6 +129,7 @@ export function EmailContextMenu({
   onReply,
   onReplyAll,
   onForward,
+  onForwardAsAttachment,
   onMarkAsRead,
   onToggleStar,
   onTogglePinned,
@@ -150,6 +153,7 @@ export function EmailContextMenu({
   const t = useTranslations("context_menu");
   const tSidebar = useTranslations("sidebar");
   const _tColor = useTranslations("email_viewer.color_tag");
+  const tEmailViewer = useTranslations("email_viewer");
   const emailKeywords = useSettingsStore((state) => state.emailKeywords);
   const isUnread = !email.keywords?.$seen;
   const isStarred = email.keywords?.$flagged;
@@ -276,6 +280,12 @@ export function EmailContextMenu({
             label={t("forward")}
             onClick={() => handleAction(onForward!)}
             disabled={!onForward}
+          />
+          <ContextMenuItem
+            icon={Paperclip}
+            label={tEmailViewer("forward_as_attachment")}
+            onClick={() => handleAction(onForwardAsAttachment!)}
+            disabled={!onForwardAsAttachment || !email.blobId}
           />
           <ContextMenuSeparator />
         </>

--- a/components/email/email-list.tsx
+++ b/components/email/email-list.tsx
@@ -33,6 +33,7 @@ interface EmailListProps {
   onReply?: (email: Email) => void;
   onReplyAll?: (email: Email) => void;
   onForward?: (email: Email) => void;
+  onForwardAsAttachment?: (email: Email) => void;
   onMarkAsRead?: (email: Email, read: boolean) => void;
   onToggleStar?: (email: Email) => void;
   onTogglePinned?: (email: Email) => void;
@@ -63,6 +64,7 @@ export function EmailList({
   onReply,
   onReplyAll,
   onForward,
+  onForwardAsAttachment,
   onMarkAsRead,
   onToggleStar,
   onTogglePinned,
@@ -583,6 +585,7 @@ export function EmailList({
           onReply={() => onReply?.(contextMenu.data!)}
           onReplyAll={() => onReplyAll?.(contextMenu.data!)}
           onForward={() => onForward?.(contextMenu.data!)}
+          onForwardAsAttachment={() => onForwardAsAttachment?.(contextMenu.data!)}
           onMarkAsRead={(read) => onMarkAsRead?.(contextMenu.data!, read)}
           onToggleStar={() => onToggleStar?.(contextMenu.data!)}
           onTogglePinned={onTogglePinned ? () => onTogglePinned(contextMenu.data!) : undefined}

--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -3344,7 +3344,7 @@ export function EmailViewer({
               )}
               <div className="h-px bg-border my-1" />
               {/* Forward as attachment */}
-              {onForwardAsAttachment && (
+              {onForwardAsAttachment && email?.blobId && (
                 <button
                   onClick={() => { onForwardAsAttachment(); setMoreMenuOpen(false); setMoreMenuSub(null); }}
                   className="w-full px-3 py-1.5 text-sm text-start hover:bg-muted text-foreground flex items-center gap-2"
@@ -3475,7 +3475,7 @@ export function EmailViewer({
                 </button>
               )}
               <div className="h-px bg-border my-1" />
-              {onForwardAsAttachment && (
+              {onForwardAsAttachment && email?.blobId && (
                 <button
                   onClick={() => { onForwardAsAttachment(); setMoreMenuOpen(false); }}
                   className="w-full px-4 py-3 min-h-[44px] text-sm text-start hover:bg-muted text-foreground flex items-center gap-3"

--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -19,6 +19,7 @@ import {
   Reply,
   ReplyAll,
   Forward,
+  Paperclip,
   Trash2,
   Archive,
   Star,
@@ -109,6 +110,7 @@ interface EmailViewerProps {
   onReply?: (draftText?: string) => void;
   onReplyAll?: () => void;
   onForward?: () => void;
+  onForwardAsAttachment?: () => void;
   onDelete?: () => void;
   onArchive?: () => void;
   onToggleStar?: () => void;
@@ -621,6 +623,7 @@ export function EmailViewer({
   onReply,
   onReplyAll,
   onForward,
+  onForwardAsAttachment,
   onDelete,
   onArchive,
   onToggleStar,
@@ -3340,6 +3343,16 @@ export function EmailViewer({
                 </button>
               )}
               <div className="h-px bg-border my-1" />
+              {/* Forward as attachment */}
+              {onForwardAsAttachment && (
+                <button
+                  onClick={() => { onForwardAsAttachment(); setMoreMenuOpen(false); setMoreMenuSub(null); }}
+                  className="w-full px-3 py-1.5 text-sm text-start hover:bg-muted text-foreground flex items-center gap-2"
+                >
+                  <Paperclip className="w-4 h-4" />
+                  {t('forward_as_attachment')}
+                </button>
+              )}
               {/* Export email */}
               <button
                 onClick={() => { handleExportEmail(); setMoreMenuOpen(false); setMoreMenuSub(null); }}
@@ -3462,6 +3475,15 @@ export function EmailViewer({
                 </button>
               )}
               <div className="h-px bg-border my-1" />
+              {onForwardAsAttachment && (
+                <button
+                  onClick={() => { onForwardAsAttachment(); setMoreMenuOpen(false); }}
+                  className="w-full px-4 py-3 min-h-[44px] text-sm text-start hover:bg-muted text-foreground flex items-center gap-3"
+                >
+                  <Paperclip className="w-5 h-5" />
+                  {t('forward_as_attachment')}
+                </button>
+              )}
               <button
                 onClick={() => { handleExportEmail(); setMoreMenuOpen(false); }}
                 className="w-full px-4 py-3 min-h-[44px] text-sm text-start hover:bg-muted text-foreground flex items-center gap-3"

--- a/components/pro/pro-email-tab-body.tsx
+++ b/components/pro/pro-email-tab-body.tsx
@@ -15,6 +15,7 @@ import { useProTabStore, type ProEmailTabData, type ProReplyContext } from "@/st
 import type { Email } from "@/lib/jmap/types";
 import { buildReplySubject, buildForwardSubject } from "@/lib/subject-prefix";
 import { getQuoteBodies } from "@/lib/email-composer-utils";
+import { buildForwardAsAttachmentPayload } from "@/lib/forward-as-attachment";
 
 interface ProEmailTabBodyProps {
   tabId: string;
@@ -133,6 +134,44 @@ export function ProEmailTabBody({ tabId, data }: ProEmailTabBodyProps) {
       replyTo: buildReplyContext(email),
       sourceEmailId: email.id,
       title: buildForwardSubject(email.subject || t('email_composer.new_message'), t('email_composer.prefix.forward')),
+    });
+  }, [email, openComposeTab, t]);
+
+  // Mirrors handleForward, but attaches the original as a message/rfc822
+  // file instead of quoting it inline - see lib/forward-as-attachment.ts.
+  // This is a separate, self-contained render path from the main Mail
+  // tab's EmailViewer (page.tsx) - Pro tabs fetch their own `email` and
+  // open compose tabs directly via useProTabStore, not through
+  // page.tsx's pendingDraft/selectedEmail plumbing - so it needed its own
+  // wiring rather than falling out of the page.tsx fix automatically.
+  const handleForwardAsAttachment = useCallback(() => {
+    if (!email) return;
+    const {
+      emailDownloadTemplate,
+      filenameSpaceReplacement,
+      filenameLowercase,
+      filenameStripDiacritics,
+      filenameCollapseSeparators,
+    } = useSettingsStore.getState();
+    const payload = buildForwardAsAttachmentPayload(email, t('email_composer.prefix.forward'), {
+      template: emailDownloadTemplate,
+      spaceReplacement: filenameSpaceReplacement,
+      lowercase: filenameLowercase,
+      stripDiacritics: filenameStripDiacritics,
+      collapseSeparators: filenameCollapseSeparators,
+    });
+    if (!payload) return;
+
+    composerSessionIdRef.current += 1;
+    openComposeTab({
+      sessionId: composerSessionIdRef.current,
+      mode: 'forward',
+      replyTo: {
+        subject: email.subject,
+        attachments: [payload.attachment],
+      },
+      sourceEmailId: email.id,
+      title: payload.subject,
     });
   }, [email, openComposeTab, t]);
 
@@ -283,6 +322,7 @@ export function ProEmailTabBody({ tabId, data }: ProEmailTabBodyProps) {
           onReply={handleReply}
           onReplyAll={handleReplyAll}
           onForward={handleForward}
+          onForwardAsAttachment={handleForwardAsAttachment}
           onDelete={handleDelete}
           onArchive={handleArchive}
           onToggleStar={handleToggleStar}

--- a/components/pro/pro-email-tab-body.tsx
+++ b/components/pro/pro-email-tab-body.tsx
@@ -171,7 +171,13 @@ export function ProEmailTabBody({ tabId, data }: ProEmailTabBodyProps) {
         attachments: [payload.attachment],
       },
       sourceEmailId: email.id,
-      title: payload.subject,
+      // payload.subject is intentionally blank for a subject-less email (to
+      // match normal Forward's *composer* subject behavior - see
+      // buildForwardAsAttachmentPayload). The Pro tab *title* is a separate
+      // UI label that still needs a sensible fallback, same as handleForward
+      // above uses - reusing payload.subject here would give the tab an
+      // empty title instead of e.g. "Fwd: New message".
+      title: buildForwardSubject(email.subject || t('email_composer.new_message'), t('email_composer.prefix.forward')),
     });
   }, [email, openComposeTab, t]);
 

--- a/lib/__tests__/forward-as-attachment.test.ts
+++ b/lib/__tests__/forward-as-attachment.test.ts
@@ -46,6 +46,12 @@ describe('buildForwardAsAttachmentPayload', () => {
     expect(payload?.subject).toBe('Fwd: already forwarded once');
   });
 
+  it('leaves the subject blank (not just the bare prefix) for a subject-less message, matching normal Forward', () => {
+    const email = makeEmail({ subject: undefined });
+    const payload = buildForwardAsAttachmentPayload(email, 'Fwd:');
+    expect(payload?.subject).toBe('');
+  });
+
   it('honors a custom filename template, matching "Export as .eml" naming instead of always using the default', () => {
     const email = makeEmail({ subject: 'Missed spam example' });
     const payload = buildForwardAsAttachmentPayload(email, 'Fwd:', {

--- a/lib/__tests__/forward-as-attachment.test.ts
+++ b/lib/__tests__/forward-as-attachment.test.ts
@@ -45,4 +45,14 @@ describe('buildForwardAsAttachmentPayload', () => {
     const payload = buildForwardAsAttachmentPayload(email, 'Fwd:');
     expect(payload?.subject).toBe('Fwd: already forwarded once');
   });
+
+  it('honors a custom filename template, matching "Export as .eml" naming instead of always using the default', () => {
+    const email = makeEmail({ subject: 'Missed spam example' });
+    const payload = buildForwardAsAttachmentPayload(email, 'Fwd:', {
+      template: 'custom-{subject}',
+      lowercase: true,
+      spaceReplacement: 'dash',
+    });
+    expect(payload?.attachment.name).toBe('custom-missed-spam-example.eml');
+  });
 });

--- a/lib/__tests__/forward-as-attachment.test.ts
+++ b/lib/__tests__/forward-as-attachment.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { buildForwardAsAttachmentPayload } from '@/lib/forward-as-attachment';
+import type { Email } from '@/lib/jmap/types';
+
+function makeEmail(overrides: Partial<Email> = {}): Email {
+  return {
+    id: 'e1',
+    threadId: 't1',
+    mailboxIds: { inbox: true },
+    keywords: {},
+    size: 12345,
+    receivedAt: '2026-07-26T22:25:22Z',
+    subject: 'Your waste service day is changing',
+    hasAttachment: false,
+    blobId: 'blob123',
+    ...overrides,
+  };
+}
+
+describe('buildForwardAsAttachmentPayload', () => {
+  it('returns null when the email has no blobId', () => {
+    const email = makeEmail({ blobId: undefined });
+    expect(buildForwardAsAttachmentPayload(email, 'Fwd:')).toBeNull();
+  });
+
+  it('prefixes the subject using the given forward prefix', () => {
+    const email = makeEmail({ subject: 'Missed spam example' });
+    const payload = buildForwardAsAttachmentPayload(email, 'Fwd:');
+    expect(payload?.subject).toBe('Fwd: Missed spam example');
+  });
+
+  it('builds a message/rfc822 attachment referencing the email\'s own blobId, not a new upload', () => {
+    const email = makeEmail({ blobId: 'the-real-blob-id', size: 26489 });
+    const payload = buildForwardAsAttachmentPayload(email, 'Fwd:');
+    expect(payload?.attachment).toEqual({
+      blobId: 'the-real-blob-id',
+      name: expect.stringMatching(/\.eml$/),
+      type: 'message/rfc822',
+      size: 26489,
+    });
+  });
+
+  it('is idempotent - repeated forwarding does not stack prefixes', () => {
+    const email = makeEmail({ subject: 'Fwd: already forwarded once' });
+    const payload = buildForwardAsAttachmentPayload(email, 'Fwd:');
+    expect(payload?.subject).toBe('Fwd: already forwarded once');
+  });
+});

--- a/lib/forward-as-attachment.ts
+++ b/lib/forward-as-attachment.ts
@@ -1,6 +1,6 @@
 import type { Email } from "@/lib/jmap/types";
 import { buildForwardSubject } from "@/lib/subject-prefix";
-import { emailExportFilename } from "@/lib/download-filename";
+import { emailExportFilename, type EmailFilenameOptions } from "@/lib/download-filename";
 
 export interface ForwardAsAttachmentEntry {
   blobId: string;
@@ -24,11 +24,19 @@ export interface ForwardAsAttachmentPayload {
  * not per-email, so the same blobId a message already has can be attached
  * to a brand new outgoing email directly.
  *
+ * `filenameOptions`, when passed, should be the same options the caller
+ * uses for "Export as .eml" / drag-out (the user's configured filename
+ * template, space/case/diacritics transforms - see
+ * useSettingsStore's emailDownloadTemplate and friends), so the two
+ * actions produce consistent filenames for the same message. Falls back
+ * to emailExportFilename's own default template when omitted.
+ *
  * Returns null when the email has no blobId (nothing to reference).
  */
 export function buildForwardAsAttachmentPayload(
   email: Email,
   forwardPrefix: string,
+  filenameOptions?: EmailFilenameOptions,
 ): ForwardAsAttachmentPayload | null {
   if (!email.blobId) return null;
 
@@ -36,7 +44,7 @@ export function buildForwardAsAttachmentPayload(
     subject: buildForwardSubject(email.subject, forwardPrefix),
     attachment: {
       blobId: email.blobId,
-      name: emailExportFilename(email),
+      name: emailExportFilename(email, filenameOptions),
       type: "message/rfc822",
       size: email.size,
     },

--- a/lib/forward-as-attachment.ts
+++ b/lib/forward-as-attachment.ts
@@ -41,7 +41,11 @@ export function buildForwardAsAttachmentPayload(
   if (!email.blobId) return null;
 
   return {
-    subject: buildForwardSubject(email.subject, forwardPrefix),
+    // Match the normal Forward flow's getInitialSubject(), which leaves the
+    // subject blank rather than prefix-only when the original has none -
+    // buildForwardSubject("", prefix) would otherwise return just the bare
+    // prefix (e.g. "Fwd:") for a subject-less message.
+    subject: email.subject ? buildForwardSubject(email.subject, forwardPrefix) : "",
     attachment: {
       blobId: email.blobId,
       name: emailExportFilename(email, filenameOptions),

--- a/lib/forward-as-attachment.ts
+++ b/lib/forward-as-attachment.ts
@@ -1,0 +1,44 @@
+import type { Email } from "@/lib/jmap/types";
+import { buildForwardSubject } from "@/lib/subject-prefix";
+import { emailExportFilename } from "@/lib/download-filename";
+
+export interface ForwardAsAttachmentEntry {
+  blobId: string;
+  name: string;
+  type: "message/rfc822";
+  size: number;
+}
+
+export interface ForwardAsAttachmentPayload {
+  subject: string;
+  attachment: ForwardAsAttachmentEntry;
+}
+
+/**
+ * Build the subject and synthetic attachment entry for forwarding a
+ * message as a message/rfc822 attachment instead of inline-quoted text
+ * (e.g. reporting spam to an upstream gateway that expects the raw
+ * original as an attachment, or preserving exact formatting/headers).
+ *
+ * Referenced by blobId, not re-uploaded - JMAP blobs are account-scoped,
+ * not per-email, so the same blobId a message already has can be attached
+ * to a brand new outgoing email directly.
+ *
+ * Returns null when the email has no blobId (nothing to reference).
+ */
+export function buildForwardAsAttachmentPayload(
+  email: Email,
+  forwardPrefix: string,
+): ForwardAsAttachmentPayload | null {
+  if (!email.blobId) return null;
+
+  return {
+    subject: buildForwardSubject(email.subject, forwardPrefix),
+    attachment: {
+      blobId: email.blobId,
+      name: emailExportFilename(email),
+      type: "message/rfc822",
+      size: email.size,
+    },
+  };
+}

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -298,6 +298,7 @@
     "print": "طباعة",
     "view_source": "عرض المصدر",
     "export_email": "تصدير كملف ‎.eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "استيراد ملف ‎.eml أو ‎.zip",
     "keyboard_shortcuts": "اختصارات لوحة المفاتيح (؟)",
     "email_source": "مصدر الرسالة",

--- a/locales/ca/common.json
+++ b/locales/ca/common.json
@@ -298,6 +298,7 @@
     "print": "Imprimeix",
     "view_source": "Mostra el codi font",
     "export_email": "Exporta com a .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Importa .eml o .zip",
     "keyboard_shortcuts": "Dreceres de teclat (?)",
     "email_source": "Codi font del correu",

--- a/locales/cs/common.json
+++ b/locales/cs/common.json
@@ -298,6 +298,7 @@
     "print": "Tisk",
     "view_source": "Zobrazit zdrojový kód",
     "export_email": "Exportovat jako .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Importovat .eml nebo .zip",
     "keyboard_shortcuts": "Klávesové zkratky (?)",
     "email_source": "Zdrojový kód zprávy",

--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -298,6 +298,7 @@
     "print": "Udskriv",
     "view_source": "Vis kilde",
     "export_email": "Eksportér som .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Importér .eml eller .zip",
     "keyboard_shortcuts": "Tastaturgenveje (?)",
     "email_source": "E-mail-kilde",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -298,6 +298,7 @@
     "print": "Drucken",
     "view_source": "Quelltext anzeigen",
     "export_email": "Als .eml exportieren",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": ".eml oder .zip importieren",
     "keyboard_shortcuts": "Tastaturkürzel (?)",
     "email_source": "E-Mail-Quelltext",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -298,6 +298,7 @@
     "print": "Print",
     "view_source": "View source",
     "export_email": "Export as .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Import .eml or .zip",
     "keyboard_shortcuts": "Keyboard shortcuts (?)",
     "email_source": "Email Source",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -298,6 +298,7 @@
     "print": "Imprimir",
     "view_source": "Ver código fuente",
     "export_email": "Exportar como .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Importar .eml o .zip",
     "keyboard_shortcuts": "Atajos de teclado (?)",
     "email_source": "Código Fuente del Correo",

--- a/locales/fa/common.json
+++ b/locales/fa/common.json
@@ -298,6 +298,7 @@
     "print": "چاپ",
     "view_source": "مشاهده منبع",
     "export_email": "خروجی .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "وارد کردن .eml یا .zip",
     "keyboard_shortcuts": "میانبرهای صفحه کلید (?)",
     "email_source": "منبع ایمیل",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -298,6 +298,7 @@
     "print": "Imprimer",
     "view_source": "Voir la source",
     "export_email": "Exporter en .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Importer .eml ou .zip",
     "keyboard_shortcuts": "Raccourcis clavier (?)",
     "email_source": "Source de l'email",

--- a/locales/he/common.json
+++ b/locales/he/common.json
@@ -245,6 +245,7 @@
     "print": "הדפס",
     "view_source": "צפה במקור",
     "export_email": "ייצא כ-.eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "ייבוא .eml",
     "keyboard_shortcuts": "קיצורי מקשים (?)",
     "email_source": "מקור דוא\"ל",

--- a/locales/hu/common.json
+++ b/locales/hu/common.json
@@ -298,6 +298,7 @@
     "print": "Nyomtatás",
     "view_source": "Forrás megtekintése",
     "export_email": "Exportálás .eml-ként",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Importálás .eml vagy .zip fájlból",
     "keyboard_shortcuts": "Billentyűparancsok (?)",
     "email_source": "E-mail forrás",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -298,6 +298,7 @@
     "print": "Stampa",
     "view_source": "Visualizza sorgente",
     "export_email": "Esporta come .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Importa .eml o .zip",
     "keyboard_shortcuts": "Scorciatoie da tastiera (?)",
     "email_source": "Sorgente del messaggio",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -298,6 +298,7 @@
     "print": "印刷",
     "view_source": "ソースを表示",
     "export_email": ".emlとしてエクスポート",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": ".eml または .zip をインポート",
     "keyboard_shortcuts": "キーボードショートカット (?)",
     "email_source": "メールソース",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -298,6 +298,7 @@
     "print": "인쇄",
     "view_source": "원본 보기",
     "export_email": ".eml 파일로 내보내기",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": ".eml 또는 .zip 가져오기",
     "keyboard_shortcuts": "단축키 (?)",
     "email_source": "메일 원본",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -298,6 +298,7 @@
     "print": "Drukāt",
     "view_source": "Skatīt avota kodu",
     "export_email": "Eksportēt kā .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Importēt .eml vai .zip",
     "keyboard_shortcuts": "Īsinājumtaustiņi (?)",
     "email_source": "Vēstules avota kods",

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -298,6 +298,7 @@
     "print": "Afdrukken",
     "view_source": "Bron bekijken",
     "export_email": "Exporteren als .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": ".eml of .zip importeren",
     "keyboard_shortcuts": "Sneltoetsen (?)",
     "email_source": "E-mailbron",

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -298,6 +298,7 @@
     "print": "Drukuj",
     "view_source": "Pokaż źródło",
     "export_email": "Eksportuj jako .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Importuj .eml lub .zip",
     "keyboard_shortcuts": "Skróty klawiszowe (?)",
     "email_source": "Źródło wiadomości",

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -298,6 +298,7 @@
     "print": "Imprimir",
     "view_source": "Ver código-fonte",
     "export_email": "Exportar como .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Importar .eml ou .zip",
     "keyboard_shortcuts": "Atalhos de teclado (?)",
     "email_source": "Código-fonte do E-mail",

--- a/locales/ro/common.json
+++ b/locales/ro/common.json
@@ -298,6 +298,7 @@
     "print": "Imprimare",
     "view_source": "Vizualizați sursa",
     "export_email": "Exportați ca fișier .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Importați fișiere .eml sau .zip",
     "keyboard_shortcuts": "Comenzi rapide de la tastatură (?)",
     "email_source": "Sursa e-mailului",

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -298,6 +298,7 @@
     "print": "Распечатать",
     "view_source": "Просмотреть исходный код",
     "export_email": "Экспортировать как .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Импортировать .eml или .zip",
     "keyboard_shortcuts": "Сочетания клавиш (?)",
     "email_source": "Исходный код письма",

--- a/locales/sk/common.json
+++ b/locales/sk/common.json
@@ -298,6 +298,7 @@
     "print": "Tlačiť",
     "view_source": "Zobraziť zdrojový kód",
     "export_email": "Exportovať ako .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Importovať .eml alebo .zip",
     "keyboard_shortcuts": "Klávesové skratky (?)",
     "email_source": "Zdrojový kód e-mailu",

--- a/locales/tr/common.json
+++ b/locales/tr/common.json
@@ -298,6 +298,7 @@
     "print": "Yazdır",
     "view_source": "Kaynağı görüntüle",
     "export_email": ".eml olarak dışa aktar",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": ".eml veya .zip içe aktar",
     "keyboard_shortcuts": "Klavye kısayolları (?)",
     "email_source": "E-posta Kaynağı",

--- a/locales/uk/common.json
+++ b/locales/uk/common.json
@@ -298,6 +298,7 @@
     "print": "Роздрукувати",
     "view_source": "Переглянути джерело",
     "export_email": "Експортувати як .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "Імпорт .eml або .zip",
     "keyboard_shortcuts": "Комбінації клавіш (?)",
     "email_source": "Джерело електронної пошти",

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -298,6 +298,7 @@
     "print": "打印",
     "view_source": "查看源码",
     "export_email": "导出为 .eml",
+    "forward_as_attachment": "Forward as attachment",
     "import_email": "导入 .eml 或 .zip",
     "keyboard_shortcuts": "键盘快捷键（？）",
     "email_source": "邮件源码",


### PR DESCRIPTION
## Summary

Adds a "Forward as attachment" action to the message overflow ("...")
menu, right next to the existing "Export as .eml" action (both desktop
and mobile layouts). Opens a new forward-mode compose window with the
original message attached as a `message/rfc822` file instead of
quoted inline. Also available from the message list's right-click context menu
(same action, right after "Forward").

**Motivating use case:** reporting spam/phishing to an upstream
gateway (e.g. MxGuarddog) that requires the complete original headers
- including the full mail path (`Received` chain) - for scanning, not
an inline-quoted approximation. Also useful generally for preserving a
message's exact formatting/headers when forwarding it as evidence.

## How it works

Reuses the composer's existing attachment-carry-forward mechanism: the
`attachments` state initializer in `email-composer.tsx` already
carries a forwarded message's own attachments into a new compose via
`replyTo.attachments`. This adds one synthetic entry representing the
*whole original message*, referenced by its existing `blobId` - no
re-fetch or re-upload needed, since JMAP blobs are account-scoped
rather than per-email. The inline quote-header step
(`prepareComposerQuoteHeader`) is skipped, so the body starts blank
instead of quoting the original.

The "build subject + attachment entry" logic is extracted into a
small, pure, unit-tested helper (`lib/forward-as-attachment.ts`)
rather than left inline in the page component.

Also wired into the message list's row context menu
(`EmailContextMenu`), right after "Forward" - reuses the same handler
and helper, no new logic. List rows already carry `blobId`
(`EMAIL_LIST_PROPERTIES` includes it for the existing drag-out-to-
filesystem `.eml` export feature), so this works without any
additional fetch.

## Test plan

- [x] `npm run typecheck` - clean
- [x] `npm run lint` - clean (only pre-existing warnings in unrelated
      files, 0 errors)
- [x] `npx vitest run lib/__tests__/forward-as-attachment.test.ts` -
      new tests pass (4/4)
- [x] `npm run test:translations` - passes for this change; one
      pre-existing, unrelated locale gap (`ca` missing several
      `email_composer.toolbar.*` keys) reproduces identically on a
      clean `main` checkout, confirmed not introduced by this PR
- [x] Manually verified in the app with the mock JMAP dev server
      (`.env.dev.example`) - see screenshot below

## Screenshot

### More Actions menu
<img width="667" height="251" alt="Screenshot from 2026-07-27 16-09-40" src="https://github.com/user-attachments/assets/2c4345fc-5306-4a47-81aa-3039ffef1364" />

### Right Click menu

<img width="197" height="430" alt="Screenshot-Right-Click-Menu-from 2026-07-27 17-03-53" src="https://github.com/user-attachments/assets/2f2778f5-f65a-466d-9c06-2daaa1988ac9" />


## Translations

Added the `email_viewer.forward_as_attachment` key to all 24 locales.
Per CONTRIBUTING.md, English text is used as a placeholder in the
non-English locales pending real translation (missing keys fall back
to English at runtime regardless, but the translations completeness
test requires structural parity across all locale files).

## Note

GitHub Copilot's review caught a real bug in the first commit: the
Pro/embedded composer-hoisting path (when the composer is popped into
its own tab) rebuilt `replyTo` from `selectedEmail` unconditionally,
ignoring `pendingDraft.replyTo` - which would've silently dropped the
synthetic attachment in that mode. Fixed in the second commit to match
the same precedence the non-embedded render path already uses.
