### PR TITLE
feat: allow privileged plugin to fetch only a range of blob

### DIFF
--- a/lib/jmap/client-interface.ts
+++ b/lib/jmap/client-interface.ts
@@ -273,7 +273,7 @@ export interface IJMAPClient {
   getBlobDownloadUrl(blobId: string, name?: string, type?: string, accountId?: string): string;
   fetchBlob(blobId: string, name?: string, type?: string, accountId?: string): Promise<Blob>;
   fetchBlobAsObjectUrl(blobId: string, name?: string, type?: string, accountId?: string): Promise<string>;
-  fetchBlobArrayBuffer(blobId: string, name?: string, type?: string, accountId?: string): Promise<ArrayBuffer>;
+  fetchBlobArrayBuffer(blobId: string, name?: string, type?: string, accountId?: string, rangeHeader?: number): Promise<ArrayBuffer>;
   downloadBlob(blobId: string, name?: string, type?: string, accountId?: string): Promise<void>;
 
   // ── Identities ────────────────────────────────────────────────

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -6751,13 +6751,58 @@ export class JMAPClient implements IJMAPClient {
   // ── S/MIME raw-email helpers ─────────────────────────────────────
 
   /** Fetch blob content as an ArrayBuffer (for S/MIME byte processing). */
-  async fetchBlobArrayBuffer(blobId: string, name?: string, type?: string, accountId?: string): Promise<ArrayBuffer> {
+  async fetchBlobArrayBuffer(blobId: string, name?: string, type?: string, accountId?: string, rangeHeader?: number): Promise<ArrayBuffer> {
     const url = this.getBlobDownloadUrl(blobId, name, type, accountId);
-    const response = await this.authenticatedFetch(url, {}, { timeoutMs: JMAPClient.TRANSFER_TIMEOUT_MS });
+    const response = await this.authenticatedFetch(url, { }, { timeoutMs: JMAPClient.TRANSFER_TIMEOUT_MS });
     if (!response.ok) {
       throw new Error(`Failed to fetch blob: ${response.status}`);
     }
-    return response.arrayBuffer();
+
+    const maxBytes = rangeHeader;
+
+    // If no Range header requested or stream is missing, fallback to standard arrayBuffer()
+    if (!maxBytes || !response.body) {
+      return response.arrayBuffer();
+    }
+    // used to download only the first N bytes of a blob, e.g. for S/MIME /PGP encryption verification
+    // Currently, Stalwart server does not support Range requests for the download endpoint, 
+    // so we have to read the stream and cancel it after reading the first N bytes.
+    // Stream reading with early termination via reader.cancel()
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let bytesRead = 0;
+
+    try {
+      while (bytesRead < maxBytes) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        chunks.push(value);
+        bytesRead += value.length;
+      }
+    } finally {
+      // Cancel the response body stream to close the network connection early
+      await reader.cancel().catch(() => {});
+    }
+
+    // Slice exact requested length and copy chunks into a contiguous ArrayBuffer
+    const totalLength = Math.min(bytesRead, maxBytes);
+    const result = new Uint8Array(totalLength);
+    let offset = 0;
+
+    // Iterate over each chunk of binary data (Uint8Array) collected during the stream
+    for (const chunk of chunks) {
+      // Determine how many bytes to copy from the current chunk without exceeding totalLength
+      const bytesToCopy = Math.min(chunk.length, totalLength - offset);
+      // Copy the needed slice from the chunk into the target array starting at the current offset
+      result.set(chunk.subarray(0, bytesToCopy), offset);
+      // Move the offset forward by the number of bytes just written
+      offset += bytesToCopy;
+      // Stop processing further chunks if the target size limit has been reached
+      if (offset >= totalLength) break;
+    }
+
+    return result.buffer;
   }
 
   /**

--- a/lib/plugin-sandbox/host-api.ts
+++ b/lib/plugin-sandbox/host-api.ts
@@ -421,11 +421,11 @@ async function doHttpFetch(plugin: InstalledPlugin, rawUrl: string, init?: Plugi
  * exposes the byte-fetch primitive. Returns a Uint8Array (structured-cloneable
  * across the postMessage boundary).
  */
-async function doJmapFetchBlob(blobId: string, opts?: { name?: string; type?: string }): Promise<Uint8Array> {
+async function doJmapFetchBlob(blobId: string, opts?: { name?: string; type?: string, rangeHeader?: number }): Promise<Uint8Array> {
   if (typeof blobId !== 'string' || !blobId) throw new Error('jmap.fetchBlob: blobId required');
   const { client } = useAuthStore.getState();
   if (!client) throw new Error('jmap.fetchBlob: no active session');
-  const buf = await client.fetchBlobArrayBuffer(blobId, opts?.name, opts?.type);
+  const buf = await client.fetchBlobArrayBuffer(blobId, opts?.name, opts?.type, undefined, opts?.rangeHeader);
   return new Uint8Array(buf);
 }
 
@@ -1159,7 +1159,7 @@ export async function dispatchApiCall(
     case 'http.post':  return doHttpPost(plugin, args[0] as string, args[1], args[2] as PluginHttpPostOptions | undefined);
     case 'http.fetch': return doHttpFetch(plugin, args[0] as string, args[1] as PluginFetchInit | undefined);
 
-    case 'jmap.fetchBlob': return doJmapFetchBlob(args[0] as string, args[1] as { name?: string; type?: string } | undefined);
+    case 'jmap.fetchBlob': return doJmapFetchBlob(args[0] as string, args[1] as { name?: string; type?: string, rangeHeader?: number } | undefined);
     case 'jmap.uploadBlob': return doJmapUploadBlob(args[0] as Uint8Array, args[1] as string, args[2] as string);
     case 'jmap.sendRaw':   return doJmapSendRaw(
       args[0] as ArrayBuffer | ArrayBufferView,

--- a/lib/plugin-sandbox/runtime.tsx
+++ b/lib/plugin-sandbox/runtime.tsx
@@ -253,7 +253,7 @@ function buildPluginApi(manifest: PluginManifest) {
       removeKeyword: (emailId: string, keyword: string, accountId?: string) =>
         callApi('jmap.removeKeyword', [emailId, keyword, accountId]) as Promise<void>,
       /** Fetch a blob's raw bytes by id. Resolves to a Uint8Array. */
-      fetchBlob: (blobId: string, opts?: { name?: string; type?: string }) =>
+      fetchBlob: (blobId: string, opts?: { name?: string; type?: string, rangeHeader?: number }) =>
         callApi('jmap.fetchBlob', [blobId, opts]) as Promise<Uint8Array>,
       uploadBlob: (content: Uint8Array, name: string, type: string) =>
         callApi('jmap.uploadBlob', [content, name, type]) as Promise<{ blobId: string; size: number; type: string; }>,


### PR DESCRIPTION
## Motivation
Encryption plugins want to know if the mail is encrypted by the sender (true end-to-end) or by the encryptionAtRest feature of stalwart server. Unfortunately, this information is not exposed through header nor in the body of email. It is between the 2. See example :
```
Delivered-To: me@example.org
X-Spam-Status: No
DKIM-Signature: ....
From: "sender@example.org" <sender@example.org>
To: me <me@example.org>
Subject: Cool subject
Date: Sat, 15 Aug 2026 06:44:46 +0000
Message-ID: <4e5dd21e-846e-4c4b-a666-96ea0d62aa0@example.org>
MIME-Version: 1.0
Content-Type: multipart/encrypted;
	protocol="application/pgp-encrypted";
	boundary="18cbe790f4a77b86_d5e8a4aa3dcdd0f3_3375fe004e1cf24a"

OpenPGP/MIME message (Automatically encrypted by Stalwart)

--18cbe790f4a77b86_d5e8a4aa3dcdd0f3_3375fe004e1cf24a
Content-Type: application/pgp-encrypted
```
So, plugin can just download the mail Blob. But, if email has heavy attachments, we have to download the entire attachment, just to check for the `Automatically encrypted by Stalwart` line. So, we can just download the first N bytes. Stalwart server doesn't support Range header, for the blob download endpoint, so we must edit the client.
## Changes

<!-- A bulleted list of the key changes made. -->

- add a new parameter in plugin API : rangeHeader with the number of bytes we want
- edited the fetchBlobArrayBuffer method to get the number of bytes. We didin't touch to undelrying private methods. The new logic is only in fetchBlobArrayBuffer.

## Related issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

If you see other way to achieve this, don't hesitate to tell me :)
