### PR TITLE
feat(plugin): add isActive property to AccountResponse in plugin API

### DIFF
--- a/lib/plugin-sandbox/host-api.ts
+++ b/lib/plugin-sandbox/host-api.ts
@@ -228,11 +228,14 @@ interface AccountResponse {
   avatarColor: string;
   isConnected: boolean;
   isDefault: boolean;
+  isActive: boolean;
 }
 function doUserGetAccounts(): AccountResponse[] {
   const state = useAccountStore.getState();
+  const activeAccountId = state.activeAccountId;
 
   // we remove sensitive fields from the account entries before returning to the plugin
+  // we add a new field isActive to indicate which account is currently active
   const accounts = state.accounts.map((account) => ({
     id: account.id,
     label: account.label,
@@ -243,6 +246,7 @@ function doUserGetAccounts(): AccountResponse[] {
     avatarColor: account.avatarColor,
     isConnected: account.isConnected,
     isDefault: account.isDefault,
+    isActive: account.id === activeAccountId,
   }));
 
   return accounts;


### PR DESCRIPTION
## Summary

We add isActive property to AccountResponse in plugin API. It enables plugins to know which account is currently selected.

## Changes

- we just add the property isActive on AccountResponse

## Related issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
