### PR TITLE
Support unsubscribed mailboxes

### DIFF
--- a/app/api/dev-jmap/[...path]/route.ts
+++ b/app/api/dev-jmap/[...path]/route.ts
@@ -37,6 +37,8 @@ interface MockMailbox {
   sortOrder: number;
   totalEmails: number;
   unreadEmails: number;
+  parentId?: string;
+  isSubscribed: boolean;
 }
 
 interface MockEmail {
@@ -64,12 +66,15 @@ function nextState(): string {
 }
 
 const mailboxes: MockMailbox[] = [
-  { id: 'mb-inbox', name: 'Inbox', role: 'inbox', sortOrder: 1, totalEmails: 5, unreadEmails: 2 },
-  { id: 'mb-drafts', name: 'Drafts', role: 'drafts', sortOrder: 2, totalEmails: 1, unreadEmails: 0 },
-  { id: 'mb-sent', name: 'Sent', role: 'sent', sortOrder: 3, totalEmails: 3, unreadEmails: 0 },
-  { id: 'mb-junk', name: 'Junk', role: 'junk', sortOrder: 4, totalEmails: 1, unreadEmails: 1 },
-  { id: 'mb-trash', name: 'Trash', role: 'trash', sortOrder: 5, totalEmails: 0, unreadEmails: 0 },
-  { id: 'mb-archive', name: 'Archive', role: 'archive', sortOrder: 6, totalEmails: 2, unreadEmails: 0 },
+  { id: 'mb-inbox', name: 'Inbox', role: 'inbox', sortOrder: 1, totalEmails: 5, unreadEmails: 2, isSubscribed: true },
+  { id: 'mb-drafts', name: 'Drafts', role: 'drafts', sortOrder: 2, totalEmails: 1, unreadEmails: 0, isSubscribed: true },
+  { id: 'mb-sent', name: 'Sent', role: 'sent', sortOrder: 3, totalEmails: 3, unreadEmails: 0, isSubscribed: true },
+  { id: 'mb-junk', name: 'Junk', role: 'junk', sortOrder: 4, totalEmails: 1, unreadEmails: 1, isSubscribed: true },
+  { id: 'mb-trash', name: 'Trash', role: 'trash', sortOrder: 5, totalEmails: 0, unreadEmails: 0, isSubscribed: true },
+  { id: 'mb-archive', name: 'Archive', role: 'archive', sortOrder: 6, totalEmails: 2, unreadEmails: 0, isSubscribed: true },
+  { id: 'mb-invoices', name: 'Invoices', role: null, sortOrder: 7, totalEmails: 8, unreadEmails: 0, isSubscribed: true },
+  { id: 'mb-invoices-2025', name: '2025', role: null, sortOrder: 8, totalEmails: 8, unreadEmails: 0, parentId: "mb-invoices", isSubscribed: false },
+  { id: 'mb-invoices-2026', name: '2026', role: null, sortOrder: 9, totalEmails: 8, unreadEmails: 0, parentId: "mb-invoices", isSubscribed: true },
 ];
 
 function recomputeMailboxCounts(): void {
@@ -1544,6 +1549,8 @@ function handleMailboxSet(args: MethodArgs, callId: string): MethodResult {
         sortOrder: mailboxes.length + 1,
         totalEmails: 0,
         unreadEmails: 0,
+        parentId: typeof data.parentId === 'string' ? (data.parentId as string) : undefined,
+        isSubscribed: data.isSubscribed !== false,
       });
       created[key] = { id: newId };
     }
@@ -1556,6 +1563,7 @@ function handleMailboxSet(args: MethodArgs, callId: string): MethodResult {
       if (mb) {
         if (changes.name !== undefined) mb.name = changes.name as string;
         if (changes.sortOrder !== undefined) mb.sortOrder = changes.sortOrder as number;
+        if (changes.isSubscribed !== undefined) mb.isSubscribed = changes.isSubscribed as boolean;
         updated[id] = null;
       }
     }

--- a/components/email/email-context-menu.tsx
+++ b/components/email/email-context-menu.tsx
@@ -172,7 +172,7 @@ export function EmailContextMenu({
   const filterTree = (nodes: MailboxNode[]): MailboxNode[] => {
     return nodes.reduce<MailboxNode[]>((acc, node) => {
       const filteredChildren = filterTree(node.children);
-      if (moveTargetIds.has(node.id) || filteredChildren.length > 0) {
+      if (node.isSubscribed && (moveTargetIds.has(node.id) || filteredChildren.length > 0)) {
         acc.push({ ...node, children: filteredChildren });
       }
       return acc;

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -37,7 +37,7 @@ import {
   MailOpen,
   MoreHorizontal,
 } from "lucide-react";
-import { cn, buildMailboxTree, MailboxNode } from "@/lib/utils";
+import { cn, buildMailboxTree, hasSubscribedChildren, MailboxNode } from "@/lib/utils";
 import { localizeMailboxName } from "@/lib/mailbox-label";
 import {
   buildKeywordTree,
@@ -495,7 +495,7 @@ function MailboxTreeItem({
 }) {
   const tNotifications = useTranslations('notifications');
   const tSidebar = useTranslations('sidebar');
-  const hasChildren = node.children.length > 0;
+  const hasChildren = node.isSubscribed && hasSubscribedChildren(node);
   const isExpanded = expandedFolders.has(node.id);
   const Icon = getIconForMailbox(node.role, node.name, hasChildren, isExpanded, node.isShared, node.id);
   const isVirtualNode = node.id.startsWith('shared-');
@@ -544,7 +544,7 @@ function MailboxTreeItem({
 
   return (
     <>
-      <SidebarRow
+      {node.isSubscribed && (<SidebarRow
         icon={<Icon className={getIconClass(isSelected, isVirtualNode, colorful, roleKey)} />}
         label={label}
         testRole={node.role}
@@ -573,7 +573,7 @@ function MailboxTreeItem({
         isValidDropTarget={isValidDropTarget}
         isInvalidDropTarget={isInvalidDropTarget}
         onContextMenu={onContextMenu && !isVirtualNode ? (e) => onContextMenu(e, node) : undefined}
-      />
+      />)}
 
       {hasChildren && isExpanded && !isCollapsed && node.children.map((child) => (
         <MailboxTreeItem

--- a/components/settings/folder-settings.tsx
+++ b/components/settings/folder-settings.tsx
@@ -14,6 +14,7 @@ import {
   Star, Heart, Bookmark, Tag, Flag, Briefcase, Users,
   Bell, Zap, Globe, Lock, Eye, MessageSquare, Mail,
   AlertTriangle, NotebookPen, CalendarClock, BellOff,
+  EyeOff,
   type LucideIcon,
 } from 'lucide-react';
 import { cn, buildMailboxTree, type MailboxNode } from '@/lib/utils';
@@ -154,7 +155,7 @@ function SortableFolderRow({ id, title, children }: { id: string; title: string;
 export function FolderSettings() {
   const t = useTranslations('settings.folders');
   const { client } = useAuthStore();
-  const { mailboxes, fetchMailboxes, createMailbox, renameMailbox, deleteMailbox, setMailboxRole, reorderMailboxes, moveMailbox } = useEmailStore();
+  const { mailboxes, fetchMailboxes, createMailbox, renameMailbox, deleteMailbox, setMailboxRole, setMailboxSubscription, reorderMailboxes, moveMailbox } = useEmailStore();
 
   const sensors = useSensors(
     // Small activation distance so clicking the row's buttons still works.
@@ -388,6 +389,19 @@ export function FolderSettings() {
     setEditingName(mb.name);
   };
 
+  const handleFolderSubscription = async (mailboxId: string, subscribe: boolean) => {
+    if (!client) return;
+    setIsLoading(true);
+    try {
+      await setMailboxSubscription(client, mailboxId, subscribe);
+    } catch (error) {
+      console.error('Failed to update folder subscription:', error);
+      toast.error('Failed to update folder subscription');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const cancelEdit = () => {
     setEditingId(null);
     setEditingName('');
@@ -577,7 +591,7 @@ export function FolderSettings() {
                 />
               )}
             </div>
-            <span className="text-sm text-foreground truncate">{mb.name}</span>
+            <span className={cn("text-sm truncate", mb.isSubscribed ? "text-foreground" : "line-through text-muted-foreground")}>{mb.name}</span>
             {mb.role && (
               <span className="text-xs px-1.5 py-0.5 rounded-full bg-primary/10 text-primary font-medium flex-shrink-0">
                 {t(`role_${mb.role}`)}
@@ -590,6 +604,15 @@ export function FolderSettings() {
             )}
           </div>
           <div className="flex items-center gap-0.5">
+            {mb.role == null &&
+              <button
+                onClick={() => handleFolderSubscription(mb.id, !mb.isSubscribed)}
+                className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors"
+                title={mb.isSubscribed ? t('unsubscribe_mailbox') : t('subscribe_mailbox')}
+              >
+                  {mb.isSubscribed ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
+              </button>
+            }
             {mb.myRights?.mayCreateChild && (
               <button
                 onClick={() => startCreateSubfolder(mb.id)}

--- a/lib/demo/demo-client.ts
+++ b/lib/demo/demo-client.ts
@@ -139,7 +139,7 @@ export class DemoJMAPClient implements IJMAPClient {
     return mb;
   }
 
-  async updateMailbox(mailboxId: string, changes: { name?: string; parentId?: string | null; role?: string | null; sortOrder?: number }, _accountId?: string): Promise<void> {
+  async updateMailbox(mailboxId: string, changes: { name?: string; parentId?: string | null; role?: string | null; sortOrder?: number; isSubscribed?: boolean }, _accountId?: string): Promise<void> {
     const mb = this.data.mailboxes.find(m => m.id === mailboxId);
     if (mb) Object.assign(mb, changes);
   }

--- a/lib/jmap/client-interface.ts
+++ b/lib/jmap/client-interface.ts
@@ -104,7 +104,7 @@ export interface IJMAPClient {
   getMailboxes(accountId?: string): Promise<Mailbox[]>;
   getAllMailboxes(): Promise<Mailbox[]>;
   createMailbox(name: string, parentId?: string, accountId?: string): Promise<Mailbox>;
-  updateMailbox(mailboxId: string, changes: { name?: string; parentId?: string | null; role?: string | null; sortOrder?: number }, accountId?: string): Promise<void>;
+  updateMailbox(mailboxId: string, changes: { name?: string; parentId?: string | null; role?: string | null; sortOrder?: number; isSubscribed?: boolean }, accountId?: string): Promise<void>;
   deleteMailbox(mailboxId: string, accountId?: string): Promise<void>;
 
   // ── Emails ────────────────────────────────────────────────────

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -2344,7 +2344,7 @@ export class JMAPClient implements IJMAPClient {
     };
   }
 
-  async updateMailbox(mailboxId: string, changes: { name?: string; parentId?: string | null; role?: string | null; sortOrder?: number }, accountId?: string): Promise<void> {
+  async updateMailbox(mailboxId: string, changes: { name?: string; parentId?: string | null; role?: string | null; sortOrder?: number; isSubscribed?: boolean }, accountId?: string): Promise<void> {
     const targetAccountId = accountId || this.accountId;
     const response = await this.request([
       ["Mailbox/set", {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -593,3 +593,7 @@ export function getMailboxPath(
   }
   return names.join(separator);
 }
+
+export function hasSubscribedChildren(node: MailboxNode): boolean {
+  return node.children.some(n => n.isSubscribed || hasSubscribedChildren(n))
+}

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -1714,7 +1714,9 @@
       "error_delete": "Ordner konnte nicht gelöscht werden",
       "error_delete_has_children": "Ordner kann nicht gelöscht werden: Er enthält noch Unterordner. Löschen oder verschieben Sie diese zuerst.",
       "error_delete_has_email": "Ordner kann nicht gelöscht werden: Er enthält noch E-Mails. Verschieben oder löschen Sie diese zuerst.",
-      "error_role": "Ordnerrolle konnte nicht aktualisiert werden"
+      "error_role": "Ordnerrolle konnte nicht aktualisiert werden",
+      "subscribe_mailbox": "Ordner abonnieren",
+      "unsubscribe_mailbox": "Ordner abbestellen"
     },
     "advanced": {
       "title": "Erweitert",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1737,7 +1737,9 @@
       "error_delete": "Failed to delete folder",
       "error_delete_has_children": "Cannot delete folder: it still contains subfolders. Delete or move them first.",
       "error_delete_has_email": "Cannot delete folder: it still contains emails. Move or delete them first.",
-      "error_role": "Failed to update folder role"
+      "error_role": "Failed to update folder role",
+      "subscribe_mailbox": "Subscribe to folder",
+      "unsubscribe_mailbox": "Unsubscribe from folder"
     },
     "advanced": {
       "title": "Advanced",

--- a/stores/email-store.ts
+++ b/stores/email-store.ts
@@ -261,6 +261,7 @@ interface EmailStore {
   renameMailbox: (client: IJMAPClient, mailboxId: string, name: string) => Promise<void>;
   deleteMailbox: (client: IJMAPClient, mailboxId: string) => Promise<void>;
   setMailboxRole: (client: IJMAPClient, mailboxId: string, role: string | null) => Promise<void>;
+  setMailboxSubscription: (client: IJMAPClient, mailboxId: string, subscribed: boolean) => Promise<void>;
   reorderMailboxes: (client: IJMAPClient, orderedIds: string[]) => Promise<void>;
   moveMailbox: (client: IJMAPClient, mailboxId: string, newParentId: string | null, orderedSiblingIds?: string[]) => Promise<void>;
   emptyMailbox: (client: IJMAPClient, mailboxId: string) => Promise<void>;
@@ -3762,6 +3763,21 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
       }
     } catch (error) {
       set({ error: error instanceof Error ? error.message : 'Failed to update folder role' });
+      throw error;
+    }
+  },
+
+  setMailboxSubscription: async (client, mailboxId, subscribed) => {
+    try {
+      const effectiveClient = resolveActionClient(client);
+      await effectiveClient.updateMailbox(mailboxId, { isSubscribed: subscribed });
+      if (get().viewingAccountId) {
+        await refreshMailboxesForViewingAccount(client);
+      } else {
+        await get().fetchMailboxes(client);
+      }
+    } catch (error) {
+      set({ error: error instanceof Error ? error.message : 'Failed to change mailbox subscription' });
       throw error;
     }
   },


### PR DESCRIPTION
## Summary

Hide unsubscribed mailboxes in folder list and move target to improve usability for accounts with many unsubscribed mailboxes. Add mechanism to subscribe and unsubscribe from mailboxes in folder settings.

## Changes

- Hide unsubscribed mailboxes from folder sidebar by default
- Filter unsubscribed mailboxes from "Move to" destinations
- Add icon to folder settings to subscribe and unsubscribe from folders
- Implement/fix handling of folder hierarchies and isSubscribed handling in mock JMAP server

## Related issues

n/a

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] (n/a) I have added or updated documentation if needed
- [ ] (partially, only for English and German) I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<img width="768" height="597" alt="Screenshot From 2026-08-13 21-50-07" src="https://github.com/user-attachments/assets/7ce3880b-2dd0-46d6-a7af-f274575f39fd" />
<img width="1251" height="1378" alt="Screenshot From 2026-08-13 21-54-19" src="https://github.com/user-attachments/assets/b167839b-ee86-4488-a09b-41a3211d320d" />
<img width="426" height="368" alt="Screenshot From 2026-08-13 21-49-45" src="https://github.com/user-attachments/assets/37c7b740-b88a-4703-ba72-fa76c65d4735" />

## Notes for reviewers

This is my first shot and the minimal viable solution I could think of to tackle my folder subscription problem. I like Bulwark very much - keep up the great work! However, my 20+ years old account has so many unsubscribed folder which I don't want to delete. Having all those folders displayed made Bulwark practically unusable for me as I could find anything and would have to scroll through huge lists when moving emails.

Please let me know what you think - I'm open for feedback. Especially using strikethrough text for unsubscribed mailboxes in the folders settings view is not perfect. I played with graying out unsubscribed folders, but this was hardly readable.

There are some corner cases that one might want to improve upon later: e.g. if you unsubscribe from a folder which still has subscribed children. Right now, everything starting from the unsubscribed parent folder will be filtered out in the folder sidebar (and move target list). One could consider displaying those parent folders in a disable state, just to anchor the subscribed child nodes. This would complicate things quite a bit - unsure whether that would be worth the added complexity.

At this point only English and German translations are present.