### PR TITLE
feat(plugins): add jmap.uploadBlob to plugins api

### DIFF
--- a/lib/plugin-sandbox/host-api.ts
+++ b/lib/plugin-sandbox/host-api.ts
@@ -27,6 +27,7 @@ import { EncryptionAtRestConfig, PublicKeyInfo, PublicKeyInput, useAccountSecuri
  */
 const PRIVILEGED_ONLY_METHODS = new Set<string>([
   'jmap.fetchBlob',
+  'jmap.uploadBlob',
   'jmap.sendRaw',
   'jmap.submitRaw',
   'jmap.importRaw',
@@ -66,6 +67,7 @@ const PERM_PER_METHOD: Record<string, Permission | null> = {
   'http.fetch': 'http:fetch',
   // jmap (privileged-tier only; see PRIVILEGED_ONLY_METHODS)
   'jmap.fetchBlob': 'email:blob-read',
+  'jmap.uploadBlob': 'email:blob-write',
   'jmap.sendRaw': 'email:raw-send',
   'jmap.submitRaw': 'email:raw-send',
   'jmap.importRaw': 'email:raw-send',
@@ -392,6 +394,13 @@ async function doJmapFetchBlob(blobId: string, opts?: { name?: string; type?: st
   if (!client) throw new Error('jmap.fetchBlob: no active session');
   const buf = await client.fetchBlobArrayBuffer(blobId, opts?.name, opts?.type);
   return new Uint8Array(buf);
+}
+
+async function doJmapUploadBlob(content: Uint8Array, name: string, type: string): Promise<{ blobId: string; size: number; type: string; }> {
+  const { client } = useAuthStore.getState();
+  if (!client) throw new Error('jmap.uploadBlob: no active session');
+  const file = new File([content as BlobPart], name, { type });
+  return await client.uploadBlob(file);
 }
 
 interface JmapSubmitRawOptions {
@@ -860,6 +869,7 @@ export async function dispatchApiCall(
     case 'http.fetch': return doHttpFetch(plugin, args[0] as string, args[1] as PluginFetchInit | undefined);
 
     case 'jmap.fetchBlob': return doJmapFetchBlob(args[0] as string, args[1] as { name?: string; type?: string } | undefined);
+    case 'jmap.uploadBlob': return doJmapUploadBlob(args[0] as Uint8Array, args[1] as string, args[2] as string);
     case 'jmap.sendRaw':   return doJmapSendRaw(
       args[0] as ArrayBuffer | ArrayBufferView,
       args[1] as string,

--- a/lib/plugin-sandbox/protocol.ts
+++ b/lib/plugin-sandbox/protocol.ts
@@ -242,7 +242,7 @@ export const API_METHODS = [
   'storage.get', 'storage.set', 'storage.remove', 'storage.keys',
   'http.post', 'http.fetch',
   'crypto.getOrCreateWebAuthn', 'crypto.getPublicKeys', 'crypto.createPublicKey', 'crypto.removePublicKey', 'crypto.getEncryptionAtRest', 'crypto.setEncryptionAtRest',
-  'jmap.fetchBlob', 'jmap.sendRaw',
+  'jmap.fetchBlob', 'jmap.uploadBlob', 'jmap.sendRaw',
   'upfiles.get', 'upfiles.save',
   'contact.get', 'contact.update', 'contact.create', 'contact.search',
   'admin.getConfig', 'admin.getAllConfig', 'admin.setConfig', 'admin.deleteConfig',

--- a/lib/plugin-sandbox/runtime.tsx
+++ b/lib/plugin-sandbox/runtime.tsx
@@ -206,6 +206,8 @@ function buildPluginApi(manifest: PluginManifest) {
       /** Fetch a blob's raw bytes by id. Resolves to a Uint8Array. */
       fetchBlob: (blobId: string, opts?: { name?: string; type?: string }) =>
         callApi('jmap.fetchBlob', [blobId, opts]) as Promise<Uint8Array>,
+      uploadBlob: (content: Uint8Array, name: string, type: string) =>
+        callApi('jmap.uploadBlob', [content, name, type]) as Promise<{ blobId: string; size: number; type: string; }>,
       /** Submit a fully-formed raw RFC822 message (already signed/encrypted). */
       sendRaw: (
         rawBytes: ArrayBuffer | ArrayBufferView,


### PR DESCRIPTION
## Summary

Sometimes, plugin wants to upload themselves a blob to server. For example, when forwarding an email, an encryption plugin could decrypt email, detect it as real attachments and upload attachments to the server. This way, the real attachments appear in the composer. Therefore, we add a new privileged api method 'jmap.uploadBlob' to enable that.

## Changes

- add new privileged plugin method 'jmap.uploadBlob' with `blob-write` permission
- add new doJmapUploadBlob function

## Related issues

Related to https://github.com/paulhenry46/pgp-plugin/issues/7

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
