### PR TITLE
test: serve a fresh mock response per fetch in the keep-alive test

### DIFF
--- a/lib/__tests__/jmap-client-resilience.test.ts
+++ b/lib/__tests__/jmap-client-resilience.test.ts
@@ -373,7 +373,10 @@ describe('JMAPClient resilience', () => {
       client.onConnectionChange(callback);
 
       const echoResponse = { methodResponses: [['Core/echo', { ping: 'pong' }, '0']] };
-      fetchSpy.mockResolvedValue(mockFetchResponse(200, echoResponse));
+      // A Response body is single-use, so one shared instance breaks as soon
+      // as anything fetches more than once in the window - serve a fresh one
+      // per call like the other tests in this file.
+      fetchSpy.mockImplementation(() => Promise.resolve(mockFetchResponse(200, echoResponse)));
 
       // Advance past keep-alive interval (30s)
       await vi.advanceTimersByTimeAsync(30_000);


### PR DESCRIPTION
## Summary

`npx vitest run` currently fails on `main`: the keep-alive test in `lib/__tests__/jmap-client-resilience.test.ts` reports a lost connection that never happened. The test parks a single `Response` instance in `mockResolvedValue`, but a Response body is single-use — as soon as more than one request lands in the simulated 30s window, the second read dies with "Body is unusable: Body has already been read", the ping counts as failed, and the `onConnectionChange(true)` assertion sees `false`. Recent client changes made a second request in that window the norm, so what used to be an occasional flake under parallel load is now a deterministic failure.

## Changes

- Serve a fresh `Response` per fetch call via `mockImplementation` — the pattern the rest of this file already uses — instead of one shared instance.

## Related issues

None — test-only repair; the production client reads each response exactly once, so there is no runtime counterpart to this failure.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

No UI involved — one-line test fix.

## Notes for reviewers

- Reproduce on `main` with `npx vitest run lib/__tests__/jmap-client-resilience.test.ts`: the keep-alive test fails with the "Body is unusable" stderr trace; with this change the file passes 33/33.
- Verified with `npm run typecheck`, `npm run lint` and the full `npx vitest run`.
