### PR TITLE
feat: add a refresh button to the mail list toolbar

### DIFF
--- a/app/(main)/[locale]/login/page.tsx
+++ b/app/(main)/[locale]/login/page.tsx
@@ -634,7 +634,10 @@ export default function LoginPage() {
       formData.username,
       formData.password,
       totpCode || undefined,
-      rememberMe
+      // Only persist credentials when the server actually supports it
+      // (a SESSION_SECRET is configured). Prevents a broken cookie write
+      // when the remember-me feature is disabled server-side.
+      rememberMeEnabled && rememberMe
     );
 
     if (success) {

--- a/app/(main)/[locale]/page.tsx
+++ b/app/(main)/[locale]/page.tsx
@@ -712,12 +712,13 @@ export default function Home() {
     handlers: keyboardHandlers,
   });
 
-  // Intercept browser refresh gestures (F5, Ctrl/Cmd+R, pull-to-refresh)
-  // and refresh mail data via JMAP instead of reloading the page.
-  useRefreshGesture({
-    enabled: isAuthenticated && !!client,
-    onRefresh: async () => {
-      if (!client) return;
+  // Shared mail refresh: re-fetch mailboxes (unread counts) + the active list
+  // via JMAP. Used by both the browser refresh gestures and the toolbar button.
+  const [isManualRefreshing, setIsManualRefreshing] = useState(false);
+  const handleManualRefresh = useCallback(async () => {
+    if (!client) return;
+    setIsManualRefreshing(true);
+    try {
       const state = useEmailStore.getState();
       if (state.isScheduledView || state.selectedMailbox === SCHEDULED_MAILBOX_ID) {
         await Promise.all([
@@ -729,7 +730,16 @@ export default function Home() {
         await state.refreshScheduledMetadata(client);
         await (state.selectedMailbox ? state.fetchEmails(client, state.selectedMailbox) : state.fetchEmails(client));
       }
-    },
+    } finally {
+      setIsManualRefreshing(false);
+    }
+  }, [client]);
+
+  // Intercept browser refresh gestures (F5, Ctrl/Cmd+R, pull-to-refresh)
+  // and refresh mail data via JMAP instead of reloading the page.
+  useRefreshGesture({
+    enabled: isAuthenticated && !!client,
+    onRefresh: handleManualRefresh,
   });
 
   useEffect(() => {
@@ -3132,6 +3142,20 @@ export default function Home() {
                         {activeFilterCount(searchFilters)}
                       </span>
                     )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleManualRefresh}
+                    disabled={!client || isManualRefreshing}
+                    className={cn(
+                      "flex-shrink-0 p-2 rounded-md transition-colors",
+                      "text-muted-foreground hover:text-foreground hover:bg-muted",
+                      (!client || isManualRefreshing) && "opacity-50 cursor-not-allowed"
+                    )}
+                    title={tCommon("refresh")}
+                    aria-label={tCommon("refresh")}
+                  >
+                    <RotateCcw className={cn("w-4 h-4", isManualRefreshing && "animate-spin")} />
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Refresh button

Today the only way to re-fetch mail is a browser refresh gesture — F5, Ctrl/Cmd+R, or pull-to-refresh — which `useRefreshGesture` intercepts and turns into a JMAP soft-refresh. That works, but there's no visible control, so users who look for one find nothing and end up reloading the page.

This extracts the gesture's inline `onRefresh` into a shared `handleManualRefresh` with a spinner state, then reuses it for a button next to the filter control in the mail-list toolbar:

- same JMAP refresh path as the gesture, so behaviour can't drift between the two
- icon spins while the fetch is in flight, button disabled until it settles, so clicks can't stack requests
- uses the existing `common.refresh` key — no new strings to translate

## Small related fix

The login submit passed `rememberMe` through unconditionally. The checkbox only renders when `rememberMeEnabled` (i.e. the server has a `SESSION_SECRET`), so with the feature disabled server-side the client could still ask for a credential cookie the server won't write. Now guarded with `rememberMeEnabled && rememberMe`.

## Testing

`npm run typecheck` clean, `eslint` clean on both changed files (the repo's existing warnings in `components/calendar/*` and `hooks/use-calendar-locale.ts` are untouched).

Running in a downstream fork since early July.

🤖 Generated with [Claude Code](https://claude.com/claude-code)