### PR TITLE
fix(jmap): hide Contacts and Calendars when account lacks capability

### DIFF
--- a/lib/__tests__/jmap-calendar-capability.test.ts
+++ b/lib/__tests__/jmap-calendar-capability.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { JMAPClient } from '../jmap/client';
+
+// The server advertises Calendars globally while the per-account
+// accountCapabilities independently includes or omits it.
+function makeSession(accountCapabilities: Record<string, unknown>, isPersonal = true, serverAdvertises = true) {
+  return {
+    capabilities: {
+      'urn:ietf:params:jmap:core': {},
+      ...(serverAdvertises ? { 'urn:ietf:params:jmap:calendars': {} } : {}),
+    },
+    accounts: {
+      'acct-1': { name: 'test', isPersonal, accountCapabilities },
+    },
+    primaryAccounts: { 'urn:ietf:params:jmap:mail': 'acct-1' },
+    apiUrl: 'https://mail.example.com/jmap/api',
+    downloadUrl: 'https://mail.example.com/jmap/download/{accountId}/{blobId}/{name}',
+    uploadUrl: 'https://mail.example.com/jmap/upload/{accountId}/',
+    eventSourceUrl: 'https://mail.example.com/jmap/eventsource',
+  };
+}
+
+function mockFetchResponse(status: number, body?: unknown): Response {
+  return new Response(body ? JSON.stringify(body) : null, {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function connect(accountCapabilities: Record<string, unknown>, isPersonal = true, serverAdvertises = true): Promise<JMAPClient> {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch');
+  fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, makeSession(accountCapabilities, isPersonal, serverAdvertises)));
+  const client = new JMAPClient('https://mail.example.com', 'user@test.com', 'pass123');
+  await client.connect();
+  fetchSpy.mockReset();
+  return client;
+}
+
+describe('JMAPClient.supportsCalendars (account-scoped capability)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('returns true when the account advertises the calendars capability', async () => {
+    const client = await connect({ 'urn:ietf:params:jmap:calendars': {} });
+    expect(client.supportsCalendars()).toBe(true);
+  });
+
+  it('returns false when the server advertises calendars but the account does not', async () => {
+    const client = await connect({ 'urn:ietf:params:jmap:mail': {} });
+    expect(client.supportsCalendars()).toBe(false);
+  });
+
+  it('treats non-personal (shared/group) accounts as capable even without per-account advertisement', async () => {
+    const client = await connect({}, /* isPersonal */ false);
+    expect(client.supportsCalendars()).toBe(true);
+  });
+
+  it('returns false for a shared account when the server does not advertise calendars', async () => {
+    const client = await connect({}, /* isPersonal */ false, /* serverAdvertises */ false);
+    expect(client.supportsCalendars()).toBe(false);
+  });
+});

--- a/lib/__tests__/jmap-contact-client.test.ts
+++ b/lib/__tests__/jmap-contact-client.test.ts
@@ -48,22 +48,39 @@ describe('JMAPClient contact methods', () => {
   });
 
   describe('supportsContacts', () => {
-    it('should return true when contacts capability exists', () => {
+    function withAccountCapabilities(
+      client: JMAPClient,
+      accountCapabilities: Record<string, unknown>,
+      isPersonal = true,
+    ) {
+      Object.assign(client, {
+        capabilities: { 'urn:ietf:params:jmap:contacts': {} },
+        accounts: { 'account-1': { name: 'test', isPersonal, accountCapabilities } },
+      });
+    }
+
+    it('should return true when the account advertises the contacts capability', () => {
       const client = createClient();
-      Object.assign(client, { capabilities: { 'urn:ietf:params:jmap:contacts': {} } });
+      withAccountCapabilities(client, { 'urn:ietf:params:jmap:contacts': {} });
       expect(client.supportsContacts()).toBe(true);
     });
 
-    it('should return false when contacts capability is missing', () => {
+    it('should return false when the server advertises contacts but the account does not', () => {
       const client = createClient();
-      Object.assign(client, { capabilities: {} });
+      withAccountCapabilities(client, { 'urn:ietf:params:jmap:mail': {} });
       expect(client.supportsContacts()).toBe(false);
     });
 
-    it('should throw when capabilities is undefined', () => {
+    it('should treat non-personal (shared/group) accounts as capable', () => {
       const client = createClient();
-      Object.assign(client, { capabilities: undefined });
-      expect(() => client.supportsContacts()).toThrow();
+      withAccountCapabilities(client, {}, /* isPersonal */ false);
+      expect(client.supportsContacts()).toBe(true);
+    });
+
+    it('should return false when no session has been loaded', () => {
+      const client = createClient();
+      Object.assign(client, { capabilities: undefined, accounts: {} });
+      expect(client.supportsContacts()).toBe(false);
     });
   });
 

--- a/lib/__tests__/jmap-contacts-capability.test.ts
+++ b/lib/__tests__/jmap-contacts-capability.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { JMAPClient } from '../jmap/client';
+
+// The server advertises Contacts globally while the per-account
+// accountCapabilities independently includes or omits it.
+function makeSession(accountCapabilities: Record<string, unknown>, isPersonal = true, serverAdvertises = true) {
+  return {
+    capabilities: {
+      'urn:ietf:params:jmap:core': {},
+      ...(serverAdvertises ? { 'urn:ietf:params:jmap:contacts': {} } : {}),
+    },
+    accounts: {
+      'acct-1': { name: 'test', isPersonal, accountCapabilities },
+    },
+    primaryAccounts: { 'urn:ietf:params:jmap:mail': 'acct-1' },
+    apiUrl: 'https://mail.example.com/jmap/api',
+    downloadUrl: 'https://mail.example.com/jmap/download/{accountId}/{blobId}/{name}',
+    uploadUrl: 'https://mail.example.com/jmap/upload/{accountId}/',
+    eventSourceUrl: 'https://mail.example.com/jmap/eventsource',
+  };
+}
+
+function mockFetchResponse(status: number, body?: unknown): Response {
+  return new Response(body ? JSON.stringify(body) : null, {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function connect(accountCapabilities: Record<string, unknown>, isPersonal = true, serverAdvertises = true): Promise<JMAPClient> {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch');
+  fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, makeSession(accountCapabilities, isPersonal, serverAdvertises)));
+  const client = new JMAPClient('https://mail.example.com', 'user@test.com', 'pass123');
+  await client.connect();
+  fetchSpy.mockReset();
+  return client;
+}
+
+describe('JMAPClient.supportsContacts (account-scoped capability)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('returns true when the account advertises the contacts capability', async () => {
+    const client = await connect({ 'urn:ietf:params:jmap:contacts': {} });
+    expect(client.supportsContacts()).toBe(true);
+  });
+
+  it('returns false when the server advertises contacts but the account does not', async () => {
+    const client = await connect({ 'urn:ietf:params:jmap:mail': {} });
+    expect(client.supportsContacts()).toBe(false);
+  });
+
+  it('treats non-personal (shared/group) accounts as capable even without per-account advertisement', async () => {
+    const client = await connect({}, /* isPersonal */ false);
+    expect(client.supportsContacts()).toBe(true);
+  });
+
+  it('returns false for a shared account when the server does not advertise contacts', async () => {
+    const client = await connect({}, /* isPersonal */ false, /* serverAdvertises */ false);
+    expect(client.supportsContacts()).toBe(false);
+  });
+});

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -3720,12 +3720,28 @@ export class JMAPClient implements IJMAPClient {
     return this.hasCapability("urn:ietf:params:jmap:vacationresponse");
   }
 
-  supportsContacts(): boolean {
-    return this.hasCapability("urn:ietf:params:jmap:contacts");
+  supportsContacts(accountId?: string): boolean {
+    // Gate on the ACCOUNT capability: a server can advertise contacts while an
+    // account has its jmap-contact-* / dav-card-* permissions revoked. Shared accounts
+    // aren't always advertised per-account, so fall back to the server-wide
+    // capability - accountCapabilities is a subset of it (RFC 8620 s2).
+    const id = accountId || this.accountId;
+    const account = this.accounts[id];
+    if (!account) return false;
+    if (account.accountCapabilities?.["urn:ietf:params:jmap:contacts"]) return true;
+    return !account.isPersonal && !!this.capabilities?.["urn:ietf:params:jmap:contacts"];
   }
 
-  supportsCalendars(): boolean {
-    return this.hasCapability("urn:ietf:params:jmap:calendars");
+  supportsCalendars(accountId?: string): boolean {
+    // Gate on the ACCOUNT capability: a server can advertise calendars while an
+    // account has its jmap-calendar-* / dav-cal-* permissions revoked. Shared accounts
+    // aren't always advertised per-account, so fall back to the server-wide
+    // capability - accountCapabilities is a subset of it (RFC 8620 s2).
+    const id = accountId || this.accountId;
+    const account = this.accounts[id];
+    if (!account) return false;
+    if (account.accountCapabilities?.["urn:ietf:params:jmap:calendars"]) return true;
+    return !account.isPersonal && !!this.capabilities?.["urn:ietf:params:jmap:calendars"];
   }
 
   supportsSieve(): boolean {


### PR DESCRIPTION


## Summary

JMAP provides both session (server) and account capabilities. The account capabilities were not being check/respected.

## Changes

supportsContacts and supportsCalendars checked the server-wide session capability. An account with jmap-contact-* / dav-card-* revoked still got Contacts, and one with jmap-calendar-* / dav-cal-* revoked still got Calendars, with every action failing on an authorization error.
- gate both on accountCapabilities instead of session capabilities
- shared accounts fall back to the server-wide capability rather than an
  unconditional yes, since accountCapabilities is a subset of it
  and Stalwart doesn't always advertise them per-account
- add capability tests for contacts and calendars
- update the supportsContacts tests, which set capabilities directly

## Related issues

Related to #563 

**Note:** https://github.com/bulwarkmail/webmail/commit/8904d724bbe64c96591600a808c1aecd3f5ffac1 which addresses #563 falls back to allowing the capability if it is a shared account/group that doesn't advertise accountCapabilities. Strictly speaking, the server capability should be checked next, and not permitted if the server doesn't provide the capability.

This PR only addresses contacts/calendars and not files, but I can do a follow on to provide the same behavior for file capabilities too.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed -- N/A
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text -- N/A
- [ ] I have included screenshots or a screen recording for UI changes -- N/A

## Screenshots / demo

N/A

## Notes for reviewers

See the related issues section
