### PR TITLE
fix: try to fix two flaky tests

### DIFF
--- a/lib/__tests__/config-route.test.ts
+++ b/lib/__tests__/config-route.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, unlink, writeFileSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -8,7 +8,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // state on the developer's machine can't leak into these env-driven
 // assertions. Must happen before the first GET, because the config manager
 // singleton loads the directory once and caches it.
-process.env.ADMIN_CONFIG_DIR = mkdtempSync(path.join(tmpdir(), 'bw-config-route-'));
+const TEMP_DIR = mkdtempSync(path.join(tmpdir(), 'bw-config-route-'));
+process.env.ADMIN_CONFIG_DIR = TEMP_DIR;
+
+/**
+ * Backing file for the SESSION_SECRET_FILE tests. Kept in the temp dir rather
+ * than the working directory, which test runs share.
+ */
+const SECRET_FILE = path.join(TEMP_DIR, 'session-secret');
 
 // Mock NextResponse before importing the route
 vi.mock('next/server', () => ({
@@ -50,6 +57,7 @@ describe('config API route', () => {
 
   afterEach(() => {
     process.env = { ...originalEnv };
+    rmSync(SECRET_FILE, { force: true });
   });
 
   function mockRequest(headers: Record<string, string> = {}): unknown {
@@ -156,14 +164,10 @@ describe('config API route', () => {
 	});
 
   it('should enable rememberMe when SESSION_SECRET_FILE is set', async () => {
-    writeFileSync('./session-secret', 'test-secret');
-    process.env.SESSION_SECRET_FILE = './session-secret';
+    writeFileSync(SECRET_FILE, 'test-secret');
+    process.env.SESSION_SECRET_FILE = SECRET_FILE;
 
     const config = await getConfig();
-
-    unlink('./session-secret', (err) => {
-      if (err) throw err;
-    });
 
     expect(config.rememberMeEnabled).toBe(true);
   });
@@ -183,14 +187,10 @@ describe('config API route', () => {
     const config1 = await getConfig();
     expect(config1.settingsSyncEnabled).toBe(false);
 
-    writeFileSync('./session-secret', 'test-secret');
-    process.env.SESSION_SECRET_FILE = './session-secret';
+    writeFileSync(SECRET_FILE, 'test-secret');
+    process.env.SESSION_SECRET_FILE = SECRET_FILE;
 
     const config2 = await getConfig();
-
-    unlink('./session-secret', (err) => {
-      if (err) throw err;
-    });
 
     expect(config2.settingsSyncEnabled).toBe(true);
   });

--- a/lib/__tests__/jmap-client-resilience.test.ts
+++ b/lib/__tests__/jmap-client-resilience.test.ts
@@ -32,8 +32,18 @@ function mockFetchResponseWithHeaders(status: number, headers: Record<string, st
   });
 }
 
+/**
+ * A mock answering every call with its own Response, for the tests that cannot
+ * say how many calls to expect. A body reads once, so a single shared Response
+ * would leave the second reader with "Body has already been read".
+ */
+function respondEveryTime(status: number, body?: unknown): () => Promise<Response> {
+  return () => Promise.resolve(mockFetchResponse(status, body));
+}
+
 describe('JMAPClient resilience', () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
+  const connectedClients: JMAPClient[] = [];
 
   beforeEach(() => {
     fetchSpy = vi.spyOn(globalThis, 'fetch');
@@ -41,6 +51,10 @@ describe('JMAPClient resilience', () => {
   });
 
   afterEach(() => {
+    // Connecting starts a keep-alive interval that outlives the test unless it
+    // is stopped here, and its ping then consumes a later test's mocked fetch.
+    connectedClients.forEach((client) => client.disconnect());
+    connectedClients.length = 0;
     fetchSpy.mockRestore();
     vi.useRealTimers();
   });
@@ -57,6 +71,7 @@ describe('JMAPClient resilience', () => {
       const client = new JMAPClient('https://mail.example.com', 'user@test.com', 'pass123');
       await client.connect();
       fetchSpy.mockReset();
+      connectedClients.push(client);
       return client;
     }
 
@@ -65,6 +80,7 @@ describe('JMAPClient resilience', () => {
     const client = JMAPClient.withBearer('https://mail.example.com', 'token123', 'user@test.com');
     await client.connect();
     fetchSpy.mockReset();
+    connectedClients.push(client);
     return client;
   }
 
@@ -238,7 +254,7 @@ describe('JMAPClient resilience', () => {
       client.onConnectionChange(callback);
 
       const echoResponse = { methodResponses: [['Core/echo', { ping: 'pong' }, '0']] };
-      fetchSpy.mockResolvedValue(mockFetchResponse(200, echoResponse));
+      fetchSpy.mockImplementation(respondEveryTime(200, echoResponse));
 
       // Advance past keep-alive interval (30s)
       await vi.advanceTimersByTimeAsync(30_000);
@@ -342,7 +358,7 @@ describe('JMAPClient resilience', () => {
       client.disconnect();
 
       // Advancing timers should not trigger any ping
-      fetchSpy.mockResolvedValue(mockFetchResponse(200, { methodResponses: [['Core/echo', { ping: 'pong' }, '0']] }));
+      fetchSpy.mockImplementation(respondEveryTime(200, { methodResponses: [['Core/echo', { ping: 'pong' }, '0']] }));
       await vi.advanceTimersByTimeAsync(60_000);
 
       expect(callback).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

I noticed while developing the other PR. These tests don't fail every time, heavy CPU usage causes them to fail more often since it is more a timing issue then anything else.

## Changes

- The keep-alive test used the same Response object for all fetch calls, so depending on the timing, a second call either failed or not. Now each call gets its own Response object.
- The config route test wrote the session-secret file into the working directory but didn't wait for the unlink to complete, so the file could outlive the test. It is put into the temp directory now and properly removed.

## Related issues

None

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

None

## Notes for reviewers

None