### PR TITLE
fix: check the specific capability a request declares, not a broader one

### DIFF
--- a/app/api/calendar-agenda/route.ts
+++ b/app/api/calendar-agenda/route.ts
@@ -22,7 +22,7 @@ import type { CalendarEvent } from '@/lib/jmap/types';
  */
 
 const CALENDAR_CAP = 'urn:ietf:params:jmap:calendars';
-const PRINCIPALS_CAP = 'urn:ietf:params:jmap:principals';
+const PRINCIPALS_OWNER_CAP = 'urn:ietf:params:jmap:principals:owner';
 
 // Mirror of lib/jmap/client.ts CALENDAR_EVENT_PROPERTIES, trimmed to what the
 // agenda actually needs (start/recurrence/display fields).
@@ -132,8 +132,8 @@ export async function POST(request: NextRequest) {
     }
 
     const using = ['urn:ietf:params:jmap:core', CALENDAR_CAP];
-    if (session.capabilities && PRINCIPALS_CAP in session.capabilities) {
-      using.push('urn:ietf:params:jmap:principals:owner');
+    if (session.capabilities && PRINCIPALS_OWNER_CAP in session.capabilities) {
+      using.push(PRINCIPALS_OWNER_CAP);
     }
 
     // Send method calls to the session's apiUrl rebased onto serverUrl's host

--- a/lib/__tests__/calendar-agenda-route.test.ts
+++ b/lib/__tests__/calendar-agenda-route.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+// ── module mocks (hoisted) ───────────────────────────────────────────────────
+vi.mock('next/server', () => {
+  class NextResponse {
+    static json(data: unknown, init?: { status?: number }) {
+      return { status: init?.status ?? 200, headers: new Headers(), json: async () => data };
+    }
+  }
+  return { NextResponse, NextRequest: class {} };
+});
+vi.mock('@/lib/logger', () => ({ logger: { error: () => {}, debug: () => {} } }));
+vi.mock('@/lib/stalwart/credentials', () => ({ getStalwartCredentials: vi.fn() }));
+vi.mock('@/lib/stalwart/jmap-api', () => ({
+  fetchJmapSession: vi.fn(),
+  postJmap: vi.fn(),
+  rebaseApiUrl: vi.fn(() => 'https://mail.example.com/jmap/'),
+}));
+
+import { POST } from '@/app/api/calendar-agenda/route';
+import { getStalwartCredentials } from '@/lib/stalwart/credentials';
+import { fetchJmapSession, postJmap } from '@/lib/stalwart/jmap-api';
+
+const mockCreds = getStalwartCredentials as unknown as Mock;
+const mockSession = fetchJmapSession as unknown as Mock;
+const mockPost = postJmap as unknown as Mock;
+
+const CALENDAR_CAP = 'urn:ietf:params:jmap:calendars';
+
+function makeSession(capabilities: Record<string, unknown>) {
+  return {
+    capabilities,
+    primaryAccounts: { [CALENDAR_CAP]: 'acct-1' },
+    apiUrl: 'https://mail.example.com/jmap/',
+  };
+}
+
+function makeReq(): Parameters<typeof POST>[0] {
+  return { json: async () => ({}) } as unknown as Parameters<typeof POST>[0];
+}
+
+async function agendaUsing(capabilities: Record<string, unknown>): Promise<string[]> {
+  mockSession.mockResolvedValue(makeSession(capabilities));
+  mockPost.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      methodResponses: [
+        ['CalendarEvent/query', { ids: [] }, '0'],
+        ['Calendar/get', { list: [] }, 'c'],
+      ],
+    }),
+  });
+
+  const res = await POST(makeReq());
+  expect(res.status).toBe(200);
+  return JSON.parse(mockPost.mock.calls[0][2] as string).using;
+}
+
+describe('calendar-agenda route (principals:owner declaration)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreds.mockResolvedValue({
+      serverUrl: 'https://mail.example.com',
+      username: 'user@example.com',
+      authHeader: 'Basic abc',
+    });
+  });
+
+  it('omits principals:owner when the server advertises only base principals', async () => {
+    const using = await agendaUsing({
+      'urn:ietf:params:jmap:core': {},
+      [CALENDAR_CAP]: {},
+      'urn:ietf:params:jmap:principals': {},
+    });
+    expect(using).toContain(CALENDAR_CAP);
+    expect(using).not.toContain('urn:ietf:params:jmap:principals:owner');
+  });
+
+  it('declares principals:owner when the server advertises it', async () => {
+    const using = await agendaUsing({
+      'urn:ietf:params:jmap:core': {},
+      [CALENDAR_CAP]: {},
+      'urn:ietf:params:jmap:principals': {},
+      'urn:ietf:params:jmap:principals:owner': {},
+    });
+    expect(using).toContain('urn:ietf:params:jmap:principals:owner');
+  });
+});

--- a/lib/__tests__/jmap-calendar-capability.test.ts
+++ b/lib/__tests__/jmap-calendar-capability.test.ts
@@ -3,11 +3,12 @@ import { JMAPClient } from '../jmap/client';
 
 // The server advertises Calendars globally while the per-account
 // accountCapabilities independently includes or omits it.
-function makeSession(accountCapabilities: Record<string, unknown>, isPersonal = true, serverAdvertises = true) {
+function makeSession(accountCapabilities: Record<string, unknown>, isPersonal = true, serverAdvertises = true, sessionCapabilities: Record<string, unknown> = {}) {
   return {
     capabilities: {
       'urn:ietf:params:jmap:core': {},
       ...(serverAdvertises ? { 'urn:ietf:params:jmap:calendars': {} } : {}),
+      ...sessionCapabilities,
     },
     accounts: {
       'acct-1': { name: 'test', isPersonal, accountCapabilities },
@@ -27,9 +28,9 @@ function mockFetchResponse(status: number, body?: unknown): Response {
   });
 }
 
-async function connect(accountCapabilities: Record<string, unknown>, isPersonal = true, serverAdvertises = true): Promise<JMAPClient> {
+async function connect(accountCapabilities: Record<string, unknown>, isPersonal = true, serverAdvertises = true, sessionCapabilities: Record<string, unknown> = {}): Promise<JMAPClient> {
   const fetchSpy = vi.spyOn(globalThis, 'fetch');
-  fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, makeSession(accountCapabilities, isPersonal, serverAdvertises)));
+  fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, makeSession(accountCapabilities, isPersonal, serverAdvertises, sessionCapabilities)));
   const client = new JMAPClient('https://mail.example.com', 'user@test.com', 'pass123');
   await client.connect();
   fetchSpy.mockReset();
@@ -65,5 +66,33 @@ describe('JMAPClient.supportsCalendars (account-scoped capability)', () => {
   it('returns false for a shared account when the server does not advertise calendars', async () => {
     const client = await connect({}, /* isPersonal */ false, /* serverAdvertises */ false);
     expect(client.supportsCalendars()).toBe(false);
+  });
+});
+
+describe('calendarUsing (principals:owner declaration)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function shareUsing(sessionCapabilities: Record<string, unknown>): Promise<string[]> {
+    const client = await connect({ 'urn:ietf:params:jmap:calendars': {} }, true, true, sessionCapabilities);
+    const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      mockFetchResponse(200, { methodResponses: [['Calendar/set', { updated: { 'cal-1': null } }, '0']] }),
+    );
+    await client.setCalendarShare('cal-1', 'principal-1', null);
+    return JSON.parse((spy.mock.calls[0][1] as RequestInit).body as string).using;
+  }
+
+  it('omits principals:owner when the server advertises only base principals', async () => {
+    const using = await shareUsing({ 'urn:ietf:params:jmap:principals': {} });
+    expect(using).not.toContain('urn:ietf:params:jmap:principals:owner');
+  });
+
+  it('declares principals:owner when the server advertises it', async () => {
+    const using = await shareUsing({
+      'urn:ietf:params:jmap:principals': {},
+      'urn:ietf:params:jmap:principals:owner': {},
+    });
+    expect(using).toContain('urn:ietf:params:jmap:principals:owner');
   });
 });

--- a/lib/__tests__/jmap-contacts-capability.test.ts
+++ b/lib/__tests__/jmap-contacts-capability.test.ts
@@ -3,11 +3,12 @@ import { JMAPClient } from '../jmap/client';
 
 // The server advertises Contacts globally while the per-account
 // accountCapabilities independently includes or omits it.
-function makeSession(accountCapabilities: Record<string, unknown>, isPersonal = true, serverAdvertises = true) {
+function makeSession(accountCapabilities: Record<string, unknown>, isPersonal = true, serverAdvertises = true, sessionCapabilities: Record<string, unknown> = {}) {
   return {
     capabilities: {
       'urn:ietf:params:jmap:core': {},
       ...(serverAdvertises ? { 'urn:ietf:params:jmap:contacts': {} } : {}),
+      ...sessionCapabilities,
     },
     accounts: {
       'acct-1': { name: 'test', isPersonal, accountCapabilities },
@@ -27,9 +28,9 @@ function mockFetchResponse(status: number, body?: unknown): Response {
   });
 }
 
-async function connect(accountCapabilities: Record<string, unknown>, isPersonal = true, serverAdvertises = true): Promise<JMAPClient> {
+async function connect(accountCapabilities: Record<string, unknown>, isPersonal = true, serverAdvertises = true, sessionCapabilities: Record<string, unknown> = {}): Promise<JMAPClient> {
   const fetchSpy = vi.spyOn(globalThis, 'fetch');
-  fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, makeSession(accountCapabilities, isPersonal, serverAdvertises)));
+  fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, makeSession(accountCapabilities, isPersonal, serverAdvertises, sessionCapabilities)));
   const client = new JMAPClient('https://mail.example.com', 'user@test.com', 'pass123');
   await client.connect();
   fetchSpy.mockReset();
@@ -65,5 +66,33 @@ describe('JMAPClient.supportsContacts (account-scoped capability)', () => {
   it('returns false for a shared account when the server does not advertise contacts', async () => {
     const client = await connect({}, /* isPersonal */ false, /* serverAdvertises */ false);
     expect(client.supportsContacts()).toBe(false);
+  });
+});
+
+describe('contactUsing (principals:owner declaration)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function addressBooksUsing(sessionCapabilities: Record<string, unknown>): Promise<string[]> {
+    const client = await connect({ 'urn:ietf:params:jmap:contacts': {} }, true, true, sessionCapabilities);
+    const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      mockFetchResponse(200, { methodResponses: [['AddressBook/get', { list: [] }, '0']] }),
+    );
+    await client.getAddressBooks();
+    return JSON.parse((spy.mock.calls[0][1] as RequestInit).body as string).using;
+  }
+
+  it('omits principals:owner when the server advertises only base principals', async () => {
+    const using = await addressBooksUsing({ 'urn:ietf:params:jmap:principals': {} });
+    expect(using).not.toContain('urn:ietf:params:jmap:principals:owner');
+  });
+
+  it('declares principals:owner when the server advertises it', async () => {
+    const using = await addressBooksUsing({
+      'urn:ietf:params:jmap:principals': {},
+      'urn:ietf:params:jmap:principals:owner': {},
+    });
+    expect(using).toContain('urn:ietf:params:jmap:principals:owner');
   });
 });

--- a/lib/__tests__/jmap-file-share.test.ts
+++ b/lib/__tests__/jmap-file-share.test.ts
@@ -46,13 +46,33 @@ describe('JMAPClient.setFileNodeShare', () => {
 
     const body = lastRequestBody(spy);
     expect(body.using).toContain('urn:ietf:params:jmap:filenode');
-    expect(body.using).toContain('urn:ietf:params:jmap:principals:owner');
+    // The fixture advertises only base principals, so the owner
+    // sub-capability must not be declared (RFC 8620 section 3.3).
+    expect(body.using).not.toContain('urn:ietf:params:jmap:principals:owner');
     const [method, args] = body.methodCalls[0] as [string, Record<string, unknown>];
     expect(method).toBe('FileNode/set');
     expect(args.accountId).toBe('account-1');
     expect(args.update).toEqual({
       'node-1': { 'shareWith/principal-9': READ },
     });
+  });
+
+  it('declares principals:owner only when the server advertises it', async () => {
+    const spy = mockFetch({
+      methodResponses: [['FileNode/set', { updated: { 'node-1': null } }, '0']],
+    });
+    const client = createClient();
+    Object.assign(client, {
+      capabilities: {
+        'urn:ietf:params:jmap:filenode': {},
+        'urn:ietf:params:jmap:principals': {},
+        'urn:ietf:params:jmap:principals:owner': {},
+      },
+    });
+
+    await client.setFileNodeShare('node-1', 'principal-9', READ);
+
+    expect(lastRequestBody(spy).using).toContain('urn:ietf:params:jmap:principals:owner');
   });
 
   it('sends null to revoke a principal\'s access', async () => {

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -4298,7 +4298,7 @@ export class JMAPClient implements IJMAPClient {
 
   private contactUsing(): string[] {
     const using = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:contacts"];
-    if (this.hasCapability("urn:ietf:params:jmap:principals")) {
+    if (this.hasCapability("urn:ietf:params:jmap:principals:owner")) {
       using.push("urn:ietf:params:jmap:principals:owner");
     }
     return using;
@@ -4306,7 +4306,7 @@ export class JMAPClient implements IJMAPClient {
 
   private calendarUsing(): string[] {
     const using = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:calendars"];
-    if (this.hasCapability("urn:ietf:params:jmap:principals")) {
+    if (this.hasCapability("urn:ietf:params:jmap:principals:owner")) {
       using.push("urn:ietf:params:jmap:principals:owner");
     }
     return using;
@@ -5802,9 +5802,10 @@ export class JMAPClient implements IJMAPClient {
     if (this.hasCapability("urn:ietf:params:jmap:filenode")) {
       using.push("urn:ietf:params:jmap:filenode");
     }
-    // Required for shareWith/myRights on FileNode and for cross-account
-    // (shared-with-me) FileNode/get, mirroring calendarUsing().
-    if (this.supportsPrincipals()) {
+    // RFC 9670 places principals:owner in accountCapabilities rather than
+    // the session capabilities, so this only fires on servers that also
+    // advertise it in the session.
+    if (this.hasCapability("urn:ietf:params:jmap:principals:owner")) {
       using.push("urn:ietf:params:jmap:principals:owner");
     }
     return using;


### PR DESCRIPTION
## Summary

`contactUsing()`, `calendarUsing()`, and `fileUsing()` checked the base `principals` capability but then declared the separate `principals:owner` sub-capability (RFC 9670) in the request's `using` array. RFC 8620 section 3.3 requires a server to reject the whole request if a client declares a capability the server does not advertise, so a server that supports base principals without the owner sub-capability rejects every one of these requests with `unknownCapability`.

## Changes

- `contactUsing()`, `calendarUsing()`, and `fileUsing()` now check `hasCapability("urn:ietf:params:jmap:principals:owner")` directly instead of checking the broader base `principals` capability and assuming the sub-capability from it.

## Related issues

None

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

N/A - non-visual client logic fix, no UI change.

## Notes for reviewers

Tested against two servers with different enforcement behavior:
- A server that enforces RFC 8620 section 3.3 strictly rejects the old code's requests outright with `unknownCapability`, which is what surfaced this bug originally.
- Stalwart v0.16 does not enforce that rule - it silently tolerates a request declaring an unadvertised capability, so this bug does not reproduce as visible breakage against Stalwart specifically. It's still a real spec violation worth fixing regardless of which server tolerates it.

`npx vitest run` has one pre-existing failing test unrelated to this change: `translations completeness > mn should not have extra keys absent from en`. Reproduces identically on a clean `upstream/main` checkout with no changes applied.