### PR TITLE
fix(identities): namespace all accounts consistently in the Pro composer

### DIFF
--- a/hooks/use-pro-multi-account-identities.ts
+++ b/hooks/use-pro-multi-account-identities.ts
@@ -16,10 +16,12 @@ interface AccountIdentityGroup {
 
 const CROSS_ACCOUNT_IDENTITY_DELIMITER = '::';
 
-/** Cross-account identity IDs are namespaced to avoid collisions between
- * JMAP servers that happen to issue the same opaque ID. The active
- * account's IDs are left untouched so existing single-account code paths
- * (reply-identity resolution, S/MIME bindings) keep working unchanged.
+/** Cross-account identity IDs are namespaced to avoid collisions between JMAP
+ * servers that happen to issue the same opaque ID. EVERY aggregated account is
+ * namespaced (including the active one) so an id doesn't change form when the
+ * active account changes; consumers resolve the raw id via
+ * stripCrossAccountIdentityPrefix. Single-account mode (hook disabled) uses the
+ * identity store's raw ids directly.
  */
 export function isCrossAccountIdentityId(id: string): boolean {
   return id.includes(CROSS_ACCOUNT_IDENTITY_DELIMITER);
@@ -94,35 +96,32 @@ export function useProMultiAccountIdentities(): {
 
   const groups = useMemo<AccountIdentityGroup[]>(() => {
     if (!enabled) return [];
+    // Namespace EVERY account's identity ids, including the active one, so an id
+    // stably identifies (account, identity) regardless of which account is
+    // active. Consumers resolve the raw id via stripCrossAccountIdentityPrefix.
+    // Mirrors the calendar/contact stores' consistent-namespacing invariant.
+    const group = (accountId: string, list: Identity[], label: string): AccountIdentityGroup => ({
+      localAccountId: accountId,
+      accountLabel: label,
+      identities: list.map((id) => ({
+        ...id,
+        id: `${accountId}${CROSS_ACCOUNT_IDENTITY_DELIMITER}${id.id}`,
+        localAccountId: accountId,
+        accountName: label,
+      })),
+    });
     const out: AccountIdentityGroup[] = [];
     if (activeAccountId) {
       const active = accounts.find((a) => a.id === activeAccountId);
       const label = active?.label || active?.email || active?.username || activeAccountId;
-      out.push({
-        localAccountId: activeAccountId,
-        accountLabel: label,
-        identities: activeIdentities.map((id) => ({
-          ...id,
-          localAccountId: activeAccountId,
-          accountName: label,
-        })),
-      });
+      out.push(group(activeAccountId, activeIdentities, label));
     }
     for (const account of accounts) {
       if (!account.isConnected || account.id === activeAccountId) continue;
       const list = remoteIdentities[account.id];
       if (!list || list.length === 0) continue;
       const label = account.label || account.email || account.username;
-      out.push({
-        localAccountId: account.id,
-        accountLabel: label,
-        identities: list.map((id) => ({
-          ...id,
-          id: `${account.id}${CROSS_ACCOUNT_IDENTITY_DELIMITER}${id.id}`,
-          localAccountId: account.id,
-          accountName: label,
-        })),
-      });
+      out.push(group(account.id, list, label));
     }
     return out;
   }, [enabled, accounts, activeAccountId, activeIdentities, remoteIdentities]);


### PR DESCRIPTION
## Summary

Follow-up to the calendar/contacts consistent-namespacing fix (the "identities"
scope note in MR-fix-consistent-cross-account-id-namespacing). The multi-account
identity aggregation left the ACTIVE account's identity ids raw while namespacing
the others, so an identity id changed form when the active account changed.

## Changes

hooks/use-pro-multi-account-identities.ts now namespaces EVERY aggregated
account, including the active one (`<accountId>::<id>`), matching the
calendar/contact stores. Single-account mode (hook disabled) still uses the
identity store's raw ids.

## Related issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #

## Type of change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [ X] I have tested my changes locally
- [] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
