### PR TITLE
feat(plugins): add onBeforeComposeOpenToReply / Forward

### DIFF
--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -1590,12 +1590,18 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
 
   const handleReply = async (draftText?: string) => {
     if (selectedEmail) {
+      const formerSelected = { ...selectedEmail };
+      const enrichedEmail = await emailHooks.onBeforeComposeOpenToReply.transform(selectedEmail);
+      selectEmail(enrichedEmail);
       const ok = await emailHooks.onBeforeReply.intercept({
         originalEmailId: selectedEmail.id,
         originalEmail: emailToReadView(selectedEmail),
         mode: 'reply' as const,
       });
-      if (!ok) return;
+      if (!ok){ 
+        selectEmail(formerSelected);
+        return;
+      }
       await prepareComposerQuoteHeader(selectedEmail, 'reply');
     } else {
       setComposerQuoteHeader(null);
@@ -1737,12 +1743,18 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
 
   const handleReplyAll = async () => {
     if (selectedEmail) {
+      const formerSelected = { ...selectedEmail };
+      const enrichedEmail = await emailHooks.onBeforeComposeOpenToReplyAll.transform(selectedEmail);
+      selectEmail(enrichedEmail);
       const ok = await emailHooks.onBeforeReplyAll.intercept({
         originalEmailId: selectedEmail.id,
         originalEmail: emailToReadView(selectedEmail),
         mode: 'reply-all' as const,
       });
-      if (!ok) return;
+      if (!ok) {
+        selectEmail(formerSelected);
+        return;
+      }
       await prepareComposerQuoteHeader(selectedEmail, 'replyAll');
     } else {
       setComposerQuoteHeader(null);
@@ -1755,12 +1767,18 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
 
   const handleForward = async () => {
     if (selectedEmail) {
+      const formerSelected = { ...selectedEmail };
+      const enrichedEmail = await emailHooks.onBeforeComposeOpenToForward.transform(selectedEmail);
+      selectEmail(enrichedEmail);
       const ok = await emailHooks.onBeforeForward.intercept({
         originalEmailId: selectedEmail.id,
         originalEmail: emailToReadView(selectedEmail),
         mode: 'forward' as const,
       });
-      if (!ok) return;
+      if (!ok) {
+        selectEmail(formerSelected);
+        return;
+      }
       await prepareComposerQuoteHeader(selectedEmail, 'forward');
     } else {
       setComposerQuoteHeader(null);
@@ -1792,6 +1810,7 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
   // unselected row. See the list context-menu wiring below.
   const handleForwardAsAttachment = async (email: Email | null = selectedEmail) => {
     if (!email) return;
+    email = await emailHooks.onBeforeComposeOpenToForwardAsAttachment.transform(email);
     // Same filename options "Export as .eml" uses (see emailFilenameOptions
     // in email-viewer.tsx), so the two actions produce consistent filenames
     // for the same message rather than the synthetic attachment silently
@@ -3030,6 +3049,7 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
 
   // Handle reply from conversation view
   const handleConversationReply = async (email: Email) => {
+    email = await emailHooks.onBeforeComposeOpenToReply.transform(email);
     selectEmail(email);
     await prepareComposerQuoteHeader(email, 'reply');
     startFreshComposerSession();
@@ -3039,6 +3059,7 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
   };
 
   const handleConversationReplyAll = async (email: Email) => {
+    email = await emailHooks.onBeforeComposeOpenToReplyAll.transform(email);
     selectEmail(email);
     await prepareComposerQuoteHeader(email, 'replyAll');
     startFreshComposerSession();
@@ -3048,6 +3069,7 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
   };
 
   const handleConversationForward = async (email: Email) => {
+    email = await emailHooks.onBeforeComposeOpenToForward.transform(email);
     selectEmail(email);
     await prepareComposerQuoteHeader(email, 'forward');
     startFreshComposerSession();

--- a/lib/plugin-hooks.ts
+++ b/lib/plugin-hooks.ts
@@ -337,6 +337,11 @@ export const emailHooks = {
   // They can add, remove, or modify chips (e.g. rewrite addresses, add colors/icons).
   // Take Recipient[] as argument.
   onRecipientChipsChange: new HookBus(),
+  // Transform hooks - lets plugins modify the email before host use it to populate fields. 
+  onBeforeComposeOpenToForwardAsAttachment: new HookBus(),
+  onBeforeComposeOpenToReply: new HookBus(),
+  onBeforeComposeOpenToReplyAll: new HookBus(),
+  onBeforeComposeOpenToForward: new HookBus(),
 };
 
 // §7.2 Calendar Hooks


### PR DESCRIPTION
## Summary

We add some new transformer hooks called when user reply, reply to all, forward or forward as attachments an email. Indeed, when encrypted, the email is not decrypted as decryption is made only when rendered.  As a result, when replying, the body quote is not populated and when forwarding the attachments are `encrypted.asc` and not real attachments. These new hooks allow plugin to decrypt / enrich email before it is used to populate the composer.

## Changes
Add new transformer hooks
-  onBeforeComposeOpenToForwardAsAttachment
- onBeforeComposeOpenToReply
- onBeforeComposeOpenToReplyAll
- onBeforeComposeOpenToForward

They enrich the `selectedEmail` or email before the intercept hook are called. This way, the intercept hook have the whole enriched email to decide

## Related issues

Related to https://github.com/paulhenry46/pgp-plugin/issues/7

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
