### PR TITLE
fix: split recipient lists whose angle brackets never close

### DIFF
--- a/lib/__tests__/email-composer-utils.test.ts
+++ b/lib/__tests__/email-composer-utils.test.ts
@@ -289,6 +289,23 @@ describe("splitRecipients", () => {
     expect(splitRecipients("")).toEqual([]);
   });
 
+  it("still splits when an angle run never closes", () => {
+    expect(
+      splitRecipients("Ap Reinders <ap@x.com, Erwin Beets <erwin@x.com, jaco@x.com"),
+    ).toEqual([
+      "Ap Reinders <ap@x.com",
+      "Erwin Beets <erwin@x.com",
+      "jaco@x.com",
+    ]);
+  });
+
+  it("splits when only the last entry closes its angle brackets", () => {
+    expect(splitRecipients("Ap <ap@x.com, Bob <bob@y.com>")).toEqual([
+      "Ap <ap@x.com",
+      "Bob <bob@y.com>",
+    ]);
+  });
+
   it("only splits on the given separators (default comma keeps semicolons/newlines literal)", () => {
     expect(splitRecipients("a@x.com; b@y.com")).toEqual(["a@x.com; b@y.com"]);
   });
@@ -409,6 +426,24 @@ describe("splitPastedRecipients", () => {
 
   it("returns empty arrays for blank input", () => {
     expect(splitPastedRecipients("   ")).toEqual({ valid: [], invalid: [] });
+  });
+
+  it("recovers every recipient from a list whose closing brackets are missing", () => {
+    const { valid, invalid } = splitPastedRecipients(
+      "Ap Reinders <ap@x.com, Erwin Beets <erwin@x.com, jaco@x.com",
+    );
+    expect(valid).toEqual([
+      { name: "Ap Reinders", email: "ap@x.com" },
+      { name: "Erwin Beets", email: "erwin@x.com" },
+      { email: "jaco@x.com" },
+    ]);
+    expect(invalid).toEqual([]);
+  });
+
+  it("keeps the display name of a `Name <email` entry missing its bracket", () => {
+    const { valid, invalid } = splitPastedRecipients("John Doe <j@x.com");
+    expect(valid).toEqual([{ name: "John Doe", email: "j@x.com" }]);
+    expect(invalid).toEqual([]);
   });
 });
 

--- a/lib/__tests__/email-composer-utils.test.ts
+++ b/lib/__tests__/email-composer-utils.test.ts
@@ -306,6 +306,19 @@ describe("splitRecipients", () => {
     ]);
   });
 
+  it("does not count a `>` inside a quoted display name as closing the run", () => {
+    expect(splitRecipients('Ap <ap@x.com, "b>c" <b@y.com>')).toEqual([
+      "Ap <ap@x.com",
+      '"b>c" <b@y.com>',
+    ]);
+  });
+
+  it("keeps a group intact even when a member's angle run never closes", () => {
+    expect(splitRecipients("Team: Ann <a@x.com, Bob <b@y.com;")).toEqual([
+      "Team: Ann <a@x.com, Bob <b@y.com;",
+    ]);
+  });
+
   it("only splits on the given separators (default comma keeps semicolons/newlines literal)", () => {
     expect(splitRecipients("a@x.com; b@y.com")).toEqual(["a@x.com; b@y.com"]);
   });
@@ -444,6 +457,14 @@ describe("splitPastedRecipients", () => {
     const { valid, invalid } = splitPastedRecipients("John Doe <j@x.com");
     expect(valid).toEqual([{ name: "John Doe", email: "j@x.com" }]);
     expect(invalid).toEqual([]);
+  });
+
+  it("keeps both addresses when one entry carries two unclosed mailboxes", () => {
+    // The name-preserving path keeps the last angle run only, so it must not
+    // claim an entry whose prefix is an address itself - that would drop it.
+    const { valid, invalid } = splitPastedRecipients("Ann <a@x.com Bob <b@y.com");
+    expect(valid).toEqual([{ email: "a@x.com" }, { email: "b@y.com" }]);
+    expect(invalid).toEqual(["Ann", "Bob"]);
   });
 });
 

--- a/lib/email-composer-utils.ts
+++ b/lib/email-composer-utils.ts
@@ -1,4 +1,5 @@
 import { isValidEmail } from "@/lib/validation";
+import { splitMailbox } from "@/lib/rfc5322-mailbox";
 import { htmlToPlainText } from "@/lib/html-to-text";
 import { emailHooks } from "@/lib/plugin-hooks";
 import { Ellipsis, Lock, TriangleAlert } from "lucide-react";
@@ -242,6 +243,18 @@ export async function enrichChipsWithColorsAndIcons(chips: Recipient[]): Promise
 };
 
 /**
+ * True when the angle run open at `from` closes before the next one opens. A
+ * `<` with no `>` of its own (or whose `>` sits past a later `<`) can never be
+ * an address delimiter, so separators after it must stay separators.
+ */
+function angleRunCloses(value: string, from: number): boolean {
+  const close = value.indexOf('>', from);
+  if (close === -1) return false;
+  const nextOpen = value.indexOf('<', from);
+  return nextOpen === -1 || close < nextOpen;
+}
+
+/**
  * Splits a recipient string into individual entries on any character in
  * `separators`, treating those characters as literal when they sit inside a
  * quoted display name (`"Doo, John" <john@doo.org>`) or angle brackets
@@ -257,7 +270,8 @@ export function splitRecipients(value: string, separators = ','): string[] {
   let inQuotes = false;
   let inAngle = false;
   let inGroup = false;
-  for (const ch of value) {
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
     if (ch === '"') {
       inQuotes = !inQuotes;
       current += ch;
@@ -267,6 +281,13 @@ export function splitRecipients(value: string, separators = ','): string[] {
     } else if (ch === '>' && !inQuotes) {
       inAngle = false;
       current += ch;
+    } else if (separators.includes(ch) && inAngle && !inQuotes && !angleRunCloses(value, i)) {
+      // An unclosed `<` would otherwise swallow every later separator, folding
+      // the whole list into one entry that is not an address at all.
+      inAngle = false;
+      const trimmed = current.trim();
+      if (trimmed) result.push(trimmed);
+      current = '';
     } else if (ch === ':' && !inQuotes && !inAngle) {
       // RFC 5322 group syntax ("Team: a@x, b@y;") - keep the whole group,
       // separators inside it included, as a single entry. A colon inside a
@@ -429,6 +450,8 @@ function splitPasteEntries(value: string): string[] {
  *   semicolon/newline separated) split into one chip per address.
  * - A token wrapped in angle brackets (`<a@x.com>`) is unwrapped before
  *   validating, so an `a <a@x.com>` fragment still yields the address.
+ * - `Name <email` entries that lost their closing bracket keep both the name
+ *   and the address instead of falling apart into bare words.
  */
 export function splitPastedRecipients(
   text: string,
@@ -460,7 +483,11 @@ export function splitPastedRecipients(
     const unwrapped = unquoteName(entry);
     if (unwrapped !== entry && tryAdd(parseRecipient(unwrapped))) continue;
 
-    // 2. Fallback: a bare-address run (`a@x.com b@y.com`) or a
+    // 2. `Name <email` with the closing bracket lost - splitMailbox tolerates
+    //    the missing `>`, so the display name survives the paste.
+    if (tryAdd(splitMailbox(entry))) continue;
+
+    // 3. Fallback: a bare-address run (`a@x.com b@y.com`) or a
     //    `John Doe <j@x.com>` fragment where only the <addr> is valid.
     //    Whitespace/semicolon-tokenize; leftover tokens stay behind.
     for (const token of entry.split(/[\s;]+/).map((t) => t.trim()).filter(Boolean)) {

--- a/lib/email-composer-utils.ts
+++ b/lib/email-composer-utils.ts
@@ -243,15 +243,23 @@ export async function enrichChipsWithColorsAndIcons(chips: Recipient[]): Promise
 };
 
 /**
- * True when the angle run open at `from` closes before the next one opens. A
- * `<` with no `>` of its own (or whose `>` sits past a later `<`) can never be
- * an address delimiter, so separators after it must stay separators.
+ * True when the angle run that is open at `from` closes before the next one
+ * opens. `from` is the index of the character under test (a separator, or the
+ * opening `<` itself); the scan starts after it either way. A `>` inside a
+ * quoted display name does not close anything, and a `<` with no `>` of its own
+ * (or whose `>` sits past a later `<`) can never be an address delimiter, so
+ * separators after it must stay separators.
  */
 function angleRunCloses(value: string, from: number): boolean {
-  const close = value.indexOf('>', from);
-  if (close === -1) return false;
-  const nextOpen = value.indexOf('<', from);
-  return nextOpen === -1 || close < nextOpen;
+  let inQuotes = false;
+  for (let i = from + 1; i < value.length; i++) {
+    const ch = value[i];
+    if (ch === '"') inQuotes = !inQuotes;
+    else if (inQuotes) continue;
+    else if (ch === '>') return true;
+    else if (ch === '<') return false;
+  }
+  return false;
 }
 
 /**
@@ -281,9 +289,10 @@ export function splitRecipients(value: string, separators = ','): string[] {
     } else if (ch === '>' && !inQuotes) {
       inAngle = false;
       current += ch;
-    } else if (separators.includes(ch) && inAngle && !inQuotes && !angleRunCloses(value, i)) {
+    } else if (separators.includes(ch) && inAngle && !inQuotes && !inGroup && !angleRunCloses(value, i)) {
       // An unclosed `<` would otherwise swallow every later separator, folding
-      // the whole list into one entry that is not an address at all.
+      // the whole list into one entry that is not an address at all. Inside a
+      // group the separators belong to the group, so `inGroup` still wins.
       inAngle = false;
       const trimmed = current.trim();
       if (trimmed) result.push(trimmed);
@@ -437,6 +446,11 @@ function splitPasteEntries(value: string): string[] {
   return splitRecipients(value, ',;\n\r');
 }
 
+/** True when a whitespace/semicolon token of `value` is an address in its own right. */
+function carriesAddress(value: string): boolean {
+  return value.split(/[\s;]+/).some((t) => isValidEmail(t.trim().replace(/^<|>$/g, '')));
+}
+
 /**
  * Splits pasted text into recipient candidates and partitions them: valid email
  * addresses become `Recipient`s (deduped case-insensitively against
@@ -484,8 +498,16 @@ export function splitPastedRecipients(
     if (unwrapped !== entry && tryAdd(parseRecipient(unwrapped))) continue;
 
     // 2. `Name <email` with the closing bracket lost - splitMailbox tolerates
-    //    the missing `>`, so the display name survives the paste.
-    if (tryAdd(splitMailbox(entry))) continue;
+    //    the missing `>`, so the display name survives the paste. It keeps the
+    //    last angle run only, so everything ahead of it would become display
+    //    name: skip this step when that prefix carries an address of its own
+    //    (`a@x.com <b@y.com`) rather than silently swallowing it.
+    const lastOpenAngle = entry.lastIndexOf('<');
+    if (
+      lastOpenAngle !== -1 &&
+      !carriesAddress(entry.slice(0, lastOpenAngle)) &&
+      tryAdd(splitMailbox(entry))
+    ) continue;
 
     // 3. Fallback: a bare-address run (`a@x.com b@y.com`) or a
     //    `John Doe <j@x.com>` fragment where only the <addr> is valid.


### PR DESCRIPTION
Fixes #794

## Problem

`splitRecipients` tracks `inAngle` as a latch: `<` sets it, only `>` clears it. A recipient string that opens an angle bracket without closing it therefore stays "inside an address" until the end, so every separator after that point is kept literal and the entire list collapses into one entry.

Pasting a list that lost its closing brackets:

```
Ap Reinders <ap@x.com, Erwin Beets <erwin@x.com, jaco@x.com
```

produces a single entry. `splitPastedRecipients` then falls through to its whitespace tokenizer, where `<ap@x.com,` still carries a trailing comma and fails `isValidEmail`. Result: `ap@` and `erwin@` land silently in `invalid` and only `jaco@` becomes a chip.

The leftovers get joined back into the input, and `commitCurrentInput` accepts whatever `parseRecipient` returns without validating it. That is how a chip whose `email` is the whole pasted list reaches `Email/set`, and the server emits one malformed mailbox in the `To` header:

```
To: <Ap Reinders <ap@x.com, Erwin Beets <erwin@x.com, jaco@x.com>, ...
```

The envelope recipients are fine, so `RCPT TO` succeeds and the relay only rejects at `DATA`:

```
host 'smtp.lettermint.co' rejected command 'DATA' with code 550 (0.0.0) 'Invalid To email address'
```

Every recipient bounces and the sender gets a delivery failure for addresses that are perfectly valid. Seen on 1.7.7 against Stalwart 0.16.13 with a Lettermint relay, and reproducible on current `main`.

Related to #672, which fixed the mailbox-level parsing (`splitMailbox` tolerates a missing `>`). This is the list-level tokenizer, which still folds on the same input.

## Change

- `splitRecipients` treats a separator as a separator when the open angle run cannot close before the next `<` opens. Balanced input is untouched, so `Group <a,b@x.com>, c@x.com` and `"Doo, John" <john@doo.org>` still behave exactly as before.
- `splitPastedRecipients` tries `splitMailbox` before the whitespace fallback, so `Name <email` keeps its display name instead of scattering into bare words.

## Tests

Four cases added to `lib/__tests__/email-composer-utils.test.ts`: unclosed runs, a list where only the final entry closes, full recovery of the pasted list above, and display-name preservation.

`npm run typecheck`, `npm run lint` and `npx vitest run` all pass. The only failing test on this branch is `translations.test.ts > mn should not have extra keys absent from en`, which fails identically on unmodified `main`.

## Not covered here

`commitCurrentInput` still commits an unvalidated recipient, and `canSend` only checks `toAddresses.length > 0`, so a malformed address typed directly can still be sent. That is filed separately as #795: blocking it needs a user-facing error string across 24 locales, so it did not belong in this PR. Happy to take it on if the approach there sounds right.


