### PR TITLE
fix(list): align the unread dot with the first line, not the row midpoint

### DIFF
--- a/components/email/thread-email-item.tsx
+++ b/components/email/thread-email-item.tsx
@@ -137,9 +137,14 @@ export function ThreadEmailItem({
           </button>
         )}
 
-        {/* Unread indicator */}
+        {/* Unread indicator — anchored on the first line (top padding + half a
+            small avatar), not on the row's midpoint, so it stays in line with
+            the checkbox and avatar when the row wraps to a second line. */}
         {isUnread && (
-          <div className="absolute start-7 top-1/2 -translate-y-1/2">
+          <div
+            className="absolute start-7 -translate-y-1/2"
+            style={{ top: `calc(var(--density-item-py) + ${density === 'extra-compact' ? '0.625rem' : '1rem'})` }}
+          >
             <Circle className="w-1.5 h-1.5 fill-unread text-unread" />
           </div>
         )}

--- a/components/email/thread-list-item.tsx
+++ b/components/email/thread-list-item.tsx
@@ -21,6 +21,27 @@ import { EmailHoverActions } from "./email-hover-actions";
 import { useTranslations } from "next-intl";
 
 /**
+ * Unread bullet in the row gutter.
+ *
+ * It is absolutely positioned so it never widens the row, which means it has
+ * to be told where the row's *first* line sits: centring it on the row (the
+ * old `top-1/2`) drifts down as soon as the row grows a second and third line,
+ * leaving it visibly out of line with the checkbox and the avatar it reads as
+ * a column with. Anchor = top padding + half an avatar.
+ */
+function UnreadDot({ density, compactAvatar }: { density: string; compactAvatar: boolean }) {
+  const halfFirstLine = density === 'extra-compact' ? '0.625rem' : compactAvatar ? '1rem' : '1.25rem';
+  return (
+    <div
+      className="absolute start-0.5 -translate-y-1/2"
+      style={{ top: `calc(var(--density-item-py) + ${halfFirstLine})` }}
+    >
+      <Circle className="w-2 h-2 fill-unread text-unread" />
+    </div>
+  );
+}
+
+/**
  * Small chip showing the originating folder of a message, rendered in the
  * aggregate "All …" views (All Mail / unified / cross-account) where rows come
  * from different folders. `email.sourceFolder` is stamped at fetch time.
@@ -244,9 +265,7 @@ const SingleEmailItem = React.forwardRef<HTMLDivElement, SingleEmailItemProps>(
           )}
 
           {isUnread && (
-            <div className="absolute start-0.5 top-1/2 -translate-y-1/2">
-              <Circle className="w-2 h-2 fill-unread text-unread" />
-            </div>
+            <UnreadDot density={density} compactAvatar={isFocusedMailLayout} />
           )}
 
           {density !== 'extra-compact' && (
@@ -683,9 +702,7 @@ export const ThreadListItem = React.forwardRef<HTMLDivElement, ThreadListItemPro
             )}
 
             {hasUnread && (
-              <div className="absolute start-0.5 top-1/2 -translate-y-1/2">
-                <Circle className="w-2 h-2 fill-unread text-unread" />
-              </div>
+              <UnreadDot density={density} compactAvatar={isFocusedMailLayout} />
             )}
 
             {density !== 'extra-compact' && (


### PR DESCRIPTION
## The problem

The unread dot is positioned with `top-1/2 -translate-y-1/2`, so it centres on the **whole
row**. At the default density a row is three lines tall (sender / subject / preview) while the
checkbox and the avatar sit at the top — the dot therefore lands roughly a line below them,
level with the subject or the preview. It reads as a column with those two, so the drift is
what the eye catches first, and it gets worse as rows grow (larger font, wrapped subject,
tag lozenges).

| before (`main`) | after (this PR) |
|---|---|
| <img src="https://raw.githubusercontent.com/lucletoffe/webmail/pr-assets/before.png" width="380"> | <img src="https://raw.githubusercontent.com/lucletoffe/webmail/pr-assets/after.png" width="380"> |

Screenshots taken with `DEMO_MODE=true npm run dev`, dark theme, default density.

## The fix

Anchor the dot on the row's *first* line instead of its midpoint: `var(--density-item-py)`
plus half an avatar, following the density (`extra-compact` has no avatar, so it uses the
sender line height). Extracted into a small `UnreadDot` component since the markup was
duplicated for the single-email and thread rows.

- `thread-list-item.tsx` — both occurrences.
- `thread-email-item.tsx` — same `top-1/2` on the messages of an expanded thread, same fix
  (its avatar is `sm`).

No layout change: the dot stays absolutely positioned, so it still costs no width.

## Checks

`npm run typecheck` clean · `npm run lint` clean (8 pre-existing warnings on `main`, none
in the touched files) · `npx vitest run` → 146 files, 2331 tests passed.

## Note for the mobile app

`bulwarkmail/native` grew the same indicator in #27 with the same `top: '50%'`, and the same
drift — bulwarkmail/native#36 fixes it there.
