### PR TITLE
fix(calendar): stop writing blank participant names and empty descriptions

### DIFF
--- a/components/calendar/event-modal.tsx
+++ b/components/calendar/event-modal.tsx
@@ -418,9 +418,10 @@ export function EventModal({
 
     const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
+    const trimmedDescription = description.trim();
+
     const data: Partial<CalendarEvent> = {
       title: trimmedTitle,
-      description: description.trim(),
       start: startStr,
       duration,
       timeZone: allDay ? null : timeZone,
@@ -430,6 +431,13 @@ export function EventModal({
       freeBusyStatus: "busy",
       privacy: "public",
     };
+
+    // On an existing event the empty string is how a description gets cleared, but
+    // sending it on creation writes a `DESCRIPTION:` with nothing after it — which
+    // invitation e-mails then render as a "Description" heading over blank space.
+    if (trimmedDescription || event) {
+      data.description = trimmedDescription;
+    }
 
     if (!event) {
       data.uid = generateUUID();

--- a/lib/__tests__/calendar-participants.test.ts
+++ b/lib/__tests__/calendar-participants.test.ts
@@ -361,6 +361,23 @@ describe('buildParticipantMap', () => {
     });
   });
 
+  it('omits blank names rather than sending an empty one', () => {
+    const map = buildParticipantMap(
+      { name: '', email: 'alice@example.com' },
+      [
+        { name: '   ', email: 'bob@example.com' },
+        { name: '  Carol  ', email: 'carol@example.com' },
+      ]
+    );
+    const entries = Object.values(map);
+
+    // An empty name becomes a bare `CN=` downstream, which renders as a dangling
+    // "- Organizer" and as guests listed with nothing before their address.
+    expect(entries.find(p => p.email === 'alice@example.com')).not.toHaveProperty('name');
+    expect(entries.find(p => p.email === 'bob@example.com')).not.toHaveProperty('name');
+    expect(entries.find(p => p.email === 'carol@example.com')!.name).toBe('Carol');
+  });
+
   it('sets kind to individual for all entries', () => {
     const map = buildParticipantMap(
       { name: 'Alice', email: 'alice@example.com' },

--- a/lib/calendar-participants.ts
+++ b/lib/calendar-participants.ts
@@ -134,12 +134,17 @@ export function buildParticipantMap(
 
   const generateId = () => generateUUID();
 
+  // An empty name is not a name: sent as "", it reaches the iCalendar stream as a
+  // bare `CN=`, and recipients see a dangling "- Organizer" or a guest listed with
+  // nothing before their address. Omitted, clients fall back to the address.
+  const named = (name: string) => (name.trim() ? { name: name.trim() } : {});
+
   // calendarAddress is the scheduling address in draft-ietf-calext-jscalendarbis
   // (implemented by Stalwart); the RFC 8984 sendTo property is retired there and
   // stored as an inert JSPROP, so it is intentionally not sent.
   participants[generateId()] = {
     '@type': 'Participant',
-    name: organizer.name,
+    ...named(organizer.name),
     email: organizer.email,
     calendarAddress: `mailto:${organizer.email}`,
     // owner only, NOT attendee: with roles.attendee set, Stalwart's server-side
@@ -155,7 +160,7 @@ export function buildParticipantMap(
   attendees.forEach((a) => {
     participants[generateId()] = {
       '@type': 'Participant',
-      name: a.name,
+      ...named(a.name),
       email: a.email,
       calendarAddress: `mailto:${a.email}`,
       roles: { attendee: true },


### PR DESCRIPTION
## Problem

When creating a calendar event, the composer writes `name: ""` for every participant that has no display name, and an empty `description` property. Both end up serialized by the JMAP server into iCalendar as **empty parameters/properties** (`CN=`, `DESCRIPTION:`), which then leak into everything downstream:

- iMIP invitation emails render an orphan "- Organizer" line and invitees with nothing before their address (observed with Stalwart, but Gmail/Infomaniak render the blank `CN=` too — this is client-inflicted, not server-specific).
- An empty `DESCRIPTION` produces a "Description" section heading over nothing in invitation mails.
- On read-back, an `ORGANIZER;CN=` with an *empty* CN parameter defeats the RFC-style attendee/organizer merge in some iCalendar→JSCalendar converters, so the organizer is duplicated as a phantom third participant with no name and no email (renders as "Unknown" in clients).

## Fix

Omit `name` when there is no display name, and omit `description` when it is empty, instead of sending empty strings. Properties that are absent cannot be mis-serialized.

Typechecked and running in a private deployment.