### PR TITLE
fix: route the calendar parse dump through the debug logger

### DIFF
--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -5263,7 +5263,7 @@ export class JMAPClient implements IJMAPClient {
 
     if (response.methodResponses?.[0]?.[0] === "CalendarEvent/parse") {
       const result = response.methodResponses[0][1];
-      console.log('[PARSE DEBUG] CalendarEvent/parse raw result:', JSON.stringify(result, null, 2));
+      debug.log('calendar', '[CalendarEvent/parse] raw result:', result);
 
       if (result.notParsable && result.notParsable.includes(blobId)) {
         throw new Error("Invalid calendar file format");


### PR DESCRIPTION
## Summary

Opening a message that carries a calendar invitation prints the whole parsed event to the browser console - title, description, attendees, location - through a leftover `[PARSE DEBUG]` `console.log` in `getCalendarEventFromBlob`. It fires in production builds, on every such message.

## Changes

- Route the dump through the debug logger the rest of the file already uses: `debug.log('calendar', '[CalendarEvent/parse] raw result:', result)`. It honours the `debugMode` setting and its per-category filters, so the output only appears when someone has switched the calendar debug category on.
- Pass the object rather than a pre-formatted string. The previous line ran `JSON.stringify(result, null, 2)` unconditionally as an argument, so the serialisation happened even though nothing was listening.

## Related issues

None - noticed while looking at the console on a message with an invitation.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

No UI changes - console output only. No user-facing strings, so `locales/` is untouched.

## Notes for reviewers

- The line dates back to 0f5d030d (calendar invitations RSVP / trust assessment / file preview) and looks like debugging that simply stayed in. `lib/jmap/client.ts` calls `debug.log('calendar', ...)` in 22 other places, so this was the only outlier in the file.
- Beyond the noise, event descriptions and attendee addresses ending up in the console is the kind of thing that leaks into screen recordings and support sessions.
- Verification: `npm run typecheck` clean, `npm run lint` 0 errors (8 pre-existing warnings, all in untouched calendar view files), `npx vitest run` 2331/2331, `npm run build` succeeds, `npm run test:translations` 48/48. `npm run test:integration` not run - no Docker stack on this machine.
- There are a few more unconditional `console.log` calls elsewhere (`components/tour/tour-overlay.tsx` logs four lines per tour step, `components/service-worker-registration.tsx` logs on registration). 