### PR TITLE
fix: resolve relative session URLs against the server origin

### DIFF
--- a/lib/__tests__/jmap-client-resilience.test.ts
+++ b/lib/__tests__/jmap-client-resilience.test.ts
@@ -287,6 +287,56 @@ describe('JMAPClient resilience', () => {
     });
   });
 
+  describe('session URL rewriting', () => {
+    async function connectWith(session: Record<string, unknown>, serverUrl = 'https://mail.example.com') {
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, makeSession(session)));
+      const client = new JMAPClient(serverUrl, 'user@test.com', 'pass123');
+      await client.connect();
+      fetchSpy.mockReset();
+      return client;
+    }
+
+    async function pingUrl(client: JMAPClient): Promise<string> {
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse(200, { methodResponses: [['Core/echo', { ping: 'pong' }, '0']] }),
+      );
+      await client.ping();
+      return String(fetchSpy.mock.calls[0][0]);
+    }
+
+    it.each([
+      ['absolute-path relative', '/jmap/api'],
+      ['bare relative', 'jmap/api'],
+      ['cross-origin absolute', 'https://other.example.com/jmap/api'],
+      ['network-path reference', '//other.example.com/jmap/api'],
+    ])('anchors a %s apiUrl at the server origin', async (_form, apiUrl) => {
+      const client = await connectWith({ apiUrl });
+      expect(await pingUrl(client)).toBe('https://mail.example.com/jmap/api');
+    });
+
+    it('anchors a relative apiUrl at the origin even when serverUrl has a path', async () => {
+      const client = await connectWith({ apiUrl: 'jmap/api' }, 'https://mail.example.com/proxy');
+      expect(await pingUrl(client)).toBe('https://mail.example.com/jmap/api');
+    });
+
+    it.each([
+      ['same-origin', 'https://mail.example.com'],
+      ['cross-origin', 'https://other.example.com'],
+    ])('keeps URI Template placeholders literal in a %s downloadUrl', async (_o, host) => {
+      const client = await connectWith({
+        downloadUrl: `${host}/download/{accountId}/{blobId}/{name}?accept={type}`,
+      });
+      expect(client.getBlobDownloadUrl('blob1', 'file.txt', 'text/plain', 'acct-1')).toBe(
+        'https://mail.example.com/download/acct-1/blob1/file.txt?accept=text%2Fplain',
+      );
+    });
+
+    it('leaves an empty downloadUrl falsy so the unavailable guard still fires', async () => {
+      const client = await connectWith({ downloadUrl: '' });
+      expect(() => client.getBlobDownloadUrl('blob1')).toThrow('Download URL not available');
+    });
+  });
+
   describe('refreshSession', () => {
     it('updates session fields from server response', async () => {
       const client = await createConnectedClient();

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -1030,12 +1030,14 @@ export class JMAPClient implements IJMAPClient {
   }
 
   private rewriteSessionUrl(url: string): string {
+    if (!url) return url;
     try {
-      const parsed = new URL(url);
-      const server = new URL(this.serverUrl);
-      if (parsed.origin === server.origin) return url;
-      const pathAndRest = url.slice(url.indexOf('/', url.indexOf('//') + 2));
-      return server.origin + pathAndRest;
+      const { origin } = new URL(this.serverUrl);
+      if (!/^(https?:)?\/\//i.test(url)) {
+        return origin + (url.startsWith('/') ? url : '/' + url);
+      }
+      const pathStart = url.indexOf('/', url.indexOf('//') + 2);
+      return origin + (pathStart === -1 ? '' : url.slice(pathStart));
     } catch {
       return url;
     }


### PR DESCRIPTION
## Summary

`rewriteSessionUrl()` assumed every JMAP Session URL (apiUrl, uploadUrl, etc.) was absolute, so it broke against any server that returns relative ones per RFC 8620 section 2. This PR resolves the URL against the server origin instead, so both relative and absolute forms work correctly.

This stays hidden in same-origin deployments (the common case for Stalwart) since a relative path happens to resolve correctly against the page's own origin by accident, it surfaces as soon as the JMAP server is on a different origin than the app.

## Changes

- `rewriteSessionUrl()` now resolves the URL with `this.serverUrl` as a base (`new URL(url, this.serverUrl)`) instead of `new URL(url)` with no base, which throws on a bare relative path and was silently falling back to the raw relative string.

## Related issues

None.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

N/A - non-visual client logic fix, no UI change.

## Notes for reviewers

`npx vitest run` has one failing test unrelated to this change: `translations completeness > mn should not have extra keys absent from en`. Reproduced identically on a clean `upstream/main` checkout with no changes applied, so it's a pre-existing issue from the Mongolian locale addition, not a regression from this PR.
