### PR TITLE
fix(jmap): remove keywords with null rather than false in Email/set

### DIFF
--- a/lib/__tests__/jmap-keyword-account.test.ts
+++ b/lib/__tests__/jmap-keyword-account.test.ts
@@ -38,6 +38,11 @@ function mockEmailSet() {
   return { captured, fetchSpy };
 }
 
+function patchFor(call: JMAPMethodCall, emailId: string): Record<string, unknown> {
+  const update = call[1].update as Record<string, Record<string, unknown>>;
+  return update[emailId];
+}
+
 describe('JMAP keyword writes route to the email account (#281)', () => {
   beforeEach(() => vi.restoreAllMocks());
   afterEach(() => vi.restoreAllMocks());
@@ -70,5 +75,62 @@ describe('JMAP keyword writes route to the email account (#281)', () => {
     const { captured } = mockEmailSet();
     await client.setKeyword('email-x', '$answered');
     expect(captured[0][1].accountId).toBe('primary-account');
+  });
+});
+
+describe('Email/set clears keywords with null, not false', () => {
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('markAsRead(false) removes $seen with null', async () => {
+    const client = createClient();
+    const { captured } = mockEmailSet();
+    await client.markAsRead('email-x', false);
+    const patch = patchFor(captured[0], 'email-x');
+    expect(patch['keywords/$seen']).toBeNull();
+    expect(patch['keywords/$seen']).not.toBe(false);
+  });
+
+  it('markAsRead(true) sets $seen to true', async () => {
+    const client = createClient();
+    const { captured } = mockEmailSet();
+    await client.markAsRead('email-x', true);
+    expect(patchFor(captured[0], 'email-x')['keywords/$seen']).toBe(true);
+  });
+
+  it('batchMarkAsRead(false) removes $seen with null for every id', async () => {
+    const client = createClient();
+    const { captured } = mockEmailSet();
+    await client.batchMarkAsRead(['email-a', 'email-b'], false);
+    for (const id of ['email-a', 'email-b']) {
+      const patch = patchFor(captured[0], id);
+      expect(patch['keywords/$seen']).toBeNull();
+      expect(patch['keywords/$seen']).not.toBe(false);
+    }
+  });
+
+  it('batchMarkAsRead(true) sets $seen to true for every id', async () => {
+    const client = createClient();
+    const { captured } = mockEmailSet();
+    await client.batchMarkAsRead(['email-a', 'email-b'], true);
+    for (const id of ['email-a', 'email-b']) {
+      expect(patchFor(captured[0], id)['keywords/$seen']).toBe(true);
+    }
+  });
+
+  it('toggleStar(false) removes $flagged with null', async () => {
+    const client = createClient();
+    const { captured } = mockEmailSet();
+    await client.toggleStar('email-x', false);
+    const patch = patchFor(captured[0], 'email-x');
+    expect(patch['keywords/$flagged']).toBeNull();
+    expect(patch['keywords/$flagged']).not.toBe(false);
+  });
+
+  it('toggleStar(true) sets $flagged to true', async () => {
+    const client = createClient();
+    const { captured } = mockEmailSet();
+    await client.toggleStar('email-x', true);
+    expect(patchFor(captured[0], 'email-x')['keywords/$flagged']).toBe(true);
   });
 });

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -1705,7 +1705,7 @@ export class JMAPClient implements IJMAPClient {
         accountId: targetAccountId,
         update: {
           [emailId]: {
-            "keywords/$seen": read,
+            "keywords/$seen": read ? true : null,
           },
         },
       }, "0"],
@@ -1716,7 +1716,7 @@ export class JMAPClient implements IJMAPClient {
     if (emailIds.length === 0) return;
 
     for (const batch of batched(emailIds, this.getMaxObjectsInSet())) {
-      const updates = Object.fromEntries(batch.map(id => [id, { "keywords/$seen": read }]));
+      const updates = Object.fromEntries(batch.map(id => [id, { "keywords/$seen": read ? true : null }]));
       await this.request([
         ["Email/set", { accountId: accountId || this.accountId, update: updates }, "0"],
       ]);
@@ -1729,7 +1729,7 @@ export class JMAPClient implements IJMAPClient {
         accountId: accountId || this.accountId,
         update: {
           [emailId]: {
-            "keywords/$flagged": starred,
+            "keywords/$flagged": starred ? true : null,
           },
         },
       }, "0"],


### PR DESCRIPTION
## Summary

`markAsRead()`, `batchMarkAsRead()` and `toggleStar()` clear a keyword by sending `{"keywords/$seen": false}` or `{"keywords/$flagged": false}` in `Email/set`. RFC 8620 section 5.3 says a PatchObject removes a property by setting it to `null`, and RFC 8621 section 4.1.1 defines the `keywords` map as holding `true` for every key, so `false` is not a valid way to clear one. A server that validates this rejects the whole update with `invalidProperties`. The client never inspects `notUpdated`, so marking a message unread or removing a star looks like it worked, the sidebar counts move optimistically, and the next refresh restores the old state from the server. Stalwart accepts both the `false` and the `null` form, so this is a no-op there and the bug only shows up against stricter servers.

## Changes

- `lib/jmap/client.ts` `markAsRead()`: patch `keywords/$seen` with `read ? true : null`
- `lib/jmap/client.ts` `batchMarkAsRead()`: same fix in the batched path.
- `lib/jmap/client.ts` `toggleStar()`: patch `keywords/$flagged` with `starred ? true : null`. Un-starring had the identical defect.

No other call sites needed changing. `removeKeyword()` already patches with `null`, and the callers of `updateEmailKeywords()` remove entries with `delete` rather than setting `false`. The integration test helpers in `integration/tests/helpers/jmap.ts` also already use the `true`/`null` form, so the client was the only place doing this.

## Related issues

None.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed (not applicable)
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text (no user-facing strings)
- [ ] I have included screenshots or a screen recording for UI changes (no UI change)

## Notes for reviewers

Verified live against two JMAP servers.

Against a server that enforces RFC 8621 keyword values:

    {"keywords/$seen": false}  ->  notUpdated {"type": "invalidProperties",
                                               "properties": ["keywords/$seen"]}
                                   message still carries $seen, unread count unchanged
    {"keywords/$seen": null}   ->  updated, keyword cleared, unread count moves to 1

Against Stalwart v0.16, both forms return `updated` and clear the keyword, so existing deployments see no behavioural change from this PR.

End to end through the UI after the fix, the request and response are:

    Email/set update = {"M700754ae865...": {"keywords/$seen": null}}
    updated = ["M700754ae865..."]  notUpdated = {}

Test suite on this branch is 2760 of 2761 passing. The single failure is `mn should have all keys from en` in `lib/__tests__/translations.test.ts`, which reproduces on a clean checkout of `main` with no changes applied, so it is pre-existing and unrelated.

Possible follow-up, deliberately not in this PR to keep it minimal: these `Email/set` calls discard the `notUpdated` map, which is why a rejected keyword update failed silently instead of surfacing an error. Handling that is a separate change.