### PR TITLE
fix(calendar): edit a single recurring occurrence via a one-shot over…

### DIFF
--- a/components/calendar/calendar-app.tsx
+++ b/components/calendar/calendar-app.tsx
@@ -51,6 +51,7 @@ import { useIsEmbedded } from "@/hooks/use-is-embedded";
 import { useProMultiAccountCalendars } from "@/hooks/use-pro-multi-account-calendars";
 import { ResizeHandle } from "@/components/layout/resize-handle";
 import { sanitizeOutgoingCalendarEventData } from "@/lib/calendar-event-normalization";
+import { buildRecurrenceOverridePatch } from "@/lib/recurrence-overrides";
 import { getEventStartDate } from "@/lib/calendar-utils";
 import { useTaskStore } from "@/stores/task-store";
 import { useContactStore } from "@/stores/contact-store";
@@ -826,12 +827,8 @@ export function CalendarApp({ linkSegments }: CalendarAppProps = {}) {
             // Patch the master event's recurrenceOverrides instead.
             const master = await findMasterEvent(event);
             if (master && event.recurrenceId) {
-              const patchUpdates: Record<string, unknown> = {};
-              for (const [key, value] of Object.entries(updates)) {
-                if (['id', 'uid', '@type', 'calendarIds', 'recurrenceRules', 'recurrenceOverrides', 'excludedRecurrenceRules'].includes(key)) continue;
-                patchUpdates[`recurrenceOverrides/${event.recurrenceId}/${key}`] = value;
-              }
-              await updateEvent(client, master.id, patchUpdates as Partial<CalendarEvent>, sendScheduling);
+              const patchUpdates = buildRecurrenceOverridePatch(updates, event.recurrenceId);
+              await updateEvent(client, master.id, patchUpdates, sendScheduling);
             } else {
               await updateEvent(client, event.id, updates, sendScheduling);
             }

--- a/lib/__tests__/recurrence-overrides.test.ts
+++ b/lib/__tests__/recurrence-overrides.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { buildRecurrenceOverridePatch } from '@/lib/recurrence-overrides';
+import type { CalendarEvent } from '@/lib/jmap/types';
+
+const RID = '2026-08-15T10:00:00';
+
+describe('buildRecurrenceOverridePatch (#774 "This event only")', () => {
+  it('sets the whole override at a single pointer, not nested per-field pointers', () => {
+    const patch = buildRecurrenceOverridePatch(
+      { title: 'Moved standup', start: '2026-08-15T11:00:00' } as Partial<CalendarEvent>,
+      RID,
+    );
+    // Exactly one top-level pointer, at the override object itself.
+    expect(Object.keys(patch)).toEqual([`recurrenceOverrides/${RID}`]);
+    // No nested `recurrenceOverrides/<id>/<field>` pointers (the shape Stalwart
+    // rejected because it can't create the missing override object).
+    expect(Object.keys(patch).some((k) => k.startsWith(`recurrenceOverrides/${RID}/`))).toBe(false);
+  });
+
+  it('carries the per-occurrence fields into the override object', () => {
+    const patch = buildRecurrenceOverridePatch(
+      {
+        title: 'Moved standup',
+        start: '2026-08-15T11:00:00',
+        duration: 'PT30M',
+        description: 'one-off',
+      } as Partial<CalendarEvent>,
+      RID,
+    );
+    expect(patch[`recurrenceOverrides/${RID}` as keyof typeof patch]).toEqual({
+      title: 'Moved standup',
+      start: '2026-08-15T11:00:00',
+      duration: 'PT30M',
+      description: 'one-off',
+    });
+  });
+
+  it('drops identity and series-level keys that must not vary per occurrence', () => {
+    const patch = buildRecurrenceOverridePatch(
+      {
+        id: 'evt1',
+        uid: 'uid-1',
+        '@type': 'Event',
+        calendarIds: { cal1: true },
+        recurrenceRules: [{ '@type': 'RecurrenceRule', frequency: 'daily' }],
+        recurrenceOverrides: {},
+        excludedRecurrenceRules: [],
+        title: 'Only this',
+      } as unknown as Partial<CalendarEvent>,
+      RID,
+    );
+    expect(patch[`recurrenceOverrides/${RID}` as keyof typeof patch]).toEqual({ title: 'Only this' });
+  });
+
+  it('produces an empty override object when nothing overridable is supplied', () => {
+    const patch = buildRecurrenceOverridePatch({ id: 'evt1', uid: 'uid-1' } as unknown as Partial<CalendarEvent>, RID);
+    expect(patch[`recurrenceOverrides/${RID}` as keyof typeof patch]).toEqual({});
+  });
+});

--- a/lib/recurrence-overrides.ts
+++ b/lib/recurrence-overrides.ts
@@ -1,0 +1,32 @@
+import type { CalendarEvent } from '@/lib/jmap/types';
+
+/** Identity / whole-series keys that must never go into a single-occurrence override. */
+export const RECURRENCE_OVERRIDE_IMMUTABLE_KEYS = [
+  'id',
+  'uid',
+  '@type',
+  'calendarIds',
+  'recurrenceRules',
+  'recurrenceOverrides',
+  'excludedRecurrenceRules',
+] as const;
+
+/**
+ * Build the "This event only" override patch for a recurring master.
+ *
+ * Why one pointer: a JMAP nested pointer can't create a missing intermediate,
+ * so the override object has to be set whole at `recurrenceOverrides/<id>`, not
+ * field-by-field (#774).
+ */
+export function buildRecurrenceOverridePatch(
+  updates: Partial<CalendarEvent>,
+  recurrenceId: string,
+): Partial<CalendarEvent> {
+  const immutable = new Set<string>(RECURRENCE_OVERRIDE_IMMUTABLE_KEYS);
+  const override: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(updates)) {
+    if (immutable.has(key)) continue;
+    override[key] = value;
+  }
+  return { [`recurrenceOverrides/${recurrenceId}`]: override } as Partial<CalendarEvent>;
+}


### PR DESCRIPTION
## Summary

Selecting a recurring event, editing it and choosing "This event only" failed and showed two error toasts; the change was never saved. The edit path built one nested JMAP PatchObject pointer per field (`recurrenceOverrides/<recurrenceId>/<field>`), but on the first edit of an occurrence there is no override object at `recurrenceOverrides/<recurrenceId>` yet and JMAP (RFC 8620 §5.3) pointers cannot create a missing intermediate object, so Stalwart returned the event in `notUpdated` and the client threw. This change sets the whole override at a single pointer instead — mirroring the already-working "delete this occurrence" path — so the edit succeeds.

## Changes

- `lib/recurrence-overrides.ts` (new): `buildRecurrenceOverridePatch(updates, recurrenceId)` — a pure helper that builds the override as a single pointer `recurrenceOverrides/<recurrenceId>` whose value is the occurrence's field set, dropping identity/series keys (`id`, `uid`, `@type`, `calendarIds`, `recurrenceRules`, `recurrenceOverrides`, `excludedRecurrenceRules`).
- `components/calendar/calendar-app.tsx`: the "This event only" edit branch now uses `buildRecurrenceOverridePatch` instead of nested per-field pointers.
- `lib/__tests__/recurrence-overrides.test.ts` (new): 4 cases — single-pointer shape (no nested pointers), per-occurrence fields carried through, identity/series keys dropped, empty-override edge case.

## Related issues

Closes #774

## Type of change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
