### PR TITLE
fix(reply): honour an external Reply-To even on a self-sent message

### DIFF
--- a/lib/__tests__/reply-recipients.test.ts
+++ b/lib/__tests__/reply-recipients.test.ts
@@ -81,6 +81,29 @@ describe('buildReplyRecipients', () => {
       expect(emails(to)).toEqual(['bob@other.com']);
     });
 
+    it('honours an EXTERNAL Reply-To even on a self-sent message (#776)', () => {
+      // Contact-form / helpdesk pattern: the mail arrives From our own address
+      // (so it looks self-sent) but Reply-To carries the real correspondent.
+      // The reply must reach them, not loop back to our own To.
+      const { to } = buildReplyRecipients(
+        { ...sent, to: [{ email: 'me@example.com' }], replyToAddresses: [{ email: 'customer@external.com' }] },
+        'reply',
+        OWN,
+      );
+      expect(emails(to)).toEqual(['customer@external.com']);
+    });
+
+    it('reply-all with an external Reply-To routes To to the Reply-To (#776)', () => {
+      const { to } = buildReplyRecipients(
+        { ...sent, replyToAddresses: [{ email: 'customer@external.com' }] },
+        'replyAll',
+        OWN,
+      );
+      // Reply-To leads; the other original recipients (bob) are still included,
+      // our own address dropped.
+      expect(emails(to)).toEqual(['customer@external.com', 'bob@other.com']);
+    });
+
     it('keeps a self-addressed recipient we chose ourselves', () => {
       const { to } = buildReplyRecipients(
         { ...sent, to: [{ email: 'info@example.com' }] },

--- a/lib/reply-recipients.ts
+++ b/lib/reply-recipients.ts
@@ -80,7 +80,10 @@ export function buildReplyRecipients(
 
   const withEmail = (list: ReplyAddress[] | undefined) => (list ?? []).filter((r) => Boolean(r.email));
 
-  if (isSelfSent(source, ownEmails)) {
+  const replyToList = withEmail(source.replyToAddresses);
+  const externalReplyTo = replyToList.filter((r) => !isOwnAddress(r.email, ownEmails));
+
+  if (!externalReplyTo.length && isSelfSent(source, ownEmails)) {
     const originalTo = withEmail(source.to);
     if (originalTo.length > 0) {
       return {
@@ -90,8 +93,8 @@ export function buildReplyRecipients(
     }
   }
 
-  const replyTarget = withEmail(source.replyToAddresses).length
-    ? withEmail(source.replyToAddresses)
+  const replyTarget = replyToList.length
+    ? replyToList
     : (source.from?.[0]?.email ? [source.from[0]] : []);
 
   if (mode === 'reply') {


### PR DESCRIPTION
## Summary

Since 1.8.1, replying to a message whose Reply-To points at an external address filled the To with the user's OWN address instead of the Reply-To, so every reply had to be corrected by hand. The self-sent handling added for #703 (reply to your own thread message → address the original recipients, ignore Reply-To) was entered whenever the From matched one of the user's identities — which also happens for the very common contact-form / helpdesk / "notify me" mail that arrives From your own address with the real correspondent in Reply-To. This change makes an explicit external Reply-To win even for self-sent messages, while preserving the #703 behaviour when the Reply-To is only the user's own address.

## Changes

- `lib/reply-recipients.ts`: only take the self-sent "original recipients" branch when there is no EXTERNAL Reply-To. A Reply-To resolving to a non-own address is treated as an explicit RFC 5322 directive and used as the reply target; a Reply-To that is only the user's own address stays ignored for self-sent messages (so replying to your own thread message still leaves the mailbox).
- `lib/__tests__/reply-recipients.test.ts`: +2 cases covering an external Reply-To on a self-sent message for reply and reply-all.

## Related issues

Closes #776

## Type of change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
