### PR TITLE
fix: scope separate translation hooks instead of relative namespace p…

### DIFF
--- a/components/email/email-list.tsx
+++ b/components/email/email-list.tsx
@@ -83,6 +83,8 @@ export function EmailList({
   onRescheduleScheduled,
 }: EmailListProps) {
   const t = useTranslations('email_list');
+  const tContextMenu = useTranslations('context_menu');
+  const tSpam = useTranslations('email_viewer.spam');
   const { client } = useAuthStore();
   const {
     selectedEmailIds,
@@ -211,10 +213,10 @@ export function EmailList({
       const emailIds = Array.from(selectedEmailIds);
       await batchUndoSpam(client, emailIds);
       const { toast } = await import('sonner');
-      toast.success(t('../email_viewer.spam.toast_not_spam_batch', { count: emailIds.length }));
+      toast.success(tSpam('toast_not_spam_batch', { count: emailIds.length }));
     } catch {
       const { toast } = await import('sonner');
-      toast.error(t('../email_viewer.spam.error_not_spam'));
+      toast.error(tSpam('error_not_spam'));
     } finally {
       setTimeout(() => setIsProcessing(false), 500);
     }
@@ -392,7 +394,7 @@ export function EmailList({
                 variant="ghost"
                 size="sm"
                 onClick={handleBatchUndoSpam}
-                title={t('../context_menu.not_spam')}
+                title={tContextMenu('not_spam')}
                 disabled={isProcessing}
                 className="text-emerald-600 dark:text-emerald-400 hover:bg-emerald-100/50 dark:hover:bg-emerald-950/30 transition-colors disabled:opacity-50"
               >
@@ -629,11 +631,11 @@ export function EmailList({
                 await batchMarkAsSpam(client, emailIds);
                 const { toast } = await import('sonner');
                 toast.success(
-                  t('../email_viewer.spam.toast_batch', { count: emailIds.length })
+                  tSpam('toast_batch', { count: emailIds.length })
                 );
               } catch {
                 const { toast } = await import('sonner');
-                toast.error(t('../email_viewer.spam.error'));
+                toast.error(tSpam('error'));
               }
             }
           }}
@@ -644,11 +646,11 @@ export function EmailList({
                 await batchUndoSpam(client, emailIds);
                 const { toast } = await import('sonner');
                 toast.success(
-                  t('../email_viewer.spam.toast_not_spam_batch', { count: emailIds.length })
+                  tSpam('toast_not_spam_batch', { count: emailIds.length })
                 );
               } catch {
                 const { toast } = await import('sonner');
-                toast.error(t('../email_viewer.spam.error_not_spam'));
+                toast.error(tSpam('error_not_spam'));
               }
             }
           }}

--- a/components/settings/about-data-settings.tsx
+++ b/components/settings/about-data-settings.tsx
@@ -51,6 +51,7 @@ function VersionUpdateTag() {
 export function AboutDataSettings() {
   const t = useTranslations('settings.advanced');
   const tCommon = useTranslations('common');
+  const tSettings = useTranslations('settings');
   const { settingsSyncDisabled, updateSetting, resetToDefaults, exportSettings, importSettings } =
     useSettingsStore();
   const { settingsSyncEnabled } = useConfig();
@@ -99,9 +100,9 @@ export function AboutDataSettings() {
       const json = event.target?.result as string;
       const success = importSettings(json);
       if (success) {
-        alert(t('../../settings.import_success'));
+        alert(tSettings('import_success'));
       } else {
-        alert(t('../../settings.import_error'));
+        alert(tSettings('import_error'));
       }
     };
     reader.readAsText(file);
@@ -120,7 +121,7 @@ export function AboutDataSettings() {
     if (showResetConfirm) {
       resetToDefaults();
       setShowResetConfirm(false);
-      alert(t('../../settings.save_success'));
+      alert(tSettings('save_success'));
     } else {
       setShowResetConfirm(true);
       setTimeout(() => setShowResetConfirm(false), 5000);

--- a/components/settings/account-settings.tsx
+++ b/components/settings/account-settings.tsx
@@ -31,6 +31,7 @@ function firstScopedTab(caps: SharedAccount['capabilities']): string | null {
 
 export function AccountSettings() {
   const t = useTranslations('settings.account');
+  const tCommon = useTranslations('common');
   const router = useRouter();
   const { username, serverUrl, isDemoMode, primaryIdentity, authMode, client } = useAuthStore();
   const activeAccountId = useAuthStore((s) => s.activeAccountId);
@@ -117,12 +118,12 @@ export function AccountSettings() {
       <SettingsSection title={t('title')} description={t('description')}>
         {/* Display Name */}
         <SettingItem label={t('name_label')}>
-          <span className="text-sm text-foreground">{displayName || t('../../common.unknown')}</span>
+          <span className="text-sm text-foreground">{displayName || tCommon('unknown')}</span>
         </SettingItem>
 
         {/* Email Address */}
         <SettingItem label={t('email.label')}>
-          <span className="text-sm text-foreground">{email || t('../../common.unknown')}</span>
+          <span className="text-sm text-foreground">{email || tCommon('unknown')}</span>
         </SettingItem>
 
         {/* Username / Login (show when it differs from email) */}
@@ -142,7 +143,7 @@ export function AccountSettings() {
         {/* Server */}
         <SettingItem label={t('server.label')}>
           <span className="text-sm text-foreground truncate max-w-xs">
-            {serverUrl || t('../../common.unknown')}
+            {serverUrl || tCommon('unknown')}
           </span>
         </SettingItem>
 

--- a/lib/__tests__/translations.test.ts
+++ b/lib/__tests__/translations.test.ts
@@ -75,7 +75,6 @@ function extractUsedKeys(filePath: string): string[] {
     const callRegex = new RegExp(`\\b${varName}\\(\\s*["']([^"'{}]+)["']`, 'g');
     while ((m = callRegex.exec(content)) !== null) {
       const key = m[1];
-      if (key.startsWith('.')) continue;
       // Find the nearest preceding assignment for this variable
       const ns = varAssignments
         .filter((a) => a.index < m!.index)


### PR DESCRIPTION
## Summary

next-intl has no `../` relative-namespace escape. `t('../context_menu.not_spam')` is not resolved relative to anything - it's concatenated literally into the lookup key and always misses, throwing `MISSING_MESSAGE`. `email-list.tsx`, `about-data-settings.tsx`, and `account-settings.tsx` all used this pattern to reach keys outside their own translation namespace (13 sites total), breaking the "not spam" context menu action, several settings labels, and toast messages.

## Changes

- `email-list.tsx`: added `tContextMenu` and `tSpam` (`useTranslations('context_menu')` / `useTranslations('email_viewer.spam')`) alongside the existing `t`, replacing 7 broken `t('../context_menu.X')` / `t('../email_viewer.spam.X')` calls.
- `about-data-settings.tsx`: added `tSettings` (`useTranslations('settings')`), replacing 3 broken `t('../../settings.X')` calls.
- `account-settings.tsx`: added `tCommon` (`useTranslations('common')`), replacing 3 broken `t('../../common.unknown')` calls.

## Related issues

Closes #

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

Verified live in the running app (mock JMAP backend): right-clicking an email in the Spam folder shows "Not spam" rendered correctly in the context menu (previously would have thrown `MISSING_MESSAGE`), and clicking it successfully moves the email out of Spam end-to-end. Settings > Account and Settings > About tabs both render cleanly with no missing-message errors.

## Notes for reviewers

`npx vitest run` has one pre-existing failing test unrelated to this change: `translations completeness > mn should not have extra keys absent from en`. Reproduces identically on a clean `upstream/main` checkout with no changes applied.