### PR TITLE
fix: per-account isolation encryptionAtRest settings

### DIFF
--- a/stores/account-security-store.ts
+++ b/stores/account-security-store.ts
@@ -627,7 +627,7 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     try {
       const accountId = getPrimaryAccountId();
       const queryResponses = await stalwartJmap([
-        ['x:PublicKey/query', { filter: { accountId } }, '0'],
+        ['x:PublicKey/query', { accountId }, '0'],
       ]);
 
       const queryResult = requireResult<{ ids: string[] }>(queryResponses, 'x:PublicKey/query');
@@ -740,6 +740,8 @@ export const useAccountSecurityStore = create<AccountSecurityState>()((set, get)
     otpEnabled: false,
     appPasswords: [],
     apiKeys: [],
+    publicKeys: [],
+    isLoadingPublicKeys: false,
     isLoadingAuth: false,
     encryptionConfig: {
       type: 'Disabled',


### PR DESCRIPTION
## Summary
encryptionAtRest settings weren't scoped by account. Now, they are.


## Changes
- edit publicKeys query to filter by account
- add publicKeys: [] and isLoadingPublicKeys: false to clearState function

## Related issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Fix #763 

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
