### PR TITLE
fix: a directly-selected shared folder has no account context (tags, compose identity)

### DIFF
--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -2676,7 +2676,7 @@ export function EmailViewer({
         subject: t('read_receipt.mdn_subject', { subject: email.subject || '' }),
         humanText: t('read_receipt.mdn_body', { recipient: receiptIdentity.email }),
       });
-      await client.setKeyword(email.id, '$mdnsent');
+      await useEmailStore.getState().markEmailKeyword(client, email.id, '$mdnsent');
     } catch (err) {
       // Surface the failure instead of silently resetting the banner so we can
       // see which step (upload / import / submission) failed.
@@ -2693,7 +2693,7 @@ export function EmailViewer({
     if (client && email) {
       // $MDNSent is the RFC 3503 flag every IMAP/JMAP client honours, so the
       // request is suppressed everywhere - not just locally.
-      try { await client.setKeyword(email.id, '$mdnsent'); } catch { /* best effort */ }
+      try { await useEmailStore.getState().markEmailKeyword(client, email.id, '$mdnsent'); } catch { /* best effort */ }
     }
   }, [client, email]);
 

--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -62,7 +62,7 @@ import { isFilePreviewable } from "@/lib/file-preview";
 import { appendHtmlSignature, appendPlainTextSignature } from "@/lib/signature-utils";
 import { computeReplyThreadingHeaders } from "@/lib/email-threading";
 import { EML_IMPORT_ACCEPT, expandImportableEmails } from "@/lib/eml-import";
-import { findDraftIdentityId, resolveReplyFrom, type ReplyFromResolution } from "@/lib/reply-identity";
+import { findDraftIdentityId, resolveComposeAccountEmail, resolveReplyFrom, type ReplyFromResolution } from "@/lib/reply-identity";
 import { buildReplyRecipients, isSelfSent } from "@/lib/reply-recipients";
 import { useProMultiAccountIdentities } from "@/hooks/use-pro-multi-account-identities";
 import { Search, Filter, ChevronDown, X, Paperclip, Star, Mail, MailOpen, RotateCcw, PenSquare, PenLine, CheckSquare, Square, AlertTriangle } from "lucide-react";
@@ -3656,11 +3656,13 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
                 <EmailComposer
                   key={composerSessionId}
                   mode={pendingDraft?.mode ?? composerMode}
-                  composeFromAccountEmail={
+                  composeFromAccountEmail={resolveComposeAccountEmail(
+                    mailboxes,
+                    selectedMailbox,
                     useAccountStore
                       .getState()
-                      .getAccountById(viewingAccountId ?? activeAccountId ?? '')?.email
-                  }
+                      .getAccountById(viewingAccountId ?? activeAccountId ?? '')?.email,
+                  )}
                   replyTo={pendingDraft !== null ? pendingDraft.replyTo : (selectedEmail ? {
                     from: selectedEmail.from,
                     replyToAddresses: selectedEmail.replyTo,

--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -301,7 +301,7 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
     deleteEmail,
     markAsRead,
     toggleStar,
-    setEmailKeywordsLocal,
+    setEmailKeywords,
     moveToMailbox,
     moveToMailboxCrossAware,
     moveThreadToMailbox,
@@ -1468,16 +1468,9 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
       // write to the email's own account so the flag lands on shared/group-mailbox
       // messages instead of being dropped against the reaching account. (#281)
       if (originalEmailId && (effectiveMode === 'reply' || effectiveMode === 'replyAll' || effectiveMode === 'forward')) {
-        const s = useEmailStore.getState();
-        const orig = s.emails.find(e => e.id === originalEmailId);
-        const kwClientId = s.isUnifiedView ? orig?.sourceClientAccountId : undefined;
-        const kwAccountId = s.isUnifiedView ? orig?.sourceAccountId : undefined;
-        const kwClient = kwClientId
-          ? (useAuthStore.getState().getClientForAccount(kwClientId) ?? client)
-          : client;
         const keyword = effectiveMode === 'forward' ? '$forwarded' : '$answered';
         try {
-          await kwClient.setKeyword(originalEmailId, keyword, kwAccountId);
+          await useEmailStore.getState().markEmailKeyword(client, originalEmailId, keyword);
         } catch (e) {
           debug.error(`Failed to set ${keyword} keyword:`, e);
         }
@@ -2076,22 +2069,13 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
         keywords['$pinned'] = true;
       }
 
-      // Same unified-view routing as tags: write to the email's own
-      // account via the login it is reachable through. (#281)
-      const pinClientId = isUnifiedView ? email.sourceClientAccountId : undefined;
-      const pinAccountId = isUnifiedView ? email.sourceAccountId : undefined;
-      const pinClient = pinClientId
-        ? (useAuthStore.getState().getClientForAccount(pinClientId) ?? client)
-        : client;
-
-      await pinClient.updateEmailKeywords(email.id, keywords, pinAccountId);
-
-      // Patch in place so the icon flips immediately, then refetch the first
-      // page so the mail floats/sinks per the server's pinned-first sort.
-      // Skip the refetch where that sort does not apply (unified views) or
-      // where it would replace a tag-filtered list (refreshCurrentMailbox
-      // fetches by folder only).
-      setEmailKeywordsLocal(email.id, keywords);
+      // Same routing as tags: the write goes to the email's own account, and
+      // the local patch flips the icon immediately. Then refetch the first page
+      // so the mail floats/sinks per the server's pinned-first sort. Skip the
+      // refetch where that sort does not apply (unified views) or where it
+      // would replace a tag-filtered list (refreshCurrentMailbox fetches by
+      // folder only). (#281)
+      await setEmailKeywords(client, email.id, keywords);
       if (!isUnifiedView && !useEmailStore.getState().selectedKeyword) {
         void refreshCurrentMailbox(client);
       }
@@ -2132,24 +2116,13 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
         }
       }
 
-      // In unified view route the write to the email's own account, reached
-      // through the login it is reachable via (`sourceClientAccountId`) and
-      // applied to its owning JMAP account (`sourceAccountId`). For personal
-      // sources these resolve to the account itself, so behavior is unchanged.
-      // Without this, tags on shared/group-mailbox messages are written to the
-      // reaching account and silently dropped by the server. (#281)
-      const tagClientId = isUnifiedView ? email.sourceClientAccountId : undefined;
-      const tagAccountId = isUnifiedView ? email.sourceAccountId : undefined;
-      const tagClient = tagClientId
-        ? (useAuthStore.getState().getClientForAccount(tagClientId) ?? client)
-        : client;
-
-      // Update email keywords via JMAP
-      await tagClient.updateEmailKeywords(emailId, keywords, tagAccountId);
-
-      // Patch the email in place so the list keeps its scroll/pagination state
-      // instead of being reset to the first page by a full refetch.
-      setEmailKeywordsLocal(emailId, keywords);
+      // Routes the write to the email's own account, then patches the email in
+      // place so the list keeps its scroll/pagination state instead of being
+      // reset to the first page by a full refetch. Resolving the account at the
+      // call site covered only the unified view, so a tag set on a directly
+      // selected shared folder was written to the reaching account and silently
+      // dropped by the server. (#281)
+      await setEmailKeywords(client, emailId, keywords);
 
       // Refresh tag counts
       fetchTagCounts(client);
@@ -2836,15 +2809,8 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
     // account so the flag lands on shared/group-mailbox messages instead of
     // being dropped against the reaching account. (#281)
     {
-      const s = useEmailStore.getState();
-      const orig = s.emails.find(e => e.id === originalEmailId);
-      const kwClientId = s.isUnifiedView ? orig?.sourceClientAccountId : undefined;
-      const kwAccountId = s.isUnifiedView ? orig?.sourceAccountId : undefined;
-      const kwClient = kwClientId
-        ? (useAuthStore.getState().getClientForAccount(kwClientId) ?? client)
-        : client;
       try {
-        await kwClient.setKeyword(originalEmailId, '$answered', kwAccountId);
+        await useEmailStore.getState().markEmailKeyword(client, originalEmailId, '$answered');
       } catch (e) {
         debug.error('Failed to set $answered keyword:', e);
       }

--- a/components/pro/pro-compose-tab-body.tsx
+++ b/components/pro/pro-compose-tab-body.tsx
@@ -96,13 +96,13 @@ export function ProComposeTabBody({ tabId, data }: ProComposeTabBodyProps) {
       // viewer and list reflect the action (same behaviour as inline compose).
       if (data.sourceEmailId && (data.mode === 'reply' || data.mode === 'replyAll')) {
         try {
-          await client.setKeyword(data.sourceEmailId, '$answered');
+          await useEmailStore.getState().markEmailKeyword(client, data.sourceEmailId, '$answered');
         } catch (e) {
           debug.error('Failed to set $answered keyword:', e);
         }
       } else if (data.sourceEmailId && data.mode === 'forward') {
         try {
-          await client.setKeyword(data.sourceEmailId, '$forwarded');
+          await useEmailStore.getState().markEmailKeyword(client, data.sourceEmailId, '$forwarded');
         } catch (e) {
           debug.error('Failed to set $forwarded keyword:', e);
         }

--- a/hooks/use-tag-drop.ts
+++ b/hooks/use-tag-drop.ts
@@ -81,19 +81,10 @@ export function useTagDrop({ tagId, onSuccess, onError }: UseTagDropOptions): Us
         // Add the tag without removing existing ones
         keywords[`$label:${tagId}`] = true;
 
-        // In unified view route the write to the email's own account, reached
-        // through the login it is reachable via (`sourceClientAccountId`) and
-        // applied to its owning JMAP account (`sourceAccountId`). For personal
-        // sources these resolve to the account itself, so behavior is unchanged.
-        // Without this, tags on shared/group-mailbox messages are written to the
-        // reaching account and silently dropped by the server. (#281)
-        const tagClientId = emailState.isUnifiedView ? email?.sourceClientAccountId : undefined;
-        const tagAccountId = emailState.isUnifiedView ? email?.sourceAccountId : undefined;
-        const tagClient = tagClientId
-          ? (useAuthStore.getState().getClientForAccount(tagClientId) ?? client)
-          : client;
-
-        await tagClient.updateEmailKeywords(emailId, keywords, tagAccountId);
+        // Routes the write to the email's own account - the email's source in an
+        // aggregate view, the selected folder's owner when a shared folder is
+        // open directly. (#281)
+        await emailState.setEmailKeywords(client, emailId, keywords);
       }
 
       // Refresh the email list

--- a/lib/__tests__/reply-identity.test.ts
+++ b/lib/__tests__/reply-identity.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { findComposeIdentityId, findDraftIdentityId, findReplyIdentityId, resolveReplyFrom } from '../reply-identity';
+import { findComposeIdentityId, findDraftIdentityId, findReplyIdentityId, resolveComposeAccountEmail, resolveReplyFrom } from '../reply-identity';
 import type { Identity } from '../jmap/types';
 
 const identities: Identity[] = [
@@ -136,5 +136,54 @@ describe('resolveReplyFrom', () => {
   it('returns null when recipients are on foreign domains', () => {
     expect(resolveReplyFrom(identities, { to: [{ email: 'nobody@elsewhere.com' }] }))
       .toBeNull();
+  });
+});
+
+describe('resolveComposeAccountEmail', () => {
+  // Selecting a shared/group folder in the "Shared" sidebar does not move the
+  // active account, so the composer used to preselect the reaching login's
+  // primary identity and start every new message as the wrong sender.
+  const mailboxes = [
+    { id: 'a-inbox' },
+    { id: 'owner-x:x-inbox', isShared: true, accountName: 'team@shared.example' },
+    { id: 'owner-y:y-inbox', isShared: true, accountName: 'Support Team' },
+  ];
+
+  it('uses the shared folder owner address when a shared folder is selected', () => {
+    expect(resolveComposeAccountEmail(mailboxes, 'owner-x:x-inbox', 'me@primary.example'))
+      .toBe('team@shared.example');
+  });
+
+  it('keeps the active account address for an own folder', () => {
+    expect(resolveComposeAccountEmail(mailboxes, 'a-inbox', 'me@primary.example'))
+      .toBe('me@primary.example');
+  });
+
+  it('falls back to the active account when the account name is not an address', () => {
+    // RFC 8620 suggests the address for Account.name, but a server may put a
+    // human label there; that must not become a From address.
+    expect(resolveComposeAccountEmail(mailboxes, 'owner-y:y-inbox', 'me@primary.example'))
+      .toBe('me@primary.example');
+  });
+
+  it('handles an unknown or empty selection', () => {
+    expect(resolveComposeAccountEmail(mailboxes, 'nope', 'me@primary.example')).toBe('me@primary.example');
+    expect(resolveComposeAccountEmail(mailboxes, null, 'me@primary.example')).toBe('me@primary.example');
+    expect(resolveComposeAccountEmail(mailboxes, 'owner-x:x-inbox', null)).toBe('team@shared.example');
+    expect(resolveComposeAccountEmail(mailboxes, 'a-inbox', null)).toBeUndefined();
+  });
+
+  it('preselects the shared identity end-to-end (the reported repro)', () => {
+    // Shared folder selected -> resolved address -> matching send-as identity.
+    const identities: Identity[] = [
+      { id: 'primary', name: 'D R', email: 'me@primary.example', mayDelete: false },
+      { id: 'shared', name: 'D R', email: 'team@shared.example', mayDelete: false },
+    ];
+    const address = resolveComposeAccountEmail(mailboxes, 'owner-x:x-inbox', 'me@primary.example');
+    expect(findComposeIdentityId(identities, address)).toBe('shared');
+
+    // Same call on an own folder keeps the primary identity.
+    const own = resolveComposeAccountEmail(mailboxes, 'a-inbox', 'me@primary.example');
+    expect(findComposeIdentityId(identities, own)).toBe('primary');
   });
 });

--- a/lib/reply-identity.ts
+++ b/lib/reply-identity.ts
@@ -96,6 +96,38 @@ export function findComposeIdentityId(
 }
 
 /**
+ * Address whose identity `findComposeIdentityId` should preselect, based on the
+ * mailbox currently open.
+ *
+ * Selecting a shared/group folder in the "Shared" sidebar section does not move
+ * the active account - a delegated mailbox has no separate login, it is reached
+ * through the viewer's - so the composer fell back to the reaching login's
+ * primary address and started every new message as the wrong sender. The owner
+ * of the selected folder is the correct default there.
+ *
+ * `accountName` is the JMAP `Account.name`, which RFC 8620 describes as "e.g.,
+ * the email address of the account". Servers that put a human label there
+ * instead simply produce no identity match, and the caller keeps the primary
+ * identity - exactly the previous behaviour. The `@` test keeps that intent
+ * explicit rather than relying on the match to fail.
+ */
+export function resolveComposeAccountEmail(
+  mailboxes: Array<{ id: string; isShared?: boolean; accountName?: string }>,
+  selectedMailbox?: string | null,
+  activeAccountEmail?: string | null,
+): string | undefined {
+  const current = selectedMailbox
+    ? mailboxes.find((mailbox) => mailbox.id === selectedMailbox)
+    : undefined;
+
+  if (current?.isShared && current.accountName?.includes('@')) {
+    return current.accountName;
+  }
+
+  return activeAccountEmail ?? undefined;
+}
+
+/**
  * Restore the identity a draft was composed with from its saved From. A draft
  * stores only the From address+name, not an identityId, so when two identities
  * share an address (a default + an alias with a different display name) the name

--- a/stores/__tests__/email-store-shared-folder-keywords.test.ts
+++ b/stores/__tests__/email-store-shared-folder-keywords.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEmailStore } from '../email-store';
+import { useAuthStore } from '../auth-store';
+import type { Email, Mailbox } from '@/lib/jmap/types';
+import type { IJMAPClient } from '@/lib/jmap/client-interface';
+
+// Regression coverage for keyword writes (tags, $pinned, $answered/$forwarded,
+// $mdnsent) performed while viewing a shared/group mailbox DIRECTLY from the
+// "Shared" sidebar section, rather than through the unified inbox.
+//
+// Same shape as email-store-shared-folder-actions.test.ts: in this view the
+// emails are undecorated (no `sourceAccountId`) because they are fetched from
+// the owner account through the active login client. The keyword call sites
+// resolved the target account as `isUnifiedView ? email.sourceAccountId :
+// undefined`, so outside the unified view the write went to the reaching
+// client's own account. Stalwart answers that with `notUpdated` / an unchanged
+// state and no error, so the UI showed the tag until the next reload and then
+// silently lost it.
+//
+// `toggleStar` never had the bug because it routes through
+// `resolveEmailActionContext`, which resolves the owner from the selected
+// mailbox when the email carries no source reference. These tests pin the
+// keyword paths to that same resolver.
+
+function makeMailbox(overrides: Partial<Mailbox> = {}): Mailbox {
+  return {
+    id: 'inbox',
+    name: 'Inbox',
+    sortOrder: 0,
+    totalEmails: 0,
+    unreadEmails: 0,
+    totalThreads: 0,
+    unreadThreads: 0,
+    myRights: {
+      mayReadItems: true,
+      mayAddItems: true,
+      mayRemoveItems: true,
+      maySetSeen: true,
+      maySetKeywords: true,
+      mayCreateChild: true,
+      mayRename: true,
+      mayDelete: true,
+      maySubmit: true,
+    },
+    isSubscribed: true,
+    isShared: false,
+    ...overrides,
+  };
+}
+
+function makeEmail(overrides: Partial<Email> = {}): Email {
+  return {
+    id: 'email-1',
+    threadId: 'thread-1',
+    subject: 'Hi',
+    receivedAt: new Date().toISOString(),
+    keywords: {},
+    mailboxIds: {},
+    ...overrides,
+  } as Email;
+}
+
+function makeClient() {
+  return {
+    updateEmailKeywords: vi.fn().mockResolvedValue(undefined),
+    setKeyword: vi.fn().mockResolvedValue(undefined),
+    toggleStar: vi.fn().mockResolvedValue(undefined),
+  } as unknown as IJMAPClient;
+}
+
+describe('non-unified shared-folder keyword routing', () => {
+  let activeClient: IJMAPClient; // account-a, the logged-in user, also reaches owner-x
+
+  beforeEach(() => {
+    activeClient = makeClient();
+
+    // Only the active login exists; the shared owner 'owner-x' is reached
+    // THROUGH it (a group mailbox has no separate login client).
+    useAuthStore.setState({
+      activeAccountId: 'account-a',
+      getClientForAccount: (id: string) => (id === 'account-a' ? activeClient : undefined) as never,
+    } as never);
+
+    // Viewing the shared inbox directly: not unified, no viewingAccountId.
+    useEmailStore.setState({
+      isUnifiedView: false,
+      unifiedRole: null,
+      viewingAccountId: null,
+      selectedMailbox: 'owner-x:x-inbox',
+      mailboxes: [
+        makeMailbox({ id: 'a-inbox', role: 'inbox' }),
+        makeMailbox({
+          id: 'owner-x:x-inbox',
+          originalId: 'x-inbox',
+          name: 'Shared Inbox',
+          role: 'inbox',
+          isShared: true,
+          accountId: 'owner-x',
+        }),
+      ],
+      accountMailboxes: {},
+      selectedEmail: null,
+      emails: [makeEmail({ id: 'e1', keywords: {}, mailboxIds: { 'owner-x:x-inbox': true } })],
+      selectedEmailIds: new Set<string>(),
+    } as never);
+  });
+
+  it('setEmailKeywords writes tags to the OWNER account, not the reaching account', async () => {
+    await useEmailStore.getState().setEmailKeywords(activeClient, 'e1', { '$label:work': true });
+
+    expect(activeClient.updateEmailKeywords).toHaveBeenCalledWith(
+      'e1',
+      { '$label:work': true },
+      'owner-x',
+    );
+  });
+
+  it('setEmailKeywords patches local state so the tag shows immediately', async () => {
+    await useEmailStore.getState().setEmailKeywords(activeClient, 'e1', { '$label:work': true });
+
+    expect(useEmailStore.getState().emails.find(e => e.id === 'e1')?.keywords).toEqual({
+      '$label:work': true,
+    });
+  });
+
+  it('markEmailKeyword writes $answered to the OWNER account', async () => {
+    await useEmailStore.getState().markEmailKeyword(activeClient, 'e1', '$answered');
+
+    expect(activeClient.setKeyword).toHaveBeenCalledWith('e1', '$answered', 'owner-x');
+  });
+
+  it('routes a keyword write for an email that is only the selected email', async () => {
+    // The read-receipt ($mdnsent) path acts on the open message, which is not
+    // necessarily in the current `emails` page.
+    useEmailStore.setState({
+      emails: [],
+      selectedEmail: makeEmail({ id: 'open-1', mailboxIds: { 'owner-x:x-inbox': true } }),
+    } as never);
+
+    await useEmailStore.getState().markEmailKeyword(activeClient, 'open-1', '$mdnsent');
+
+    expect(activeClient.setKeyword).toHaveBeenCalledWith('open-1', '$mdnsent', 'owner-x');
+  });
+
+  it('does NOT guess an owner for an email the store does not know', async () => {
+    // A Pro tab fetches its own email and never puts it in `emails` or
+    // `selectedEmail`. The selected mailbox says nothing about that message's
+    // owner, so routing by it would send an own-account write to the shared
+    // account merely because a shared folder happened to be open. Such a write
+    // must keep the previous behaviour: no explicit accountId.
+    useEmailStore.setState({ emails: [], selectedEmail: null } as never);
+
+    await useEmailStore.getState().markEmailKeyword(activeClient, 'tab-only', '$mdnsent');
+
+    expect(activeClient.setKeyword).toHaveBeenCalledWith('tab-only', '$mdnsent', undefined);
+  });
+
+  it('leaves own-account keyword writes untouched (no JMAP accountId)', async () => {
+    // Selecting the user's own inbox must still write to the own account with
+    // no explicit accountId, exactly as before.
+    useEmailStore.setState({
+      selectedMailbox: 'a-inbox',
+      emails: [makeEmail({ id: 'o1', keywords: {}, mailboxIds: { 'a-inbox': true } })],
+    } as never);
+
+    await useEmailStore.getState().setEmailKeywords(activeClient, 'o1', { '$label:work': true });
+
+    expect(activeClient.updateEmailKeywords).toHaveBeenCalledWith(
+      'o1',
+      { '$label:work': true },
+      undefined,
+    );
+  });
+
+  it('still routes by the email source in the unified view', async () => {
+    // The aggregate path keeps precedence: a decorated email routes to its own
+    // source account even though a different mailbox is selected.
+    useEmailStore.setState({
+      isUnifiedView: true,
+      selectedMailbox: 'a-inbox',
+      emails: [
+        makeEmail({
+          id: 'u1',
+          sourceClientAccountId: 'account-a',
+          sourceAccountId: 'owner-y',
+          mailboxIds: {},
+        }),
+      ],
+    } as never);
+
+    await useEmailStore.getState().setEmailKeywords(activeClient, 'u1', { '$label:work': true });
+
+    expect(activeClient.updateEmailKeywords).toHaveBeenCalledWith(
+      'u1',
+      { '$label:work': true },
+      'owner-y',
+    );
+  });
+});

--- a/stores/email-store.ts
+++ b/stores/email-store.ts
@@ -214,6 +214,8 @@ interface EmailStore {
   clearSearchFilters: () => void;
   toggleAdvancedSearch: () => void;
   toggleStar: (client: IJMAPClient, emailId: string) => Promise<void>;
+  setEmailKeywords: (client: IJMAPClient, emailId: string, keywords: Record<string, boolean>) => Promise<void>;
+  markEmailKeyword: (client: IJMAPClient, emailId: string, keyword: string) => Promise<void>;
   setEmailKeywordsLocal: (emailId: string, keywords: Record<string, boolean>) => void;
 
   // Batch operations
@@ -443,6 +445,30 @@ function resolveEmailActionContext(
     mailboxes,
     accountId: currentMailbox?.isShared ? currentMailbox.accountId : undefined,
   };
+}
+
+/**
+ * Resolution for a keyword write, by email id.
+ *
+ * Same routing as `resolveEmailActionContext`, but only when the email is
+ * actually known to the store. A keyword write can be triggered for a message
+ * that is NOT the current selection - a Pro tab fetches its own email and does
+ * not go through `selectedEmail` - and for those the selected mailbox says
+ * nothing about the message's owner. Guessing from it would send an own-account
+ * write to a shared account whenever a shared folder happened to be open, so an
+ * unknown email keeps the previous behaviour instead: no explicit accountId,
+ * i.e. the reaching client's own account.
+ */
+function resolveKeywordActionContext(
+  emailId: string,
+  passedClient: IJMAPClient,
+): { client: IJMAPClient; accountId: string | undefined } {
+  const state = useEmailStore.getState();
+  const email = state.emails.find(e => e.id === emailId)
+    ?? (state.selectedEmail?.id === emailId ? state.selectedEmail : undefined);
+  if (!email) return { client: passedClient, accountId: undefined };
+  const { client, accountId } = resolveEmailActionContext(email, passedClient);
+  return { client, accountId };
 }
 
 /**
@@ -2317,6 +2343,33 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
       });
       throw error;
     }
+  },
+
+  markEmailKeyword: async (client, emailId, keyword) => {
+    // Single-flag counterpart of setEmailKeywords ($answered / $forwarded /
+    // $mdnsent). Same routing, same reason: an unrouted write against the
+    // reaching client's primary account is a silent no-op on a shared/group
+    // message. Best-effort by contract - callers treat a failure as non-fatal.
+    const { client: actionClient, accountId } = resolveKeywordActionContext(emailId, client);
+    await actionClient.setKeyword(emailId, keyword, accountId);
+  },
+
+  setEmailKeywords: async (client, emailId, keywords) => {
+    // Route the write to the email's OWN account, exactly like toggleStar and
+    // every other single-email action. `resolveEmailActionContext` covers both
+    // shapes: in an aggregate view the owner comes from the email's
+    // `sourceAccountId`, and when a shared/group folder is selected directly in
+    // the "Shared" sidebar section - where emails are undecorated - it falls back
+    // to the owner of the selected mailbox.
+    //
+    // Resolving only the aggregate shape (`isUnifiedView ? ... : undefined`) sent
+    // the write to the reaching client's primary account, which the server
+    // answers with `notUpdated`/`updated: null` and no error, so the keyword was
+    // silently lost on the next reload - the same class of bug as the batch
+    // actions in `email-store-shared-folder-actions.test.ts`. (#281)
+    const { client: actionClient, accountId } = resolveKeywordActionContext(emailId, client);
+    await actionClient.updateEmailKeywords(emailId, keywords, accountId);
+    get().setEmailKeywordsLocal(emailId, keywords);
   },
 
   setEmailKeywordsLocal: (emailId, keywords) => {


### PR DESCRIPTION
Two bugs with one root cause: a shared/group mailbox opened **directly** from the "Shared" sidebar section carries no account context.

Such a folder is not an `AccountEntry` (a delegated mailbox has no separate login), `setViewingAccount` is only ever called with `null`, and the emails fetched from it are undecorated — no `sourceAccountId`. Anything that asks "which account am I acting on?" therefore falls back to the reaching login's primary account.

### 1. Keyword writes don't persist (tags, pins, `$answered`/`$forwarded`/`$mdnsent`)

Setting a tag on a message in a shared folder appears to work and is gone after the next reload.

The call sites resolved the target account as `isUnifiedView ? email.sourceAccountId : undefined`. Outside the unified view that is always `undefined`, so the write went to the reaching client's own account. The server answers that with `notUpdated` / `updated: null` and **no error**, so the UI keeps showing the tag until it refetches — the same silent no-op that `email-store-shared-folder-actions.test.ts` already documents for the batch actions.

`toggleStar` never had this bug, because it routes through `resolveEmailActionContext`, which resolves the owner from the email's source in an aggregate view and **from the selected mailbox otherwise**. That resolver had been reimplemented inline at each keyword call site, and every inline copy covered only the aggregate half. The observable symptom is precise: on a shared folder, starring a message persists while tagging the same message does not.

The two keyword writes move into store actions built on the shared resolver, and every call site routes through them — including the read-receipt and Pro-compose paths, which passed no `accountId` at all.

The store actions resolve only for an email the store actually knows. A Pro tab fetches its own email and never enters `emails` or `selectedEmail`; for those the selected mailbox says nothing about the message's owner, so routing by it would send an **own-account** write to a shared account whenever a shared folder happened to be open. An unknown email keeps the previous behaviour instead.

### 2. New messages compose as the wrong sender

With a shared folder selected, a new message starts as the primary address even when a matching send-as identity exists.

`composeFromAccountEmail` came from `getAccountById(viewingAccountId ?? activeAccountId)`, and both ids point at the primary account in this view — so `findComposeIdentityId` was handed the wrong address and correctly matched the primary identity. It is now resolved from the selected mailbox, falling back to the account lookup for own folders.

`accountName` is the JMAP `Account.name`, which RFC 8620 describes as "e.g., the email address of the account". A server that puts a human label there produces no identity match and the composer keeps the primary identity — the previous behaviour. Replies are unaffected: `composeFromAccountEmail` is only read when `mode === 'compose'`.

### Testing

* `stores/__tests__/email-store-shared-folder-keywords.test.ts` — 7 store-level tests mirroring the existing shared-folder-actions harness: tags and `$answered` route to the owner, the local patch applies, own-account writes stay unrouted, the unified view keeps precedence, and an unknown email is not guessed at.
* `lib/__tests__/reply-identity.test.ts` — 5 tests for `resolveComposeAccountEmail`, including a non-address `accountName` and an end-to-end selected-folder → address → identity check.
* Each test was verified to **fail** against the pre-fix logic, not merely to pass after it.
* `tsc --noEmit` and `eslint` clean; each commit typechecks standalone. Full suite: 2660 passing. Two failures are present on an unmodified `main` as well — `translations.test.ts` (`mn` key parity) and `jmap-client-resilience.test.ts` (timing-dependent, passes on re-run).

### Note on an adjacent path, not touched here

Single-email **delete** from a directly-selected shared folder looks up the trash with `matchesScope = !m.isShared`, which selects the user's *own* trash rather than the shared one. Same class, different path — left out to keep this reviewable.

Happy to split this into two PRs if you'd prefer the compose-identity change separately.
