### PR TITLE
fix(plugins): prevent a privileged plugin to get PRF secret of anothe…

### DIFF
--- a/lib/plugin-sandbox/host-api.ts
+++ b/lib/plugin-sandbox/host-api.ts
@@ -430,21 +430,20 @@ async function doContactCreate(contact: ContactCard): Promise<ContactCard> {
 
 // ─── WebAuthn (privileged tier) ─────────────────────────────────────────────
 
-// This salt acts as a constant context identifier for key derivation.
-// While hardcoded, security is maintained because the WebAuthn PRF extension 
-// mixes this salt with the device's unique, hardware-bound private key.
-// Changing this string will result in a completely different derived secret.
-const PRF_SALT = new TextEncoder().encode("bulwark-plugins-v1");
-
 /**
  * Retrieves or creates a WebAuthn passkey and extracts its PRF secret.
  * This secret is typically used as a local master encryption key.
  */
 async function doGetOrCreatePRF(
     masterCredentialIdBytes: number[] | undefined, 
+    pluginId: string,
     name?: string, 
-    displayName?: string
+    displayName?: string,
 ): Promise<{ credentialId: number[]; prfSecret: number[] } | string> {
+
+  // To avoid a privileged plugin to access secret created from another privileged plugin,
+  // we add the pluginID from manifest in salt.
+  const PRF_SALT = new TextEncoder().encode("bulwark-plugins-v1" + pluginId)
     
     // ─── CASE 1: Credential already exists (Authentication) ──────────────────
     if (masterCredentialIdBytes && masterCredentialIdBytes.length > 0) {
@@ -456,18 +455,18 @@ async function doGetOrCreatePRF(
           challenge: crypto.getRandomValues(new Uint8Array(32)),
           allowCredentials: [{ type: "public-key", id: credentialId }],
           userVerification: "required", // Required to ensure user presence & intent (biometrics/PIN)
-          extensions: { prf: { eval: { first: PRF_SALT } } } as any
+          extensions: { prf: { eval: { first: PRF_SALT } } }
         }
       }) as PublicKeyCredential;
 
       // Extract the derived symmetric key from the authenticator's output
       const outputs = assertion.getClientExtensionResults();
-      const prfSecret = (outputs as any).prf?.results?.first;
+      const prfSecret = (outputs).prf?.results?.first;
       if (!prfSecret) return 'Cannot get PRF secret from existing credential.';
 
       return {
         credentialId: masterCredentialIdBytes,
-        prfSecret: Array.from(new Uint8Array(prfSecret))
+        prfSecret: Array.from(new Uint8Array(prfSecret as ArrayBuffer))
       };
     }
     
@@ -492,14 +491,14 @@ async function doGetOrCreatePRF(
             authenticatorAttachment: "platform", // Forces the use of hardware/OS-bound passkeys (TouchID, Windows Hello, etc.)
             userVerification: "required"
           },
-          extensions: { prf: {} } as any // Request PRF extension support from the authenticator
+          extensions: { prf: {} } // Request PRF extension support from the authenticator
         }
       }) as PublicKeyCredential;
       
       const outputs = credential.getClientExtensionResults();
 
       // Ensure the authenticator successfully enabled and supports the PRF extension
-      const isPrfEnabled = (outputs as any).prf?.enabled;
+      const isPrfEnabled = (outputs).prf?.enabled;
       if (!isPrfEnabled) {
         return 'The authenticator does not support or has rejected the PRF extension.';
       }
@@ -516,20 +515,20 @@ async function doGetOrCreatePRF(
           userVerification: "required",
           extensions: {
             prf: { eval: { first: PRF_SALT } }
-          } as any
+          }
         }
       }) as PublicKeyCredential;
 
       const assertionOutputs = assertion.getClientExtensionResults();
 
-      const prfSecret = (assertionOutputs as any).prf?.results?.first;
+      const prfSecret = (assertionOutputs).prf?.results?.first;
       if (!prfSecret) {
         return 'Cannot get PRF secret from existing credential.';
       }
 
       return {
         credentialId: Array.from(new Uint8Array(credential.rawId)),
-        prfSecret: Array.from(new Uint8Array(prfSecret))
+        prfSecret: Array.from(new Uint8Array(prfSecret as ArrayBuffer))
       };
     }
     
@@ -738,7 +737,7 @@ export async function dispatchApiCall(
     );
     case 'upfiles.get' : return getFile(args[0] as string);
     case 'upfiles.save' : return saveFile(args[0] as string, args[1] as File);
-    case 'webauthn.getOrCreate': return doGetOrCreatePRF(args[0] as number[] | undefined, args[1] as string | undefined, args[2] as string | undefined);
+    case 'webauthn.getOrCreate': return doGetOrCreatePRF(args[0] as number[] | undefined, args[1] as string, args[2] as string | undefined, args[3] as string | undefined);
     
     case 'contact.get': return doContactGet(args[0] as string);
     case 'contact.update': return doContactUpdate(args[0] as string, args[1] as Partial<ContactCard>);

--- a/lib/plugin-sandbox/runtime.tsx
+++ b/lib/plugin-sandbox/runtime.tsx
@@ -167,7 +167,7 @@ function buildPluginApi(manifest: PluginManifest) {
       settings: { ...manifest.settings },
     },
     webauthn: {
-      getOrCreate: (masterCredentialIdBytes?: number[], name?: string, displayName?: string) => callApi('webauthn.getOrCreate', [masterCredentialIdBytes, name, displayName], 0)
+      getOrCreate: (masterCredentialIdBytes?: number[], name?: string, displayName?: string) => callApi('webauthn.getOrCreate', [masterCredentialIdBytes, manifest.id, name, displayName], 0)
     },
     storage: {
       get: (key: string) => callApi('storage.get', [key]),


### PR DESCRIPTION
## Summary

Edit salt given to webauthn keys when requesting a PRF secret. Indeed, now, all privileged plugins share the same salt so they can obtain the same secret. This is a bad behavior. So, in the secret, we inject the plugin ID. This way, each plugin gets a different salt.
It is a breaking change because users will have to recreate a key if they used this feature.

## Changes
- add a new `pluginId` to doGetOrCreatePRF method
- webauthn.getOrCreate method call the API with the new argument manifest.id

## Related issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
