### PR TITLE
feat: manage public keys and at rest encryption

### DIFF
--- a/components/settings/account-security-settings.tsx
+++ b/components/settings/account-security-settings.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import QRCode from 'qrcode';
 import * as OTPAuth from 'otpauth';
-import { Shield, Key, Smartphone, Lock, Trash2, Plus, Eye, EyeOff, Copy, Check, Loader2, Monitor, Terminal, QrCode } from 'lucide-react';
+import { Shield, Key, Smartphone, Lock, Trash2, Plus, Eye, EyeOff, Copy, Check, Loader2, Monitor, Terminal, QrCode, Unlock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { SettingsSection, SettingItem, ToggleSwitch } from './settings-section';
@@ -570,25 +570,271 @@ function ApiKeysSection() {
   );
 }
 
-function EncryptionSection() {
+function PublicKeysSection() {
   const t = useTranslations('settings.security');
-  const { encryptionType, isLoadingCrypto } = useAccountSecurityStore();
+  const tk = (key: string) => t(`public_keys.${key}`);
+  const {
+    publicKeys,
+    createPublicKey,
+    removePublicKey,
+    encryptionConfig,
+    updateEncryptionAtRest,
+    isSaving,
+    isLoadingAuth,
+  } = useAccountSecurityStore();
 
-  if (isLoadingCrypto) {
+  const [showAdd, setShowAdd] = useState(false);
+  const [description, setDescription] = useState('');
+  const [publicKey, setPublicKey] = useState('');
+
+  // Encryption config dialog state
+  const [selectedKeyForEncryption, setSelectedKeyForEncryption] = useState<string | null>(null);
+  const [selectedAlgorithm, setSelectedAlgorithm] = useState<'Aes128' | 'Aes256'>('Aes256');
+  const [encryptOnAppend, setEncryptOnAppend] = useState(false);
+  const [allowSpamTraining, setAllowSpamTraining] = useState(false);
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!description.trim() || !publicKey.trim()) return;
+
+    try {
+      await createPublicKey({
+        description: description.trim(),
+        key: publicKey.trim(),
+      });
+      setDescription('');
+      setPublicKey('');
+      setShowAdd(false);
+      toast.success(tk('added'));
+    } catch (err) {
+      toast.error(tk('add_error'), err instanceof Error ? err.message : undefined);
+    }
+  };
+
+  const handleRemove = async (id: string) => {
+    try {
+      await removePublicKey(id);
+      toast.success(tk('removed'));
+    } catch (err) {
+      toast.error(tk('remove_error'), err instanceof Error ? err.message : undefined);
+    }
+  };
+
+  const handleToggleEncryption = async (keyId: string) => {
+    const isCurrentlyActiveKey =
+      encryptionConfig.type !== 'Disabled' && encryptionConfig.publicKeyId === keyId;
+
+    if (isCurrentlyActiveKey) {
+      // Disable encryption
+      try {
+        await updateEncryptionAtRest({ type: 'Disabled' });
+        toast.success(t('encryption.disabled_success'));
+      } catch (err) {
+        toast.error(t('encryption.error'), err instanceof Error ? err.message : undefined);
+      }
+    } else {
+      // Open algorithm selection dialog for this key
+      setSelectedKeyForEncryption(keyId);
+      setSelectedAlgorithm('Aes256');
+      setEncryptOnAppend(false);
+      setAllowSpamTraining(false);
+    }
+  };
+
+  const handleEnableEncryptionSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedKeyForEncryption) return;
+
+    try {
+      await updateEncryptionAtRest({
+        type: selectedAlgorithm,
+        publicKeyId: selectedKeyForEncryption,
+        encryptOnAppend,
+        allowSpamTraining,
+      });
+      setSelectedKeyForEncryption(null);
+      toast.success(t('encryption.enabled_success'));
+    } catch (err) {
+      toast.error(t('encryption.error'), err instanceof Error ? err.message : undefined);
+    }
+  };
+
+  if (isLoadingAuth) {
     return (
-      <SettingItem label={t('encryption.label')} description={t('encryption.description')}>
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 mb-2">
+          <Lock className="w-4 h-4 text-muted-foreground" />
+          <h4 className="text-sm font-medium text-foreground">{tk('title')}</h4>
+        </div>
         <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
-      </SettingItem>
+      </div>
     );
   }
 
-  const isEnabled = encryptionType !== 'Disabled';
   return (
-    <SettingItem label={t('encryption.label')} description={t('encryption.description')}>
-      <span className={cn('text-xs font-medium', isEnabled ? 'text-green-600 dark:text-green-400' : 'text-muted-foreground')}>
-        {isEnabled ? t('encryption.active', { type: encryptionType }) : t('encryption.inactive')}
-      </span>
-    </SettingItem>
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Lock className="w-4 h-4 text-muted-foreground" />
+          <h4 className="text-sm font-medium text-foreground">{t('encryption.section_title')}</h4>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => setShowAdd(!showAdd)}>
+          <Plus className="w-3 h-3 me-1" />
+          {t('app_passwords.add')}
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">{t('encryption.description')}</p>
+
+      {showAdd && (
+        <form onSubmit={handleAdd} className="p-3 bg-muted rounded-md space-y-2">
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">{tk('name_label')}</label>
+            <Input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={tk('name_placeholder')}
+              required
+            />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">{tk('key_label')}</label>
+            <textarea
+              value={publicKey}
+              onChange={(e) => setPublicKey(e.target.value)}
+              placeholder={tk('key_placeholder')}
+              rows={3}
+              required
+              className="w-full text-xs font-mono px-3 py-2 rounded-md border border-border bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+          <div className="flex gap-2">
+            <Button type="submit" size="sm" disabled={isSaving || !description.trim() || !publicKey.trim()}>
+              {isSaving ? <Loader2 className="w-4 h-4 me-1 animate-spin" /> : null}
+              {t('app_passwords.create')}
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={() => setShowAdd(false)}>
+              {t('app_passwords.cancel')}
+            </Button>
+          </div>
+        </form>
+      )}
+
+      {selectedKeyForEncryption && (
+        <form onSubmit={handleEnableEncryptionSubmit} className="p-3 bg-muted border border-border rounded-md space-y-3">
+          <h5 className="text-xs font-semibold text-foreground">{t('encryption.configure_title')}</h5>
+          
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">{t('encryption.algorithm_label')}</label>
+            <select
+              value={selectedAlgorithm}
+              onChange={(e) => setSelectedAlgorithm(e.target.value as 'Aes128' | 'Aes256')}
+              className="w-full text-xs px-3 py-1.5 rounded-md border border-border bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="Aes256">AES-256</option>
+              <option value="Aes128">AES-128</option>
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <label className="flex items-center gap-2 cursor-pointer text-xs text-foreground">
+              <input
+                type="checkbox"
+                checked={encryptOnAppend}
+                onChange={(e) => setEncryptOnAppend(e.target.checked)}
+                className="rounded border-border text-primary focus:ring-ring"
+              />
+              {t('encryption.encrypt_on_append')}
+            </label>
+
+            <label className="flex items-center gap-2 cursor-pointer text-xs text-foreground">
+              <input
+                type="checkbox"
+                checked={allowSpamTraining}
+                onChange={(e) => setAllowSpamTraining(e.target.checked)}
+                className="rounded border-border text-primary focus:ring-ring"
+              />
+              {t('encryption.allow_spam_training')}
+            </label>
+          </div>
+
+          <div className="flex gap-2 pt-1">
+            <Button type="submit" size="sm" disabled={isSaving}>
+              {isSaving ? <Loader2 className="w-4 h-4 me-1 animate-spin" /> : null}
+              {t('encryption.enable_button')}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setSelectedKeyForEncryption(null)}
+            >
+              {t('app_passwords.cancel')}
+            </Button>
+          </div>
+        </form>
+      )}
+
+      {publicKeys.length > 0 ? (
+        <div className="space-y-1">
+          {publicKeys.map((key) => {
+            const isEncryptedWithThisKey =
+              encryptionConfig.type !== 'Disabled' && encryptionConfig.publicKeyId === key.id;
+
+            return (
+              <div key={key.id} className="flex items-start justify-between py-2 px-3 bg-muted/50 rounded-md gap-2">
+                <div className="flex flex-col min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-foreground truncate">{key.description || key.id}</span>
+                    {isEncryptedWithThisKey && (
+                      <span className="text-[10px] bg-green-500/10 text-green-600 dark:text-green-400 font-medium px-1.5 py-0.5 rounded border border-green-500/20">
+                        {encryptionConfig.type}
+                      </span>
+                    )}
+                  </div>
+                  {key.createdAt && (
+                    <span className="text-xs text-muted-foreground">
+                      {new Date(key.createdAt).toLocaleDateString()}
+                    </span>
+                  )}
+                  <code className="text-[10px] font-mono bg-background border border-border rounded px-1.5 py-0.5 text-muted-foreground truncate mt-1">
+                    {key.key}
+                  </code>
+                </div>
+
+                <div className="flex items-center gap-1 shrink-0">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleToggleEncryption(key.id)}
+                    disabled={isSaving}
+                    title={isEncryptedWithThisKey ? t('encryption.disable_tooltip') : t('encryption.enable_tooltip')}
+                    className={cn(
+                      isEncryptedWithThisKey
+                        ? 'text-green-600 hover:text-green-700 dark:text-green-400'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    {isEncryptedWithThisKey ? <Lock className="w-4 h-4" /> : <Unlock className="w-4 h-4" />}
+                  </Button>
+
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleRemove(key.id)}
+                    disabled={isSaving || isEncryptedWithThisKey}
+                    className="text-destructive hover:text-destructive"
+                  >
+                    <Trash2 className="w-3 h-3" />
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground italic">{tk('none')}</p>
+      )}
+    </div>
   );
 }
 
@@ -780,7 +1026,7 @@ function LinkDeviceSection() {
 
 export function AccountSecuritySettings() {
   const t = useTranslations('settings.security');
-  const { isStalwart, isProbing, probe, fetchAll, fetchAuthInfo } = useAccountSecurityStore();
+  const { isStalwart, isProbing, probe, fetchAll, fetchAuthInfo, fetchPublicKeys, fetchCryptoInfo } = useAccountSecurityStore();
   const { isAuthenticated, authMode, client } = useAuthStore();
   const isOAuth = authMode === 'oauth';
 
@@ -795,13 +1041,15 @@ export function AccountSecuritySettings() {
         if (detected) {
           if (isOAuth) {
             fetchAuthInfo();
+            fetchPublicKeys();
+            fetchCryptoInfo();
           } else {
             fetchAll();
           }
         }
       });
     }
-  }, [isAuthenticated, client, isStalwart, probe, fetchAll, fetchAuthInfo, isOAuth]);
+  }, [isAuthenticated, client, isStalwart, probe, fetchAll, fetchAuthInfo, isOAuth, fetchPublicKeys, fetchCryptoInfo]);
 
   if (isProbing) {
     return (
@@ -871,19 +1119,11 @@ export function AccountSecuritySettings() {
             <LinkDeviceSection />
           </>
         )}
-
-        {!isOAuth && (
-          <>
             <div className="border-t border-border" />
             <div>
-              <div className="flex items-center gap-2 mb-3">
-                <Lock className="w-4 h-4 text-muted-foreground" />
-                <h4 className="text-sm font-medium text-foreground">{t('encryption.section_title')}</h4>
-              </div>
-              <EncryptionSection />
+              
+              <PublicKeysSection />
             </div>
-          </>
-        )}
       </div>
     </SettingsSection>
   );

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -646,7 +646,6 @@
     "drop_files": "Drop files to attach",
     "show_less": "Show less",
     "send_failed": "Failed to send email",
-    "send_timeout": "The server stopped responding. Check your Sent folder before sending again — the message may have gone out.",
     "continue_draft": "Continue draft",
     "close_draft_title": "Save or discard draft?",
     "close_draft_message": "You have unsaved changes. Would you like to save this as a draft or discard it?",
@@ -1524,7 +1523,23 @@
         "inactive": "Disabled",
         "enabled": "Encryption at rest enabled",
         "disabled_success": "Encryption at rest disabled",
-        "error": "Failed to update encryption settings"
+        "error": "Failed to update encryption settings",
+        "algorithm_label": "Encryption Algorithm",
+        "encrypt_on_append": "Encrypt new emails on upload",
+        "allow_spam_training": "Allow spam training before encrypting emails",
+        "enable_encryption": "Enable encryption",
+        "enable_tooltip": "Enable encryption with this key",
+        "configure_title": "Enable encryption with this key",
+        "enable_button": "Enable",
+        "disable_tooltip": "Disable encryption",
+        "enabled_success": "Encryption at rest enabled"
+      },
+      "public_keys":{
+        "name_label": "Public Key name",
+        "name_placeholder": "e.g. My Key",
+        "key_label": "Public Key (S/MIME or PGP ASCII-armored)",
+        "key_placeholder": "Paste your public key here",
+        "none": "No public keys configured"
       },
       "email_client": {
         "title": "Email Client Setup",

--- a/stores/__tests__/account-security-store.test.ts
+++ b/stores/__tests__/account-security-store.test.ts
@@ -137,7 +137,7 @@ describe('account-security-store', () => {
 
       await useAccountSecurityStore.getState().fetchCryptoInfo();
 
-      expect(useAccountSecurityStore.getState().encryptionType).toBe('Aes256');
+      expect(useAccountSecurityStore.getState().encryptionConfig.type).toBe('Aes256');
     });
 
     it('defaults to Disabled when @type is missing or unknown', async () => {
@@ -147,7 +147,7 @@ describe('account-security-store', () => {
 
       await useAccountSecurityStore.getState().fetchCryptoInfo();
 
-      expect(useAccountSecurityStore.getState().encryptionType).toBe('Disabled');
+      expect(useAccountSecurityStore.getState().encryptionConfig.type).toBe('Disabled');
     });
   });
 
@@ -407,7 +407,7 @@ describe('account-security-store', () => {
         otpEnabled: true,
         appPasswords: [{ id: 'p', description: 'd', createdAt: null, expiresAt: null, allowedIps: [] }],
         apiKeys: [{ id: 'k', description: 'd', createdAt: null, expiresAt: null, allowedIps: [] }],
-        encryptionType: 'Aes256',
+        encryptionConfig: { type: 'Disabled', publicKeyId: null, encryptOnAppend: false, allowSpamTraining: false },
         displayName: 'user',
         emails: ['a@b'],
         quota: 10,
@@ -422,7 +422,7 @@ describe('account-security-store', () => {
       expect(state.otpEnabled).toBe(false);
       expect(state.appPasswords).toEqual([]);
       expect(state.apiKeys).toEqual([]);
-      expect(state.encryptionType).toBe('Disabled');
+      expect(state.encryptionConfig.type).toBe('Disabled');
       expect(state.displayName).toBe('');
       expect(state.emails).toEqual([]);
       expect(state.quota).toBe(0);

--- a/stores/account-security-store.ts
+++ b/stores/account-security-store.ts
@@ -5,6 +5,13 @@ import { stalwartJmap, requireResult, type JmapMethodResponse } from '@/lib/stal
 
 export type EncryptionType = 'Disabled' | 'Aes128' | 'Aes256';
 
+export interface EncryptionAtRestConfig {
+  type: EncryptionType;
+  publicKeyId: string | null;
+  encryptOnAppend?: boolean;
+  allowSpamTraining?: boolean;
+}
+
 export interface AppPasswordInfo {
   id: string;
   description: string;
@@ -27,6 +34,23 @@ export interface AppCredentialInput {
   allowedIps?: string[];
 }
 
+export interface PublicKeyInfo {
+  id: string;
+  accountId: string;
+  description: string;
+  key: string;
+  createdAt?: string | null;
+  expiresAt?: string | null;
+  emailAddresses: string[];
+}
+
+export interface PublicKeyInput {
+  description: string;
+  key: string;
+  emailAddresses?: string[];
+  expiresAt?: string | null;
+}
+
 interface AccountSecurityState {
   isStalwart: boolean | null;
   isProbing: boolean;
@@ -38,8 +62,10 @@ interface AccountSecurityState {
   isLoadingAuth: boolean;
 
   // Encryption-at-rest
-  encryptionType: EncryptionType;
+  encryptionConfig: EncryptionAtRestConfig;
+  publicKeys: PublicKeyInfo[];
   isLoadingCrypto: boolean;
+  isLoadingPublicKeys: boolean;
 
   // Profile
   displayName: string;
@@ -55,6 +81,7 @@ interface AccountSecurityState {
   fetchAuthInfo: () => Promise<void>;
   fetchCryptoInfo: () => Promise<void>;
   fetchPrincipal: () => Promise<void>;
+  fetchPublicKeys: () => Promise<void>;
   fetchAll: () => Promise<void>;
 
   changePassword: (currentPassword: string, newPassword: string) => Promise<void>;
@@ -68,6 +95,15 @@ interface AccountSecurityState {
 
   createApiKey: (input: AppCredentialInput) => Promise<{ id: string; secret: string }>;
   removeApiKey: (id: string) => Promise<void>;
+
+  createPublicKey: (input: PublicKeyInput) => Promise<string>;
+  removePublicKey: (id: string) => Promise<void>;
+  updateEncryptionAtRest: (config: {
+    type: EncryptionType;
+    publicKeyId?: string | null;
+    encryptOnAppend?: boolean;
+    allowSpamTraining?: boolean;
+  }) => Promise<void>;
 
   clearState: () => void;
 }
@@ -91,9 +127,32 @@ function credentialFromResult(raw: Record<string, unknown>): AppPasswordInfo {
   };
 }
 
+function publicKeyFromResult(raw: Record<string, unknown>): PublicKeyInfo {
+  const emailAddresses = raw.emailAddresses && typeof raw.emailAddresses === 'object'
+    ? Object.keys(raw.emailAddresses as Record<string, unknown>)
+    : Array.isArray(raw.emailAddresses)
+      ? raw.emailAddresses.map(String)
+      : [];
+
+  return {
+    id: String(raw.id ?? ''),
+    accountId: raw.accountId ? String(raw.accountId) : getPrimaryAccountId(),
+    description: typeof raw.description === 'string' ? raw.description : '',
+    key: typeof raw.key === 'string' ? raw.key : '',
+    createdAt: typeof raw.createdAt === 'string' ? raw.createdAt : null,
+    expiresAt: typeof raw.expiresAt === 'string' ? raw.expiresAt : null,
+    emailAddresses,
+  };
+}
+
 function ipsToMap(ips?: string[]): Record<string, true> | undefined {
   if (!ips || ips.length === 0) return undefined;
   return Object.fromEntries(ips.map((ip) => [ip, true]));
+}
+
+function emailsToMap(emails?: string[]): Record<string, true> | undefined {
+  if (!emails || emails.length === 0) return undefined;
+  return Object.fromEntries(emails.map((email) => [email, true]));
 }
 
 function buildCreateBody(input: AppCredentialInput): Record<string, unknown> {
@@ -190,22 +249,22 @@ function requireAccountPasswordUpdate(responses: JmapMethodResponse[], fallbackE
   }
 }
 
-function extractEncryptionType(raw: unknown): EncryptionType {
-  if (!raw || typeof raw !== 'object') return 'Disabled';
-  const type = (raw as { ['@type']?: string })['@type'];
-  if (type === 'Aes128' || type === 'Aes256') return type;
-  return 'Disabled';
-}
-
 export const useAccountSecurityStore = create<AccountSecurityState>()((set, get) => ({
   isStalwart: null,
   isProbing: false,
   otpEnabled: false,
   appPasswords: [],
   apiKeys: [],
+  publicKeys: [],
   isLoadingAuth: false,
-  encryptionType: 'Disabled',
+  encryptionConfig: {
+    type: 'Disabled',
+    publicKeyId: null,
+    encryptOnAppend: false,
+    allowSpamTraining: false,
+  },
   isLoadingCrypto: false,
+  isLoadingPublicKeys: false,
   displayName: '',
   emails: [],
   quota: 0,
@@ -293,20 +352,104 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     try {
       const accountId = getPrimaryAccountId();
       const responses = await stalwartJmap([
-        ['x:AccountSettings/get', { accountId, ids: ['singleton'] }, '0'],
+        [
+          'x:AccountSettings/get',
+          {
+            accountId,
+            ids: ['singleton'],
+          },
+          '0',
+        ],
       ]);
-      const result = requireResult<{ list: Array<{ encryptionAtRest?: unknown }> }>(
+
+      const result = requireResult<{ list: Array<{ encryptionAtRest?: Record<string, unknown> }> }>(
         responses,
-        'x:AccountSettings/get',
+        'x:AccountSettings/get'
       );
-      const encryptionType = extractEncryptionType(result.list?.[0]?.encryptionAtRest);
-      set({ encryptionType, isLoadingCrypto: false });
+
+      const settings = result.list?.[0];
+      const enc = settings?.encryptionAtRest ?? {};
+
+      // The backend returns type via "@type" (e.g. "Disabled", "Aes128", "Aes256")
+      const rawType = String(enc['@type'] ?? 'Disabled') as EncryptionType;
+      const publicKeyId = typeof enc.publicKey === 'string' ? enc.publicKey : null;
+      const encryptOnAppend = Boolean(enc.encryptOnAppend);
+      const allowSpamTraining = Boolean(enc.allowSpamTraining);
+
+      set({
+        encryptionConfig: {
+          type: rawType,
+          publicKeyId,
+          encryptOnAppend,
+          allowSpamTraining,
+        },
+        isLoadingCrypto: false,
+      });
     } catch (error) {
-      debug.error('Failed to fetch crypto info:', error);
+      debug.error('Failed to fetch encryption settings:', error);
       set({
         isLoadingCrypto: false,
-        error: error instanceof Error ? error.message : 'Failed to fetch crypto info',
+        error: error instanceof Error ? error.message : 'Failed to fetch encryption settings',
       });
+    }
+  },
+
+  updateEncryptionAtRest: async ({ type, publicKeyId, encryptOnAppend = false, allowSpamTraining = false }) => {
+    set({ isSaving: true, error: null });
+    try {
+      const accountId = getPrimaryAccountId();
+      let encryptionAtRestPayload: Record<string, unknown>;
+
+      if (type === 'Disabled') {
+        encryptionAtRestPayload = {
+          '@type': 'Disabled',
+        };
+      } else {
+        if (!publicKeyId) {
+          throw new Error('A Public Key ID is required to enable encryption.');
+        }
+        encryptionAtRestPayload = {
+          '@type': type,
+          publicKey: publicKeyId,
+          encryptOnAppend,
+          allowSpamTraining,
+        };
+      }
+
+      const responses = await stalwartJmap([
+        [
+          'x:AccountSettings/set',
+          {
+            accountId,
+            update: {
+              singleton: {
+                encryptionAtRest: encryptionAtRestPayload,
+              },
+            },
+          },
+          '0',
+        ],
+      ]);
+
+      const result = requireResult<{
+        updated?: Record<string, unknown>;
+        notUpdated?: Record<string, { type: string; description?: string }>;
+      }>(responses, 'x:AccountSettings/set');
+
+      const notUpdated = result.notUpdated?.singleton;
+      if (notUpdated) {
+        throw new Error(notUpdated.description || notUpdated.type || 'Failed to update encryption settings');
+      }
+
+      // Refresh settings after success
+      await get().fetchCryptoInfo();
+      set({ isSaving: false });
+    } catch (error) {
+      set({
+        isSaving: false,
+        error: error instanceof Error ? error.message : 'Failed to update encryption settings',
+      });
+      throw error;
     }
   },
 
@@ -353,8 +496,8 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
   },
 
   fetchAll: async () => {
-    const { fetchAuthInfo, fetchCryptoInfo, fetchPrincipal } = get();
-    await Promise.allSettled([fetchAuthInfo(), fetchCryptoInfo(), fetchPrincipal()]);
+    const { fetchAuthInfo, fetchCryptoInfo, fetchPrincipal, fetchPublicKeys } = get();
+    await Promise.allSettled([fetchAuthInfo(), fetchCryptoInfo(), fetchPrincipal(), fetchPublicKeys()]);
   },
 
   changePassword: async (currentPassword, newPassword) => {
@@ -479,6 +622,118 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     return removeCredential(get, set, 'x:ApiKey/set', id, 'Failed to remove API key');
   },
 
+  fetchPublicKeys: async () => {
+    set({ isLoadingPublicKeys: true, error: null });
+    try {
+      const accountId = getPrimaryAccountId();
+      const queryResponses = await stalwartJmap([
+        ['x:PublicKey/query', { filter: { accountId } }, '0'],
+      ]);
+
+      const queryResult = requireResult<{ ids: string[] }>(queryResponses, 'x:PublicKey/query');
+
+      if (!queryResult.ids || queryResult.ids.length === 0) {
+        set({ publicKeys: [], isLoadingPublicKeys: false });
+        return;
+      }
+
+      const getResponses = await stalwartJmap([
+        ['x:PublicKey/get', {accountId, ids: queryResult.ids }, '0'],
+      ]);
+      const getResult = requireResult<{ list: Array<Record<string, unknown>> }>(getResponses, 'x:PublicKey/get');
+
+      const publicKeys = (getResult.list ?? []).map(publicKeyFromResult);
+      set({ publicKeys, isLoadingPublicKeys: false });
+    } catch (error) {
+      debug.error('Failed to fetch public keys:', error);
+      set({
+        isLoadingPublicKeys: false,
+        error: error instanceof Error ? error.message : 'Failed to fetch public keys',
+      });
+    }
+  },
+
+  createPublicKey: async (input) => {
+    set({ isSaving: true, error: null });
+    try {
+      const accountId = getPrimaryAccountId();
+      const tmpId = 'new1';
+
+      const createPayload: Record<string, unknown> = {
+        description: input.description,
+        key: input.key,
+        emailAddresses: emailsToMap(input.emailAddresses) ?? {},
+      };
+
+      if (input.expiresAt) {
+        createPayload.expiresAt = input.expiresAt;
+      }
+
+      const responses = await stalwartJmap([
+        [
+          'x:PublicKey/set',
+          {
+            accountId,
+            create: {
+              [tmpId]: createPayload,
+            },
+          },
+          '0',
+        ],
+      ]);
+
+      const result = requireResult<{
+        created?: Record<string, { id: string }>;
+        notCreated?: Record<string, { type: string; description?: string }>;
+      }>(responses, 'x:PublicKey/set');
+
+      const notCreated = result.notCreated?.[tmpId];
+      if (notCreated) {
+        throw new Error(notCreated.description || notCreated.type || 'Failed to create public key');
+      }
+
+      const created = result.created?.[tmpId];
+      if (!created?.id) {
+        throw new Error('Server did not return created public key');
+      }
+
+      await get().fetchPublicKeys();
+      set({ isSaving: false });
+      return created.id;
+    } catch (error) {
+      set({
+        isSaving: false,
+        error: error instanceof Error ? error.message : 'Failed to create public key',
+      });
+      throw error;
+    }
+  },
+
+  removePublicKey: async (id) => {
+    set({ isSaving: true, error: null });
+    try {
+      const accountId = getPrimaryAccountId();
+      await stalwartJmap([
+        [
+          'x:PublicKey/set',
+          {
+            accountId,
+            destroy: [id],
+          },
+          '0',
+        ],
+      ]);
+      await get().fetchPublicKeys();
+      set({ isSaving: false });
+    } catch (error) {
+      set({
+        isSaving: false,
+        error: error instanceof Error ? error.message : 'Failed to remove public key',
+      });
+      throw error;
+    }
+  },
+
   clearState: () => set({
     isStalwart: null,
     isProbing: false,
@@ -486,7 +741,12 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     appPasswords: [],
     apiKeys: [],
     isLoadingAuth: false,
-    encryptionType: 'Disabled',
+    encryptionConfig: {
+      type: 'Disabled',
+      publicKeyId: null,
+      encryptOnAppend: false,
+      allowSpamTraining: false,
+    },
     isLoadingCrypto: false,
     displayName: '',
     emails: [],


### PR DESCRIPTION
## Summary
This PR allow users to manage their public keys / S/MIME certificates and the state of encryption at rest. It allow them to folow the workflow described at https://stalw.art/docs/encryption/manage/#enabling-encryption :

> End users enable encryption from the self-service portal by performing two steps:
>1. Register at least one public key as a [PublicKey](https://stalw.art/docs/ref/object/public-key) object. Upload the OpenPGP public key or S/MIME certificate and fill in [description](https://stalw.art/docs/ref/object/public-key#description); 
>2. Set the [encryptionAtRest](https://stalw.art/docs/ref/object/account-settings#encryptionatrest) field to the chosen algorithm variant, referencing the registered key by id.

## Changes
- Remove the former EncryptedAtRest Section and replace it with a PublicKey Section in Security Settings. This new section handle the Public Key and the Encryption State at same time
- add PublicKeyInfo type, PublicKeyInput type, fetchPublicKeys method, createPublicKey, removePublicKey
- add EncryptionAtRestConfig type, updateEncryptionAtRest method
- Section is shown even if users are authenticated with SSO
## Related issues

Related to #481 

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Screenshots / demo
<img width="776" height="261" alt="Copie d&#39;écran_20260805_170506" src="https://github.com/user-attachments/assets/eb750317-41f9-4b06-b78f-2b32a9ba77e3" />
<img width="776" height="392" alt="Copie d&#39;écran_20260805_170434" src="https://github.com/user-attachments/assets/64a56688-cff4-4ec8-ad1f-b4de2562eba3" />
<img width="776" height="193" alt="Copie d&#39;écran_20260805_170416" src="https://github.com/user-attachments/assets/f9d4e175-19a1-49bc-9817-eb1049b642c2" />
<img width="776" height="352" alt="Copie d&#39;écran_20260805_170400" src="https://github.com/user-attachments/assets/eeec6aae-eff9-4dd4-af9a-40d56dd9a31c" />
<img width="776" height="352" alt="Copie d&#39;écran_20260805_170322" src="https://github.com/user-attachments/assets/0b5097fe-f1a8-418a-8633-659815d4e3a8" />
<img width="776" height="161" alt="Copie d&#39;écran_20260805_170259" src="https://github.com/user-attachments/assets/df605b0a-6d28-447c-9824-23e975916a55" />


## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
