### PR TITLE
fix(typecheck): regenerate route types and skip stale dev validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:translations": "vitest run --no-isolate lib/__tests__/translations.test.ts",
     "test:integration": "bash integration/run-tests.sh",
     "prepare": "husky",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "next typegen && tsc --noEmit"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
     "node_modules",
     "repos",
     "examples",
-    "integration"
+    "integration",
+    ".next/dev/types"
   ]
 }


### PR DESCRIPTION
## Summary

`npm run typecheck` failed with 8 TS2307 errors from Next's generated route validators referencing old page paths (e.g. calendar/page.js) after routes moved to catch-all segments. Two causes:


## Changes

- The production validator (.next/types) was stale. Prepend `next typegen` so `tsc` always runs against freshly generated route types.
- The dev validator (.next/dev/types) is a turbopack-dev-only artifact that is absent from clean/CI checkouts and goes stale locally. `next typegen` force-re-adds it to tsconfig `include`, so exclude it instead (exclude overrides include), leaving route typing to the maintained .next/types.

tsc still catches real type errors; verified `npm run typecheck` is clean and idempotent.


## Related issues

## Type of change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [X] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
