### PR TITLE
feat: expose label settings to extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,13 +264,12 @@ const api = require('@plugin-host');
 
 const known = await api.keywords.list();                 // settings:read
 const scan = await api.jmap.getKeywords();               // email:read
-const id = Object.keys(scan.keywords)
-  .find((keyword) => keyword.startsWith('$label:'))
-  ?.slice('$label:'.length);
-if (id) {
+const providerLabel = scan.labels
+  .find((label) => label.id.startsWith('$label:'));
+if (providerLabel) {
   await api.keywords.add([{                              // settings:write
-    id,
-    label: 'Provider label',
+    id: providerLabel.id.slice('$label:'.length),
+    label: providerLabel.name,
     // color is optional; Bulwark picks a palette colour when omitted
     visibility: 'show',
   }]);
@@ -287,9 +286,11 @@ await api.jmap.removeKeyword('email-id', '$label:work');  // email:write
 ```
 
 `jmap.getKeywords()` is a narrow read-only facade rather than an arbitrary JMAP
-request API. It currently discovers keywords used by messages in the active
-account; labels with no messages cannot be discovered through standard JMAP.
-`keywords.discover()` remains available as a compatibility alias.
+request API. When the server advertises `urn:mail-gateway:keywords`, it returns
+all cached keywords with exact total/unread counts and provider-label metadata,
+including empty Gmail labels. On ordinary JMAP servers it falls back to a
+bounded scan of message keywords. `keywords.discover()` retains its original
+message-scan response for compatibility.
 
 `jmap.setKeywords()` replaces one message's complete keyword map via
 `Email/set`. Omitted keywords are removed, so extensions should use the existing

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Sandboxed plugins that integrate provider-side labels can use the native
 const api = require('@plugin-host');
 
 const known = await api.keywords.list();                 // settings:read
-const scan = await api.keywords.discover();              // email:read
+const scan = await api.jmap.getKeywords();               // email:read
 const id = Object.keys(scan.keywords)
   .find((keyword) => keyword.startsWith('$label:'))
   ?.slice('$label:'.length);
@@ -276,12 +276,31 @@ if (id) {
   }]);
 }
 const counts = await api.keywords.refreshCounts();        // email:read
+
+// Complete replacement: keywords omitted here are removed from the message.
+await api.jmap.setKeywords('email-id', {                 // email:write
+  '$seen': true,
+  '$label:provider-label-id': true,
+});
+await api.jmap.setKeyword('email-id', '$label:work');     // email:write
+await api.jmap.removeKeyword('email-id', '$label:work');  // email:write
 ```
+
+`jmap.getKeywords()` is a narrow read-only facade rather than an arbitrary JMAP
+request API. It currently discovers keywords used by messages in the active
+account; labels with no messages cannot be discovered through standard JMAP.
+`keywords.discover()` remains available as a compatibility alias.
+
+`jmap.setKeywords()` replaces one message's complete keyword map via
+`Email/set`. Omitted keywords are removed, so extensions should use the existing
+`jmap.setKeyword()` and `jmap.removeKeyword()` methods for incremental edits.
+The existing `email.setKeyword()` and `email.removeKeyword()` names remain as
+compatibility aliases.
 
 `keywords.add()` is append-only and case-insensitive by id: it returns added
 and skipped definitions without overwriting the user's existing label name,
-colour, visibility, or order. `keywords.discover()` scans the active account's
-JMAP message keywords and reports whether its bounded scan was complete.
+colour, visibility, or order. Keyword discovery reports whether its bounded
+scan was complete.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -286,11 +286,12 @@ await api.jmap.removeKeyword('email-id', '$label:work');  // email:write
 ```
 
 `jmap.getKeywords()` is a narrow read-only facade rather than an arbitrary JMAP
-request API. When the server advertises `urn:mail-gateway:keywords`, it returns
-all cached keywords with exact total/unread counts and provider-label metadata,
-including empty Gmail labels. On ordinary JMAP servers it falls back to a
-bounded scan of message keywords. `keywords.discover()` retains its original
-message-scan response for compatibility.
+request API. When the JMAP server advertises
+`https://bulwarkmail.com/ns/jmap/keywords`, it returns all cached keywords with
+exact total/unread counts and provider-label metadata, including empty provider
+labels. On servers without the capability it falls back to a bounded scan of
+message keywords. `keywords.discover()` retains its original message-scan
+response for compatibility.
 
 `jmap.setKeywords()` replaces one message's complete keyword map via
 `Email/set`. Omitted keywords are removed, so extensions should use the existing

--- a/README.md
+++ b/README.md
@@ -256,6 +256,33 @@ PLUGIN_DEV_DIR=../my-plugins          # load plugins from disk instead of ZIPs
 
 `EXTENSION_DIRECTORY_URL` enables the admin marketplace for browsing and installing plugins and themes. `PLUGIN_DEV_DIR` is for plugin authors: each immediate subfolder is one plugin with a `manifest.json`, and an entrypoint under `src/` is bundled on demand with esbuild, so editing sources needs only a browser refresh.
 
+Sandboxed plugins that integrate provider-side labels can use the native
+`api.keywords` facade exposed by `@plugin-host`:
+
+```js
+const api = require('@plugin-host');
+
+const known = await api.keywords.list();                 // settings:read
+const scan = await api.keywords.discover();              // email:read
+const id = Object.keys(scan.keywords)
+  .find((keyword) => keyword.startsWith('$label:'))
+  ?.slice('$label:'.length);
+if (id) {
+  await api.keywords.add([{                              // settings:write
+    id,
+    label: 'Provider label',
+    // color is optional; Bulwark picks a palette colour when omitted
+    visibility: 'show',
+  }]);
+}
+const counts = await api.keywords.refreshCounts();        // email:read
+```
+
+`keywords.add()` is append-only and case-insensitive by id: it returns added
+and skipped definitions without overwriting the user's existing label name,
+colour, visibility, or order. `keywords.discover()` scans the active account's
+JMAP message keywords and reports whether its bounded scan was complete.
+
 </details>
 
 <details>

--- a/lib/__tests__/jmap-keyword-discovery.test.ts
+++ b/lib/__tests__/jmap-keyword-discovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { GATEWAY_KEYWORDS_CAPABILITY, JMAPClient } from '../jmap/client';
+import { KEYWORDS_CAPABILITY, JMAPClient } from '../jmap/client';
 
 // JMAP has no way to ask which keywords an account uses, so `discoverKeywords`
 // finds them by walking the message list: an Email/query for the next slice of
@@ -8,17 +8,17 @@ import { GATEWAY_KEYWORDS_CAPABILITY, JMAPClient } from '../jmap/client';
 // admits when it stopped early rather than passing a partial scan off as the
 // whole account.
 
-function makeSession(core: Record<string, number> = {}, gatewayKeywords = false) {
+function makeSession(core: Record<string, number> = {}, supportsKeywordGet = false) {
   return {
     capabilities: {
       'urn:ietf:params:jmap:core': core,
-      ...(gatewayKeywords ? { [GATEWAY_KEYWORDS_CAPABILITY]: { supportsCounts: true } } : {}),
+      ...(supportsKeywordGet ? { [KEYWORDS_CAPABILITY]: { supportsCounts: true } } : {}),
     },
     accounts: {
       'acct-1': {
         name: 'test',
         isPersonal: true,
-        accountCapabilities: gatewayKeywords ? { [GATEWAY_KEYWORDS_CAPABILITY]: {} } : {},
+        accountCapabilities: supportsKeywordGet ? { [KEYWORDS_CAPABILITY]: {} } : {},
       },
     },
     primaryAccounts: { 'urn:ietf:params:jmap:mail': 'acct-1' },
@@ -67,7 +67,7 @@ describe('JMAPClient.discoverKeywords', () => {
     return client;
   }
 
-  async function connectedGatewayClient(core?: Record<string, number>): Promise<JMAPClient> {
+  async function connectedKeywordGetClient(core?: Record<string, number>): Promise<JMAPClient> {
     fetchSpy.mockResolvedValueOnce(jsonResponse(makeSession(core, true)));
     const client = JMAPClient.withBearer('https://mail.example.com', 'token123', 'user@test.com');
     await client.connect();
@@ -224,8 +224,8 @@ describe('JMAPClient.discoverKeywords', () => {
     expect(result).toMatchObject({ keywords: {}, scanned: 0, total: 0, complete: true });
   });
 
-  it('uses Gateway Keyword/get and preserves provider-label metadata', async () => {
-    const client = await connectedGatewayClient();
+  it('uses JMAP Keyword/get and preserves provider-label metadata', async () => {
+    const client = await connectedKeywordGetClient();
     let requestBody: Record<string, unknown> | undefined;
     fetchSpy.mockImplementationOnce((async (_url: string, init: RequestInit) => {
       requestBody = JSON.parse(init.body as string);
@@ -245,7 +245,7 @@ describe('JMAPClient.discoverKeywords', () => {
     const result = await client.getKeywords();
 
     expect(requestBody).toMatchObject({
-      using: ['urn:ietf:params:jmap:core', GATEWAY_KEYWORDS_CAPABILITY],
+      using: ['urn:ietf:params:jmap:core', KEYWORDS_CAPABILITY],
       methodCalls: [['Keyword/get', { accountId: 'acct-1' }, '0']],
     });
     expect(result).toEqual({

--- a/lib/__tests__/jmap-keyword-discovery.test.ts
+++ b/lib/__tests__/jmap-keyword-discovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { JMAPClient } from '../jmap/client';
+import { GATEWAY_KEYWORDS_CAPABILITY, JMAPClient } from '../jmap/client';
 
 // JMAP has no way to ask which keywords an account uses, so `discoverKeywords`
 // finds them by walking the message list: an Email/query for the next slice of
@@ -8,10 +8,19 @@ import { JMAPClient } from '../jmap/client';
 // admits when it stopped early rather than passing a partial scan off as the
 // whole account.
 
-function makeSession(core: Record<string, number> = {}) {
+function makeSession(core: Record<string, number> = {}, gatewayKeywords = false) {
   return {
-    capabilities: { 'urn:ietf:params:jmap:core': core },
-    accounts: { 'acct-1': { name: 'test', isPersonal: true, accountCapabilities: {} } },
+    capabilities: {
+      'urn:ietf:params:jmap:core': core,
+      ...(gatewayKeywords ? { [GATEWAY_KEYWORDS_CAPABILITY]: { supportsCounts: true } } : {}),
+    },
+    accounts: {
+      'acct-1': {
+        name: 'test',
+        isPersonal: true,
+        accountCapabilities: gatewayKeywords ? { [GATEWAY_KEYWORDS_CAPABILITY]: {} } : {},
+      },
+    },
     primaryAccounts: { 'urn:ietf:params:jmap:mail': 'acct-1' },
     apiUrl: 'https://mail.example.com/jmap/api',
     downloadUrl: 'https://mail.example.com/jmap/download/{accountId}/{blobId}/{name}',
@@ -52,6 +61,14 @@ describe('JMAPClient.discoverKeywords', () => {
 
   async function connectedClient(core?: Record<string, number>): Promise<JMAPClient> {
     fetchSpy.mockResolvedValueOnce(jsonResponse(makeSession(core)));
+    const client = JMAPClient.withBearer('https://mail.example.com', 'token123', 'user@test.com');
+    await client.connect();
+    fetchSpy.mockReset();
+    return client;
+  }
+
+  async function connectedGatewayClient(core?: Record<string, number>): Promise<JMAPClient> {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(makeSession(core, true)));
     const client = JMAPClient.withBearer('https://mail.example.com', 'token123', 'user@test.com');
     await client.connect();
     fetchSpy.mockReset();
@@ -205,5 +222,55 @@ describe('JMAPClient.discoverKeywords', () => {
     const result = await client.discoverKeywords();
 
     expect(result).toMatchObject({ keywords: {}, scanned: 0, total: 0, complete: true });
+  });
+
+  it('uses Gateway Keyword/get and preserves provider-label metadata', async () => {
+    const client = await connectedGatewayClient();
+    let requestBody: Record<string, unknown> | undefined;
+    fetchSpy.mockImplementationOnce((async (_url: string, init: RequestInit) => {
+      requestBody = JSON.parse(init.body as string);
+      return jsonResponse({
+        methodResponses: [['Keyword/get', {
+          accountId: 'acct-1',
+          totalEmails: 42,
+          list: [
+            { id: '$flagged', name: '$flagged', color: null, total: 8, unread: 3, isProviderLabel: false, source: 'message' },
+            { id: '$label:GoogleVoice', name: 'Google Voice', color: null, total: 0, unread: 0, isProviderLabel: true, source: 'provider' },
+          ],
+          notFound: [],
+        }, '0']],
+      });
+    }) as never);
+
+    const result = await client.getKeywords();
+
+    expect(requestBody).toMatchObject({
+      using: ['urn:ietf:params:jmap:core', GATEWAY_KEYWORDS_CAPABILITY],
+      methodCalls: [['Keyword/get', { accountId: 'acct-1' }, '0']],
+    });
+    expect(result).toEqual({
+      keywords: { $flagged: 8, '$label:GoogleVoice': 0 },
+      labels: [
+        { id: '$flagged', name: '$flagged', color: null, total: 8, unread: 3, isProviderLabel: false, source: 'message' },
+        { id: '$label:GoogleVoice', name: 'Google Voice', color: null, total: 0, unread: 0, isProviderLabel: true, source: 'provider' },
+      ],
+      scanned: 42,
+      total: 42,
+      complete: true,
+    });
+  });
+
+  it('falls back to scanning on ordinary JMAP servers', async () => {
+    const client = await connectedClient();
+    recordRequests(() => page(['m1'], [{ '$label:work': true, $seen: true }], 1));
+
+    const result = await client.getKeywords();
+
+    expect(result.keywords).toEqual({ '$label:work': 1, $seen: 1 });
+    expect(result.labels).toEqual([
+      expect.objectContaining({ id: '$label:work', name: 'work', total: 1, source: 'message' }),
+      expect.objectContaining({ id: '$seen', name: '$seen', total: 1, source: 'message' }),
+    ]);
+    expect(result).toMatchObject({ scanned: 1, total: 1, complete: true });
   });
 });

--- a/lib/__tests__/plugin-api-gates.test.ts
+++ b/lib/__tests__/plugin-api-gates.test.ts
@@ -151,7 +151,7 @@ describe('native keyword extension API', () => {
   });
 
   it('gates discovery and counts as email metadata', async () => {
-    for (const method of ['keywords.discover', 'keywords.getCounts', 'keywords.refreshCounts']) {
+    for (const method of ['jmap.getKeywords', 'keywords.discover', 'keywords.getCounts', 'keywords.refreshCounts']) {
       expect(await gateError(plugin(), method, [])).toMatch(/lacks permission "email:read"/);
     }
 
@@ -159,5 +159,46 @@ describe('native keyword extension API', () => {
     const reader = plugin({ permissions: ['email:read'], grantedPermissions: ['email:read'] });
     expect(await dispatchApiCall(reader, 'keywords.getCounts', [['shopping']]))
       .toEqual({ shopping: { total: 9, unread: 2 } });
+  });
+
+  it('keeps jmap.getKeywords available to untrusted plugins with email:read', async () => {
+    const reader = plugin({ permissions: ['email:read'], grantedPermissions: ['email:read'] });
+    const error = await gateError(reader, 'jmap.getKeywords', []);
+
+    expect(error).not.toMatch(GATE_FAILURE);
+    expect(error).toMatch(/No active session/);
+  });
+
+  it('gates jmap.setKeywords with email:write and validates complete maps', async () => {
+    expect(await gateError(plugin(), 'jmap.setKeywords', ['email-1', { '$seen': true }]))
+      .toMatch(/lacks permission "email:write"/);
+
+    const writer = plugin({ permissions: ['email:write'], grantedPermissions: ['email:write'] });
+    expect(await gateError(writer, 'jmap.setKeywords', ['email-1', { '$seen': false }]))
+      .toMatch(/must be true; omit it to remove it/);
+    expect(await gateError(writer, 'jmap.setKeywords', ['email-1', { 'invalid keyword': true }]))
+      .toMatch(/Invalid JMAP keyword/);
+
+    const error = await gateError(writer, 'jmap.setKeywords', ['email-1', { '$seen': true }]);
+    expect(error).not.toMatch(GATE_FAILURE);
+    expect(error).toMatch(/No active session/);
+  });
+
+  it('exposes incremental JMAP keyword aliases with email:write', async () => {
+    for (const method of ['jmap.setKeyword', 'jmap.removeKeyword']) {
+      expect(await gateError(plugin(), method, ['email-1', '$label:work']))
+        .toMatch(/lacks permission "email:write"/);
+    }
+
+    const writer = plugin({ permissions: ['email:write'], grantedPermissions: ['email:write'] });
+    for (const method of ['jmap.setKeyword', 'jmap.removeKeyword']) {
+      expect(await gateError(writer, method, ['', '$label:work']))
+        .toMatch(/emailId is required/);
+      expect(await gateError(writer, method, ['email-1', 'invalid keyword']))
+        .toMatch(/Invalid JMAP keyword/);
+      const error = await gateError(writer, method, ['email-1', '$label:work']);
+      expect(error).not.toMatch(GATE_FAILURE);
+      expect(error).toMatch(/No active session/);
+    }
   });
 });

--- a/lib/__tests__/plugin-api-gates.test.ts
+++ b/lib/__tests__/plugin-api-gates.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import type { InstalledPlugin } from '../plugin-types';
+import { useAuthStore } from '@/stores/auth-store';
 import { useEmailStore } from '@/stores/email-store';
 import { DEFAULT_KEYWORDS, useSettingsStore } from '@/stores/settings-store';
 
@@ -98,6 +99,7 @@ describe('method-name typos', () => {
 
 describe('native keyword extension API', () => {
   afterEach(() => {
+    useAuthStore.setState({ client: null });
     useSettingsStore.setState({ emailKeywords: [...DEFAULT_KEYWORDS] });
     useEmailStore.setState({ tagCounts: {} });
   });
@@ -167,6 +169,27 @@ describe('native keyword extension API', () => {
 
     expect(error).not.toMatch(GATE_FAILURE);
     expect(error).toMatch(/No active session/);
+  });
+
+  it('routes jmap.getKeywords through the client implementation', async () => {
+    const result = {
+      keywords: { '$label:work': 2 },
+      labels: [{
+        id: '$label:work', name: 'Work', color: null, total: 2, unread: 1,
+        isProviderLabel: true, source: 'provider' as const,
+      }],
+      scanned: 8,
+      total: 8,
+      complete: true,
+    };
+    const getKeywords = vi.fn().mockResolvedValue(result);
+    const discoverKeywords = vi.fn();
+    useAuthStore.setState({ client: { getKeywords, discoverKeywords } as never });
+    const reader = plugin({ permissions: ['email:read'], grantedPermissions: ['email:read'] });
+
+    await expect(dispatchApiCall(reader, 'jmap.getKeywords', [{ limit: 100 }])).resolves.toEqual(result);
+    expect(getKeywords).toHaveBeenCalledWith({ limit: 100 });
+    expect(discoverKeywords).not.toHaveBeenCalled();
   });
 
   it('gates jmap.setKeywords with email:write and validates complete maps', async () => {

--- a/lib/__tests__/plugin-api-gates.test.ts
+++ b/lib/__tests__/plugin-api-gates.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import type { InstalledPlugin } from '../plugin-types';
+import { useEmailStore } from '@/stores/email-store';
+import { DEFAULT_KEYWORDS, useSettingsStore } from '@/stores/settings-store';
 
 vi.mock('@/stores/toast-store', () => ({
   toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
@@ -91,5 +93,71 @@ describe('method-name typos', () => {
   // nothing while looking like it does.
   it('rejects a method with no entry in the permission map', async () => {
     expect(await gateError(plugin(), 'upfiles.set', ['x'])).toMatch(/Unknown API method/);
+  });
+});
+
+describe('native keyword extension API', () => {
+  afterEach(() => {
+    useSettingsStore.setState({ emailKeywords: [...DEFAULT_KEYWORDS] });
+    useEmailStore.setState({ tagCounts: {} });
+  });
+
+  it('uses the existing settings permissions for definition reads and writes', async () => {
+    expect(await gateError(plugin(), 'keywords.list', []))
+      .toMatch(/lacks permission "settings:read"/);
+    expect(await gateError(plugin(), 'keywords.add', [[]]))
+      .toMatch(/lacks permission "settings:write"/);
+
+    const reader = plugin({ permissions: ['settings:read'], grantedPermissions: ['settings:read'] });
+    expect(await dispatchApiCall(reader, 'keywords.list', []))
+      .toEqual(useSettingsStore.getState().emailKeywords);
+  });
+
+  it('only appends missing definitions and preserves existing user metadata', async () => {
+    useSettingsStore.setState({
+      emailKeywords: [{ id: 'work', label: 'My Work', color: 'purple', visibility: 'hide' }],
+    });
+    const writer = plugin({ permissions: ['settings:write'], grantedPermissions: ['settings:write'] });
+
+    const result = await dispatchApiCall(writer, 'keywords.add', [[
+      { id: 'WORK', label: 'Plugin Work', color: 'red' },
+      { id: 'gmail~shopping', label: 'Shopping', visibility: 'unread' },
+    ]]) as { added: Array<{ id: string }>; skipped: string[] };
+
+    expect(result.added.map((keyword) => keyword.id)).toEqual(['gmail~shopping']);
+    expect(result.skipped).toEqual(['WORK']);
+    expect(useSettingsStore.getState().emailKeywords).toEqual([
+      { id: 'work', label: 'My Work', color: 'purple', visibility: 'hide' },
+      expect.objectContaining({
+        id: 'gmail~shopping',
+        label: 'Shopping',
+        visibility: 'unread',
+        color: expect.any(String),
+      }),
+    ]);
+  });
+
+  it('rejects invalid definitions without partially updating settings', async () => {
+    useSettingsStore.setState({ emailKeywords: [...DEFAULT_KEYWORDS] });
+    const before = useSettingsStore.getState().emailKeywords;
+    const writer = plugin({ permissions: ['settings:write'], grantedPermissions: ['settings:write'] });
+
+    await expect(dispatchApiCall(writer, 'keywords.add', [[
+      { id: 'valid', label: 'Valid', color: 'blue' },
+      { id: 'invalid label', label: 'Invalid', color: 'blue' },
+    ]])).rejects.toThrow(/not a valid JMAP label id/);
+
+    expect(useSettingsStore.getState().emailKeywords).toEqual(before);
+  });
+
+  it('gates discovery and counts as email metadata', async () => {
+    for (const method of ['keywords.discover', 'keywords.getCounts', 'keywords.refreshCounts']) {
+      expect(await gateError(plugin(), method, [])).toMatch(/lacks permission "email:read"/);
+    }
+
+    useEmailStore.setState({ tagCounts: { shopping: { total: 9, unread: 2 } } });
+    const reader = plugin({ permissions: ['email:read'], grantedPermissions: ['email:read'] });
+    expect(await dispatchApiCall(reader, 'keywords.getCounts', [['shopping']]))
+      .toEqual({ shopping: { total: 9, unread: 2 } });
   });
 });

--- a/lib/demo/demo-client.ts
+++ b/lib/demo/demo-client.ts
@@ -1,4 +1,4 @@
-import type { IJMAPClient } from '@/lib/jmap/client-interface';
+import type { IJMAPClient, KeywordDiscoveryResult } from '@/lib/jmap/client-interface';
 import type { Email, Mailbox, StateChange, AccountStates, Thread, Identity, EmailAddress, ContactCard, AddressBook, VacationResponse, Calendar, CalendarEvent, CalendarEventFilter, CalendarTask, FileNode, ScheduledEmail, SendEmailResult, SharedAccount } from '@/lib/jmap/types';
 import type { SieveScript, SieveCapabilities } from '@/lib/jmap/sieve-types';
 import { getDemoData, type DemoData } from './demo-data';
@@ -247,6 +247,26 @@ export class DemoJMAPClient implements IJMAPClient {
     }
     options?.onProgress?.(scanned, total);
     return { keywords, scanned, total, complete: scanned >= total };
+  }
+
+  async getKeywords(options?: {
+    limit?: number;
+    onProgress?: (scanned: number, total: number) => void;
+    signal?: AbortSignal;
+  }): Promise<KeywordDiscoveryResult> {
+    const scan = await this.discoverKeywords(options);
+    return {
+      ...scan,
+      labels: Object.entries(scan.keywords).map(([id, total]) => ({
+        id,
+        name: id.startsWith('$label:') ? id.slice('$label:'.length) : id,
+        color: null,
+        total,
+        unread: 0,
+        isProviderLabel: false,
+        source: 'message' as const,
+      })),
+    };
   }
 
   async getCategoryUnreadCounts(mailboxId: string, tabs: Array<{ id: string; filter: Record<string, unknown> | null }>, _accountId?: string): Promise<Record<string, number>> {

--- a/lib/jmap/client-interface.ts
+++ b/lib/jmap/client-interface.ts
@@ -107,8 +107,9 @@ export interface IJMAPClient {
   getSomeEmails(emailsId: string[], accountId?: string): Promise<Email[]>
   getTagCounts(tagIds: string[]): Promise<Record<string, { total: number; unread: number }>>;
   /**
-   * Enumerate account keywords for extensions. Mail Gateway can return exact
-   * counts and provider-label metadata; other servers use the bounded scan.
+   * Enumerate account keywords for extensions. Servers supporting Keyword/get
+   * can return exact counts and provider-label metadata; other servers use the
+   * bounded scan.
    */
   getKeywords(options?: {
     limit?: number;

--- a/lib/jmap/client-interface.ts
+++ b/lib/jmap/client-interface.ts
@@ -1,6 +1,24 @@
 import type { Email, Mailbox, StateChange, AccountStates, Thread, Identity, EmailAddress, ContactCard, AddressBook, AddressBookRights, VacationResponse, Calendar, CalendarRights, CalendarEvent, CalendarEventFilter, CalendarTask, FileNode, FileNodeRights, Principal, PushSubscription, ScheduledEmail, SendEmailResult, SharedAccount } from "./types";
 import type { SieveScript, SieveCapabilities } from "./sieve-types";
 
+export interface KeywordInfo {
+  id: string;
+  name: string;
+  color: string | null;
+  total: number;
+  unread: number;
+  isProviderLabel: boolean;
+  source: 'provider' | 'message';
+}
+
+export interface KeywordDiscoveryResult {
+  keywords: Record<string, number>;
+  labels: KeywordInfo[];
+  scanned: number;
+  total: number;
+  complete: boolean;
+}
+
 /**
  * Interface defining the public JMAP client contract.
  *
@@ -88,6 +106,15 @@ export interface IJMAPClient {
   getEmail(emailId: string, accountId?: string): Promise<Email | null>;
   getSomeEmails(emailsId: string[], accountId?: string): Promise<Email[]>
   getTagCounts(tagIds: string[]): Promise<Record<string, { total: number; unread: number }>>;
+  /**
+   * Enumerate account keywords for extensions. Mail Gateway can return exact
+   * counts and provider-label metadata; other servers use the bounded scan.
+   */
+  getKeywords(options?: {
+    limit?: number;
+    onProgress?: (scanned: number, total: number) => void;
+    signal?: AbortSignal;
+  }): Promise<KeywordDiscoveryResult>;
   /**
    * Every keyword currently set on the account's messages and how many of the
    * walked messages carry it, found by walking the message list - JMAP offers no

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -139,7 +139,7 @@ const SUBMISSION_USING = [
   'urn:ietf:params:jmap:submission',
 ] as const;
 
-export const GATEWAY_KEYWORDS_CAPABILITY = 'urn:mail-gateway:keywords';
+export const KEYWORDS_CAPABILITY = 'https://bulwarkmail.com/ns/jmap/keywords';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type JMAPResponseResult = Record<string, any>;
@@ -1507,21 +1507,21 @@ export class JMAPClient implements IJMAPClient {
   /**
    * Extension-facing keyword enumeration.
    *
-   * Mail Gateway advertises a narrow capability that can enumerate all cached
-   * keywords in one request, including provider labels with no messages. A
-   * normal JMAP server has no equivalent method, so retain the existing
-   * message walk as a transparent fallback.
+   * A JMAP server can advertise a narrow capability that enumerates all cached
+   * keywords in one request, including provider labels with no messages.
+   * Servers without the capability retain the existing message walk as a
+   * transparent fallback.
    */
   async getKeywords(options?: {
     limit?: number;
     onProgress?: (scanned: number, total: number) => void;
     signal?: AbortSignal;
   }): Promise<KeywordDiscoveryResult> {
-    const supportsGatewayKeywords =
-      this.hasCapability(GATEWAY_KEYWORDS_CAPABILITY) &&
-      this.hasAccountCapability(GATEWAY_KEYWORDS_CAPABILITY);
+    const supportsKeywordGet =
+      this.hasCapability(KEYWORDS_CAPABILITY) &&
+      this.hasAccountCapability(KEYWORDS_CAPABILITY);
 
-    if (!supportsGatewayKeywords) {
+    if (!supportsKeywordGet) {
       const scan = await this.discoverKeywords(options);
       const labels: KeywordInfo[] = Object.entries(scan.keywords).map(([id, total]) => ({
         id,
@@ -1541,12 +1541,12 @@ export class JMAPClient implements IJMAPClient {
 
     const response = await this.request(
       [["Keyword/get", { accountId: this.accountId }, "0"]],
-      ["urn:ietf:params:jmap:core", GATEWAY_KEYWORDS_CAPABILITY],
+      ["urn:ietf:params:jmap:core", KEYWORDS_CAPABILITY],
     );
     const [method, result] = response.methodResponses?.[0] ?? [];
     if (method !== 'Keyword/get' || !Array.isArray(result?.list)) {
       const description = typeof result?.description === 'string' ? `: ${result.description}` : '';
-      throw new Error(`Mail Gateway Keyword/get failed${description}`);
+      throw new Error(`JMAP Keyword/get failed${description}`);
     }
 
     const labels = (result.list as KeywordInfo[]).map((item) => ({ ...item }));

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -1,6 +1,6 @@
 import type { Email, Mailbox, StateChange, AccountStates, Thread, Identity, EmailAddress, ContactCard, AddressBook, AddressBookRights, VacationResponse, Calendar, CalendarRights, CalendarEvent, CalendarEventFilter, CalendarTask, FileNode, FileNodeFilter, FileNodeRights, Principal, PushSubscription, EmailSubmission, ScheduledEmail, SendEmailResult, SharedAccount } from "./types";
 import type { SieveScript, SieveCapabilities } from "./sieve-types";
-import type { IJMAPClient } from "./client-interface";
+import type { IJMAPClient, KeywordDiscoveryResult, KeywordInfo } from "./client-interface";
 import { toWildcardQuery } from "./search-utils";
 import { batched, itemsPerRequest } from "./request-limits";
 import { debug } from "@/lib/debug";
@@ -138,6 +138,8 @@ const SUBMISSION_USING = [
   'urn:ietf:params:jmap:mail',
   'urn:ietf:params:jmap:submission',
 ] as const;
+
+export const GATEWAY_KEYWORDS_CAPABILITY = 'urn:mail-gateway:keywords';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type JMAPResponseResult = Record<string, any>;
@@ -1500,6 +1502,58 @@ export class JMAPClient implements IJMAPClient {
     }
 
     return { keywords, scanned, total: Math.max(total, scanned), complete };
+  }
+
+  /**
+   * Extension-facing keyword enumeration.
+   *
+   * Mail Gateway advertises a narrow capability that can enumerate all cached
+   * keywords in one request, including provider labels with no messages. A
+   * normal JMAP server has no equivalent method, so retain the existing
+   * message walk as a transparent fallback.
+   */
+  async getKeywords(options?: {
+    limit?: number;
+    onProgress?: (scanned: number, total: number) => void;
+    signal?: AbortSignal;
+  }): Promise<KeywordDiscoveryResult> {
+    const supportsGatewayKeywords =
+      this.hasCapability(GATEWAY_KEYWORDS_CAPABILITY) &&
+      this.hasAccountCapability(GATEWAY_KEYWORDS_CAPABILITY);
+
+    if (!supportsGatewayKeywords) {
+      const scan = await this.discoverKeywords(options);
+      const labels: KeywordInfo[] = Object.entries(scan.keywords).map(([id, total]) => ({
+        id,
+        name: id.startsWith('$label:') ? id.slice('$label:'.length) : id,
+        color: null,
+        total,
+        unread: 0,
+        isProviderLabel: false,
+        source: 'message',
+      }));
+      return { ...scan, labels };
+    }
+
+    if (options?.signal?.aborted) {
+      return { keywords: {}, labels: [], scanned: 0, total: 0, complete: false };
+    }
+
+    const response = await this.request(
+      [["Keyword/get", { accountId: this.accountId }, "0"]],
+      ["urn:ietf:params:jmap:core", GATEWAY_KEYWORDS_CAPABILITY],
+    );
+    const [method, result] = response.methodResponses?.[0] ?? [];
+    if (method !== 'Keyword/get' || !Array.isArray(result?.list)) {
+      const description = typeof result?.description === 'string' ? `: ${result.description}` : '';
+      throw new Error(`Mail Gateway Keyword/get failed${description}`);
+    }
+
+    const labels = (result.list as KeywordInfo[]).map((item) => ({ ...item }));
+    const keywords = Object.fromEntries(labels.map((item) => [item.id, item.total]));
+    const total = typeof result.totalEmails === 'number' ? result.totalEmails : 0;
+    options?.onProgress?.(total, total);
+    return { keywords, labels, scanned: total, total, complete: true };
   }
 
   /**

--- a/lib/plugin-sandbox/host-api.ts
+++ b/lib/plugin-sandbox/host-api.ts
@@ -937,18 +937,26 @@ function doKeywordsGetCounts(value?: unknown): Record<string, { total: number; u
   return selected;
 }
 
-async function doKeywordsDiscover(value?: unknown) {
+function keywordDiscoveryOptions(value: unknown, method: string): { limit: number } | undefined {
   if (value !== undefined && !isPlainObject(value)) {
-    throw new Error('keywords.discover: options must be an object');
+    throw new Error(`${method}: options must be an object`);
   }
   const rawLimit = value?.limit;
   if (
     rawLimit !== undefined &&
     (typeof rawLimit !== 'number' || !Number.isInteger(rawLimit) || rawLimit < 1 || rawLimit > DEFAULT_KEYWORD_SCAN_LIMIT)
   ) {
-    throw new Error(`keywords.discover: limit must be an integer from 1 to ${DEFAULT_KEYWORD_SCAN_LIMIT}`);
+    throw new Error(`${method}: limit must be an integer from 1 to ${DEFAULT_KEYWORD_SCAN_LIMIT}`);
   }
-  return requireClient().discoverKeywords(rawLimit === undefined ? undefined : { limit: rawLimit });
+  return rawLimit === undefined ? undefined : { limit: rawLimit };
+}
+
+async function doJmapGetKeywords(value?: unknown) {
+  return requireClient().getKeywords(keywordDiscoveryOptions(value, 'jmap.getKeywords'));
+}
+
+async function doKeywordsDiscover(value?: unknown) {
+  return requireClient().discoverKeywords(keywordDiscoveryOptions(value, 'keywords.discover'));
 }
 
 async function doKeywordsRefreshCounts(): Promise<Record<string, { total: number; unread: number }>> {
@@ -1104,7 +1112,7 @@ export async function dispatchApiCall(
       args[1] as string[],
       args[2] as { keywords?: Record<string, boolean>; accountId?: string } | undefined,
     );
-    case 'jmap.getKeywords': return doKeywordsDiscover(args[0]);
+    case 'jmap.getKeywords': return doJmapGetKeywords(args[0]);
     case 'jmap.setKeywords': {
       const emailId = assertEmailId(args[0], 'jmap.setKeywords');
       const accountId = assertOptionalAccountId(args[2], 'jmap.setKeywords');

--- a/lib/plugin-sandbox/host-api.ts
+++ b/lib/plugin-sandbox/host-api.ts
@@ -11,8 +11,18 @@ import { useIdentityStore } from '@/stores/identity-store';
 import { useEmailStore } from '@/stores/email-store';
 import { useFilterStore } from '@/stores/filter-store';
 import { useMessageListTabsStore } from '@/stores/message-list-tabs-store';
+import {
+  KEYWORD_PALETTE,
+  useSettingsStore,
+  type KeywordDefinition,
+  type KeywordVisibility,
+} from '@/stores/settings-store';
 import type { MessageListTabsConfig } from '../plugin-types';
 import { apiFetch } from '../browser-navigation';
+import { DEFAULT_KEYWORD_SCAN_LIMIT } from '../jmap/client';
+import { suggestKeywordColor } from '../keyword-discovery';
+import { MAX_KEYWORD_LENGTH } from '../keyword-nesting';
+import { KEYWORD_PREFIX } from '../thread-utils';
 import { awaitDialog, awaitPrompt, type PromptField } from './host-dialog';
 import { fileStorage } from '../plugin-storage';
 import { generateUUID } from '../utils';
@@ -109,6 +119,15 @@ const PERM_PER_METHOD: Record<string, Permission | null> = {
   // email keyword mutations
   'email.setKeyword': 'email:write',
   'email.removeKeyword': 'email:write',
+  // Native keyword definitions are a deliberately narrow settings API: a
+  // plugin can read definitions or append missing ones, but cannot overwrite
+  // or remove user-managed tags. Discovery/counts reveal mail metadata and
+  // therefore use email:read rather than a settings permission.
+  'keywords.list': 'settings:read',
+  'keywords.add': 'settings:write',
+  'keywords.discover': 'email:read',
+  'keywords.getCounts': 'email:read',
+  'keywords.refreshCounts': 'email:read',
   // message-list category tabs
   'tabs.set': 'ui:message-list-tabs',
   'tabs.clear': 'ui:message-list-tabs',
@@ -737,6 +756,164 @@ function requireClient() {
   return client;
 }
 
+// ─── Native keyword definitions ──────────────────────────────
+
+const MAX_PLUGIN_KEYWORD_DEFINITIONS = 500;
+const MAX_PLUGIN_KEYWORD_LABEL_LENGTH = 255;
+const VALID_VISIBILITIES = new Set<KeywordVisibility>(['show', 'hide', 'unread']);
+
+type PluginKeywordDefinitionInput = Omit<KeywordDefinition, 'color'> & { color?: string };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** RFC 8621 keyword syntax, applied to the complete `$label:<id>` value. */
+function isValidKeywordDefinitionId(id: string): boolean {
+  const keyword = KEYWORD_PREFIX + id;
+  if (id.length === 0 || keyword.length > MAX_KEYWORD_LENGTH) return false;
+  for (let i = 0; i < keyword.length; i++) {
+    const code = keyword.charCodeAt(i);
+    if (
+      code < 0x21 || code > 0x7e ||
+      code === 0x28 || code === 0x29 || code === 0x7b || code === 0x7d ||
+      code === 0x5d || code === 0x25 || code === 0x2a || code === 0x22 || code === 0x5c
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function assertKeywordDefinition(value: unknown, index: number): PluginKeywordDefinitionInput {
+  if (!isPlainObject(value)) {
+    throw new Error(`keywords.add: definitions[${index}] must be an object`);
+  }
+
+  const id = value.id;
+  const label = value.label;
+  const color = value.color;
+  const visibility = value.visibility;
+
+  if (typeof id !== 'string' || !isValidKeywordDefinitionId(id)) {
+    throw new Error(`keywords.add: definitions[${index}].id is not a valid JMAP label id`);
+  }
+  if (
+    typeof label !== 'string' || label.trim().length === 0 ||
+    label.length > MAX_PLUGIN_KEYWORD_LABEL_LENGTH
+  ) {
+    throw new Error(
+      `keywords.add: definitions[${index}].label must be 1-${MAX_PLUGIN_KEYWORD_LABEL_LENGTH} characters`,
+    );
+  }
+  if (
+    color !== undefined &&
+    (typeof color !== 'string' || !Object.prototype.hasOwnProperty.call(KEYWORD_PALETTE, color))
+  ) {
+    throw new Error(`keywords.add: definitions[${index}].color is not in the keyword palette`);
+  }
+  if (visibility !== undefined && !VALID_VISIBILITIES.has(visibility as KeywordVisibility)) {
+    throw new Error(`keywords.add: definitions[${index}].visibility is invalid`);
+  }
+
+  return {
+    id,
+    label: label.trim(),
+    ...(color === undefined ? {} : { color }),
+    ...(visibility === undefined ? {} : { visibility: visibility as KeywordVisibility }),
+  };
+}
+
+function assertKeywordDefinitionArray(value: unknown): PluginKeywordDefinitionInput[] {
+  if (!Array.isArray(value)) throw new Error('keywords.add: definitions must be an array');
+  if (value.length > MAX_PLUGIN_KEYWORD_DEFINITIONS) {
+    throw new Error(`keywords.add: at most ${MAX_PLUGIN_KEYWORD_DEFINITIONS} definitions may be added at once`);
+  }
+  return value.map(assertKeywordDefinition);
+}
+
+function doKeywordsList(): KeywordDefinition[] {
+  return useSettingsStore.getState().emailKeywords.map((keyword) => ({ ...keyword }));
+}
+
+function doKeywordsAdd(value: unknown): { added: KeywordDefinition[]; skipped: string[] } {
+  const definitions = assertKeywordDefinitionArray(value);
+  const existing = useSettingsStore.getState().emailKeywords;
+  const known = new Set(existing.map((keyword) => keyword.id.toLowerCase()));
+  const takenColors = new Set(existing.map((keyword) => keyword.color));
+  const added: KeywordDefinition[] = [];
+  const skipped: string[] = [];
+
+  for (const definition of definitions) {
+    const foldedId = definition.id.toLowerCase();
+    if (known.has(foldedId)) {
+      skipped.push(definition.id);
+      continue;
+    }
+    known.add(foldedId);
+    const color = definition.color ?? suggestKeywordColor(definition.id, takenColors);
+    takenColors.add(color);
+    added.push({ ...definition, color });
+  }
+
+  if (added.length > 0) {
+    // One atomic append keeps concurrent plugin calls from partially
+    // overwriting the list and triggers the normal persist/settings-sync path.
+    useSettingsStore.setState((state) => ({
+      emailKeywords: [...state.emailKeywords, ...added],
+    }));
+  }
+
+  return { added: added.map((keyword) => ({ ...keyword })), skipped };
+}
+
+function assertKeywordIds(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value) || value.length > MAX_PLUGIN_KEYWORD_DEFINITIONS) {
+    throw new Error(`keywords.getCounts: ids must be an array of at most ${MAX_PLUGIN_KEYWORD_DEFINITIONS} strings`);
+  }
+  if (value.some((id) => typeof id !== 'string' || !isValidKeywordDefinitionId(id))) {
+    throw new Error('keywords.getCounts: ids contains an invalid label id');
+  }
+  return value as string[];
+}
+
+function doKeywordsGetCounts(value?: unknown): Record<string, { total: number; unread: number }> {
+  const ids = assertKeywordIds(value);
+  const counts = useEmailStore.getState().tagCounts;
+  if (!ids) {
+    return Object.fromEntries(
+      Object.entries(counts).map(([id, count]) => [id, { ...count }]),
+    );
+  }
+
+  const selected: Record<string, { total: number; unread: number }> = {};
+  for (const id of ids) {
+    const count = counts[id];
+    if (count) selected[id] = { ...count };
+  }
+  return selected;
+}
+
+async function doKeywordsDiscover(value?: unknown) {
+  if (value !== undefined && !isPlainObject(value)) {
+    throw new Error('keywords.discover: options must be an object');
+  }
+  const rawLimit = value?.limit;
+  if (
+    rawLimit !== undefined &&
+    (typeof rawLimit !== 'number' || !Number.isInteger(rawLimit) || rawLimit < 1 || rawLimit > DEFAULT_KEYWORD_SCAN_LIMIT)
+  ) {
+    throw new Error(`keywords.discover: limit must be an integer from 1 to ${DEFAULT_KEYWORD_SCAN_LIMIT}`);
+  }
+  return requireClient().discoverKeywords(rawLimit === undefined ? undefined : { limit: rawLimit });
+}
+
+async function doKeywordsRefreshCounts(): Promise<Record<string, { total: number; unread: number }>> {
+  await useEmailStore.getState().fetchTagCounts(requireClient());
+  return doKeywordsGetCounts();
+}
+
 // ─── Message-list category tabs ───────────────────────────────
 
 /**
@@ -998,6 +1175,12 @@ export async function dispatchApiCall(
       await requireClient().removeKeyword(String(args[0]), keyword, args[2] as string | undefined);
       return undefined;
     }
+
+    case 'keywords.list': return doKeywordsList();
+    case 'keywords.add': return doKeywordsAdd(args[0]);
+    case 'keywords.discover': return doKeywordsDiscover(args[0]);
+    case 'keywords.getCounts': return doKeywordsGetCounts(args[0]);
+    case 'keywords.refreshCounts': return doKeywordsRefreshCounts();
 
     case 'tabs.set': {
       // validateTabsConfig (inside registerTabs) throws a developer-readable

--- a/lib/plugin-sandbox/host-api.ts
+++ b/lib/plugin-sandbox/host-api.ts
@@ -81,6 +81,14 @@ const PERM_PER_METHOD: Record<string, Permission | null> = {
   'jmap.sendRaw': 'email:raw-send',
   'jmap.submitRaw': 'email:raw-send',
   'jmap.importRaw': 'email:raw-send',
+  // Narrow read-only JMAP facade. This intentionally does not expose an
+  // arbitrary request primitive that could turn email:read into Email/set.
+  'jmap.getKeywords': 'email:read',
+  // Replace one message's complete keyword map. Kept separate from the raw
+  // request surface so email:write authorizes exactly this mutation.
+  'jmap.setKeywords': 'email:write',
+  'jmap.setKeyword': 'email:write',
+  'jmap.removeKeyword': 'email:write',
   // uploaded files :
   // upfiles.get reads back a just-attached file (see onBeforeBlobUpload) and
   // is a read - it sits behind email:blob-read. To read a stored message
@@ -750,6 +758,40 @@ function assertPluginKeyword(keyword: unknown): string {
   return keyword;
 }
 
+function assertPluginKeywords(value: unknown): Record<string, true> {
+  if (!isPlainObject(value)) {
+    throw new Error('jmap.setKeywords: keywords must be an object');
+  }
+  const entries = Object.entries(value);
+  if (entries.length > MAX_PLUGIN_KEYWORD_DEFINITIONS) {
+    throw new Error(`jmap.setKeywords: at most ${MAX_PLUGIN_KEYWORD_DEFINITIONS} keywords are allowed`);
+  }
+  const keywords: Record<string, true> = {};
+  for (const [keyword, enabled] of entries) {
+    assertPluginKeyword(keyword);
+    if (enabled !== true) {
+      throw new Error(`jmap.setKeywords: keyword "${keyword}" must be true; omit it to remove it`);
+    }
+    keywords[keyword] = true;
+  }
+  return keywords;
+}
+
+function assertEmailId(value: unknown, method: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${method}: emailId is required`);
+  }
+  return value;
+}
+
+function assertOptionalAccountId(value: unknown, method: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${method}: accountId must be a non-empty string`);
+  }
+  return value;
+}
+
 function requireClient() {
   const { client } = useAuthStore.getState();
   if (!client) throw new Error('No active session');
@@ -1062,6 +1104,28 @@ export async function dispatchApiCall(
       args[1] as string[],
       args[2] as { keywords?: Record<string, boolean>; accountId?: string } | undefined,
     );
+    case 'jmap.getKeywords': return doKeywordsDiscover(args[0]);
+    case 'jmap.setKeywords': {
+      const emailId = assertEmailId(args[0], 'jmap.setKeywords');
+      const accountId = assertOptionalAccountId(args[2], 'jmap.setKeywords');
+      const keywords = assertPluginKeywords(args[1]);
+      await requireClient().updateEmailKeywords(emailId, keywords, accountId);
+      return undefined;
+    }
+    case 'jmap.setKeyword': {
+      const emailId = assertEmailId(args[0], 'jmap.setKeyword');
+      const keyword = assertPluginKeyword(args[1]);
+      const accountId = assertOptionalAccountId(args[2], 'jmap.setKeyword');
+      await requireClient().setKeyword(emailId, keyword, accountId);
+      return undefined;
+    }
+    case 'jmap.removeKeyword': {
+      const emailId = assertEmailId(args[0], 'jmap.removeKeyword');
+      const keyword = assertPluginKeyword(args[1]);
+      const accountId = assertOptionalAccountId(args[2], 'jmap.removeKeyword');
+      await requireClient().removeKeyword(emailId, keyword, accountId);
+      return undefined;
+    }
     case 'upfiles.get' : return getFile(args[0] as string);
     case 'upfiles.save' : return saveFile(args[0] as string, args[1] as File);
 

--- a/lib/plugin-sandbox/protocol.ts
+++ b/lib/plugin-sandbox/protocol.ts
@@ -243,6 +243,9 @@ export const API_METHODS = [
   'http.post', 'http.fetch',
   'crypto.getOrCreateWebAuthn', 'crypto.getPublicKeys', 'crypto.createPublicKey', 'crypto.removePublicKey', 'crypto.getEncryptionAtRest', 'crypto.setEncryptionAtRest',
   'jmap.fetchBlob', 'jmap.uploadBlob', 'jmap.sendRaw',
+  // Narrow keyword helpers. Unlike the raw-blob methods, these are available
+  // to untrusted plugins with email:read/email:write as appropriate.
+  'jmap.getKeywords', 'jmap.setKeywords', 'jmap.setKeyword', 'jmap.removeKeyword',
   'upfiles.get', 'upfiles.save',
   'contact.get', 'contact.update', 'contact.create', 'contact.search',
   'admin.getConfig', 'admin.getAllConfig', 'admin.setConfig', 'admin.deleteConfig',

--- a/lib/plugin-sandbox/protocol.ts
+++ b/lib/plugin-sandbox/protocol.ts
@@ -250,6 +250,8 @@ export const API_METHODS = [
   'ui.confirm', 'ui.alert', 'ui.prompt', 'ui.rerenderEmail', 'ui.rerenderFetchedEmails', 'ui.openExternalUrl', 'ui.downloadFile',
   // Email keyword mutations (JMAP Email/set keyword patches).
   'email.setKeyword', 'email.removeKeyword',
+  // Native tag definitions, discovery, and sidebar counts.
+  'keywords.list', 'keywords.add', 'keywords.discover', 'keywords.getCounts', 'keywords.refreshCounts',
   // Message-list category tabs (Gmail-style inbox tabs).
   'tabs.set', 'tabs.clear', 'tabs.getState', 'tabs.categorize', 'tabs.refreshCounts',
   // Sieve integration for delivery-time classification plugins.

--- a/lib/plugin-sandbox/runtime.tsx
+++ b/lib/plugin-sandbox/runtime.tsx
@@ -165,6 +165,22 @@ function decodeCallbacks(value: unknown, depth = 0): unknown {
 
 type PluginManifest = BackgroundInit['manifest'];
 
+type PluginKeywordVisibility = 'show' | 'hide' | 'unread';
+
+interface PluginKeywordDefinition {
+  id: string;
+  label: string;
+  color: string;
+  visibility?: PluginKeywordVisibility;
+}
+
+type PluginKeywordDefinitionInput = Omit<PluginKeywordDefinition, 'color'> & { color?: string };
+
+interface PluginKeywordCounts {
+  total: number;
+  unread: number;
+}
+
 function buildPluginApi(manifest: PluginManifest) {
   return {
     plugin: {
@@ -288,6 +304,29 @@ function buildPluginApi(manifest: PluginManifest) {
         callApi('email.setKeyword', [emailId, keyword, accountId]) as Promise<void>,
       removeKeyword: (emailId: string, keyword: string, accountId?: string) =>
         callApi('email.removeKeyword', [emailId, keyword, accountId]) as Promise<void>,
+    },
+    // Native sidebar tag definitions. Definition reads/writes use the existing
+    // settings permissions; server discovery and message counts use email:read.
+    // add() is intentionally append-only: it never overwrites or removes tags
+    // the user has already named, coloured, hidden, or reordered.
+    keywords: {
+      list: () => callApi('keywords.list', []) as Promise<PluginKeywordDefinition[]>,
+      add: (definitions: PluginKeywordDefinitionInput[]) =>
+        callApi('keywords.add', [definitions]) as Promise<{
+          added: PluginKeywordDefinition[];
+          skipped: string[];
+        }>,
+      discover: (options?: { limit?: number }) =>
+        callApi('keywords.discover', [options]) as Promise<{
+          keywords: Record<string, number>;
+          scanned: number;
+          total: number;
+          complete: boolean;
+        }>,
+      getCounts: (ids?: string[]) =>
+        callApi('keywords.getCounts', [ids]) as Promise<Record<string, PluginKeywordCounts>>,
+      refreshCounts: () =>
+        callApi('keywords.refreshCounts', []) as Promise<Record<string, PluginKeywordCounts>>,
     },
     // Message-list category tabs (permission: ui:message-list-tabs; categorize
     // additionally needs email:write). The host renders the strip natively and

--- a/lib/plugin-sandbox/runtime.tsx
+++ b/lib/plugin-sandbox/runtime.tsx
@@ -220,9 +220,9 @@ function buildPluginApi(manifest: PluginManifest) {
     // to the privileged tier for crypto plugins.
     jmap: {
       /**
-       * Discover keywords used by messages in the active account. This is a
-       * safe read-only facade, available to untrusted plugins with email:read;
-       * it does not expose arbitrary JMAP method calls.
+       * Enumerate keywords in the active account. Mail Gateway supplies exact
+       * counts and provider-label metadata; ordinary JMAP servers fall back to
+       * scanning message keywords.
        */
       getKeywords: (options?: { limit?: number }) =>
         callApi('jmap.getKeywords', [options]) as Promise<{
@@ -230,6 +230,15 @@ function buildPluginApi(manifest: PluginManifest) {
           scanned: number;
           total: number;
           complete: boolean;
+          labels: Array<{
+            id: string;
+            name: string;
+            color: string | null;
+            total: number;
+            unread: number;
+            isProviderLabel: boolean;
+            source: 'provider' | 'message';
+          }>;
         }>,
       /**
        * Replace an email's complete keyword map. Omitted keywords are removed;

--- a/lib/plugin-sandbox/runtime.tsx
+++ b/lib/plugin-sandbox/runtime.tsx
@@ -215,10 +215,34 @@ function buildPluginApi(manifest: PluginManifest) {
         callApi('http.post', [path, body, options], NETWORK_API_TIMEOUT_MS),
       fetch: (url: string, init?: unknown) => callApi('http.fetch', [url, init], NETWORK_API_TIMEOUT_MS),
     },
-    // Privileged-tier only (same-origin plugins). Calls throw for untrusted
-    // plugins (the host refuses the method) — these power crypto plugins that
-    // need raw message bytes and raw submission.
+    // Safe keyword methods are available to untrusted plugins with the
+    // matching email permission. Raw blob/submission methods remain restricted
+    // to the privileged tier for crypto plugins.
     jmap: {
+      /**
+       * Discover keywords used by messages in the active account. This is a
+       * safe read-only facade, available to untrusted plugins with email:read;
+       * it does not expose arbitrary JMAP method calls.
+       */
+      getKeywords: (options?: { limit?: number }) =>
+        callApi('jmap.getKeywords', [options]) as Promise<{
+          keywords: Record<string, number>;
+          scanned: number;
+          total: number;
+          complete: boolean;
+        }>,
+      /**
+       * Replace an email's complete keyword map. Omitted keywords are removed;
+       * use api.email.setKeyword/removeKeyword for an incremental mutation.
+       */
+      setKeywords: (emailId: string, keywords: Record<string, true>, accountId?: string) =>
+        callApi('jmap.setKeywords', [emailId, keywords, accountId]) as Promise<void>,
+      /** Add one keyword without changing the message's other keywords. */
+      setKeyword: (emailId: string, keyword: string, accountId?: string) =>
+        callApi('jmap.setKeyword', [emailId, keyword, accountId]) as Promise<void>,
+      /** Remove one keyword without changing the message's other keywords. */
+      removeKeyword: (emailId: string, keyword: string, accountId?: string) =>
+        callApi('jmap.removeKeyword', [emailId, keyword, accountId]) as Promise<void>,
       /** Fetch a blob's raw bytes by id. Resolves to a Uint8Array. */
       fetchBlob: (blobId: string, opts?: { name?: string; type?: string }) =>
         callApi('jmap.fetchBlob', [blobId, opts]) as Promise<Uint8Array>,

--- a/lib/plugin-sandbox/runtime.tsx
+++ b/lib/plugin-sandbox/runtime.tsx
@@ -220,9 +220,9 @@ function buildPluginApi(manifest: PluginManifest) {
     // to the privileged tier for crypto plugins.
     jmap: {
       /**
-       * Enumerate keywords in the active account. Mail Gateway supplies exact
-       * counts and provider-label metadata; ordinary JMAP servers fall back to
-       * scanning message keywords.
+       * Enumerate keywords in the active account. JMAP servers supporting
+       * Keyword/get supply exact counts and provider-label metadata; other
+       * servers fall back to scanning message keywords.
        */
       getKeywords: (options?: { limit?: number }) =>
         callApi('jmap.getKeywords', [options]) as Promise<{

--- a/stores/__tests__/folder-management.test.ts
+++ b/stores/__tests__/folder-management.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useEmailStore } from '../email-store';
 import type { Mailbox } from '@/lib/jmap/types';
 import { UNIFIED_MAILBOX_IDS } from '@/lib/jmap/types';
+import { emailHooks } from '@/lib/plugin-hooks';
 
 function makeMailbox(overrides: Partial<Mailbox> = {}): Mailbox {
   return {
@@ -272,6 +273,22 @@ describe('email-store folder management', () => {
   // drafts in "All Drafts") must not reset a virtual unified/cross-view selection
   // to the inbox, which would jump the user out of the view they're in.
   describe('fetchMailboxes selection preservation', () => {
+    it('publishes the refreshed mailbox list to extensions', async () => {
+      const observer = vi.fn();
+      const disposable = emailHooks.onMailboxesRefresh.register('mailbox-refresh-test', observer);
+      const refreshed = [inbox, sent, trash, custom];
+      const client = makeMockClient({
+        getAllMailboxes: vi.fn().mockResolvedValue(refreshed),
+      });
+
+      try {
+        await useEmailStore.getState().fetchMailboxes(client);
+        expect(observer).toHaveBeenCalledWith(refreshed);
+      } finally {
+        disposable.dispose();
+      }
+    });
+
     it('keeps a unified-view selection (e.g. All Drafts) on background refresh', async () => {
       useEmailStore.setState({
         mailboxes: [inbox, sent, trash, custom],

--- a/stores/email-store.ts
+++ b/stores/email-store.ts
@@ -1082,6 +1082,11 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
         return;
       }
 
+      // Publish the existing mailbox-refresh extension hook after a successful
+      // fetch. This is also emitted for Mailbox-only state changes (for example
+      // an empty provider label), where no Email fetch follows.
+      await emailHooks.onMailboxesRefresh.emit(mailboxes);
+
       // Auto-select inbox if no mailbox is selected or the current selection
       // doesn't exist in the fetched list (e.g. after an account switch)
       const currentSelectedMailbox = get().selectedMailbox;


### PR DESCRIPTION
## Summary

- expose native label definitions to sandboxed extensions through `api.keywords`
- add narrowly scoped JMAP keyword helpers without exposing arbitrary JMAP requests
- reuse the existing `settings:read`, `settings:write`, `email:read`, and `email:write` permissions
- keep label registration append-only so extensions cannot overwrite or remove user-managed names, colors, visibility, or ordering
- let `api.jmap.getKeywords()` consume an optional JMAP `Keyword/get` method when available
- preserve the existing bounded message scan for servers without the optional capability and for `keywords.discover()` compatibility
- emit the existing `onMailboxesRefresh` extension hook after successful mailbox fetches so mailbox-only changes can drive extensions
- document the extension API and validate inputs against the Bulwark palette and JMAP keyword constraints

## Extension API

- `jmap.getKeywords(options?)` (`email:read`)
- `jmap.setKeywords(emailId, keywords, accountId?)` (`email:write`; complete replacement)
- `jmap.setKeyword(emailId, keyword, accountId?)` (`email:write`; incremental)
- `jmap.removeKeyword(emailId, keyword, accountId?)` (`email:write`; incremental)
- `keywords.list()` (`settings:read`)
- `keywords.add(definitions)` (`settings:write`)
- `keywords.discover(options?)` (`email:read`; original message-scan response)
- `keywords.getCounts(ids?)` (`email:read`)
- `keywords.refreshCounts()` (`email:read`)
- existing `email.setKeyword()` / `email.removeKeyword()` remain compatible

## Optional JMAP keyword capability

When both the JMAP session and active account advertise
`https://bulwarkmail.com/ns/jmap/keywords`, `api.jmap.getKeywords()` calls:

```json
[
  "Keyword/get",
  { "accountId": "<active-account-id>" },
  "0"
]
```

The extension receives the existing `keywords` count map plus `labels` metadata
(`id`, `name`, `color`, `total`, `unread`, `isProviderLabel`, and `source`). This
allows server-provided labels with no messages to remain discoverable. JMAP
servers without the capability transparently fall back to `Email/query` +
`Email/get` scanning.

An integration extension can listen to `onEmailsFetched` and
`onMailboxesRefresh` to synchronize labels. Bulwark contains no
provider-specific label-import logic and no label polling timer.

## Validation

- `npm run typecheck`
- `npm run lint` (0 errors; 8 pre-existing calendar warnings)
- focused keyword and extension API tests pass
