### PR TITLE
fix(calendar): hide tasks-only calendars from the event calendar UI

### DIFF
--- a/components/calendar/calendar-sidebar-panel.tsx
+++ b/components/calendar/calendar-sidebar-panel.tsx
@@ -132,9 +132,13 @@ export function CalendarSidebarPanel({
   const localAccounts = useAccountStore((s) => s.accounts);
   const activeLocalAccountId = useAccountStore((s) => s.activeAccountId);
 
-  const personalCalendars = useMemo(() => calendars.filter(c => !c.isShared), [calendars]);
+  // Tasks-only calendars (VTODO, no events) are kept in the store for the tasks
+  // view but hidden from the event calendar list here.
+  const eventCalendars = useMemo(() => calendars.filter(c => !c.isTasksOnly), [calendars]);
+
+  const personalCalendars = useMemo(() => eventCalendars.filter(c => !c.isShared), [eventCalendars]);
   const sharedAccountGroups = useMemo(() => {
-    const shared = calendars.filter(c => c.isShared);
+    const shared = eventCalendars.filter(c => c.isShared);
     const groups = new Map<string, { accountName: string; calendars: Calendar[] }>();
     for (const cal of shared) {
       const key = cal.accountId || cal.accountName || cal.id;
@@ -144,7 +148,7 @@ export function CalendarSidebarPanel({
       groups.get(key)!.calendars.push(cal);
     }
     return Array.from(groups.values());
-  }, [calendars]);
+  }, [eventCalendars]);
 
   /**
    * Pro / multi-account grouping: every calendar bucketed by its owning
@@ -156,7 +160,7 @@ export function CalendarSidebarPanel({
   const localAccountGroups = useMemo(() => {
     if (!multiAccountMode) return [];
     const byAccount = new Map<string, Calendar[]>();
-    for (const cal of calendars) {
+    for (const cal of eventCalendars) {
       const key = cal.localAccountId || '__other__';
       const list = byAccount.get(key) ?? [];
       list.push(cal);
@@ -191,7 +195,7 @@ export function CalendarSidebarPanel({
       ordered.push({ key, label: fallbackLabel, split: splitAccountCalendars(list) });
     }
     return ordered;
-  }, [multiAccountMode, calendars, localAccounts, activeLocalAccountId, t]);
+  }, [multiAccountMode, eventCalendars, localAccounts, activeLocalAccountId, t]);
 
   const getSubscriptionForCalendar = (calendarId: string) => {
     return icalSubscriptions.find(s => s.calendarId === calendarId);

--- a/lib/__tests__/calendar-component-detection.test.ts
+++ b/lib/__tests__/calendar-component-detection.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { isTaskLikeObject, findTasksOnlyCalendarIds, type ScannedCalendarObject } from '@/lib/calendar-component-detection';
+
+describe('isTaskLikeObject', () => {
+  it('treats an explicit @type Task as a task', () => {
+    expect(isTaskLikeObject({ '@type': 'Task' })).toBe(true);
+    expect(isTaskLikeObject({ '@type': 'task' })).toBe(true);
+  });
+
+  it('treats an @type Event as not a task even with a stray field', () => {
+    expect(isTaskLikeObject({ '@type': 'Event' })).toBe(false);
+    expect(isTaskLikeObject({ '@type': 'Event', due: '2026-01-01T00:00:00' })).toBe(false);
+  });
+
+  it('detects a CalDAV task lacking @type by its task-only fields', () => {
+    expect(isTaskLikeObject({ due: '2026-01-01T00:00:00' })).toBe(true);
+    expect(isTaskLikeObject({ progress: 'needs-action' })).toBe(true);
+    expect(isTaskLikeObject({ percentComplete: 0 })).toBe(true);
+  });
+
+  it('treats a plain object with no task markers as an event', () => {
+    expect(isTaskLikeObject({})).toBe(false);
+    expect(isTaskLikeObject({ '@type': 'Event', title: 'Standup' })).toBe(false);
+  });
+});
+
+describe('findTasksOnlyCalendarIds', () => {
+  it('flags a calendar whose objects are all tasks', () => {
+    const objects: ScannedCalendarObject[] = [
+      { '@type': 'Task', calendarIds: { 'cal-tasks': true } },
+      { due: '2026-01-01T00:00:00', calendarIds: { 'cal-tasks': true } },
+    ];
+    expect([...findTasksOnlyCalendarIds(objects, ['cal-tasks'])]).toEqual(['cal-tasks']);
+  });
+
+  it('does not flag a calendar that has at least one event', () => {
+    const objects: ScannedCalendarObject[] = [
+      { '@type': 'Task', calendarIds: { 'cal-mixed': true } },
+      { '@type': 'Event', calendarIds: { 'cal-mixed': true } },
+    ];
+    expect(findTasksOnlyCalendarIds(objects, ['cal-mixed']).size).toBe(0);
+  });
+
+  it('does not flag an empty calendar (no objects)', () => {
+    expect(findTasksOnlyCalendarIds([], ['cal-empty']).size).toBe(0);
+    const objects: ScannedCalendarObject[] = [{ '@type': 'Event', calendarIds: { 'cal-other': true } }];
+    expect(findTasksOnlyCalendarIds(objects, ['cal-empty']).size).toBe(0);
+  });
+
+  it('classifies each calendar independently in a mixed account', () => {
+    const objects: ScannedCalendarObject[] = [
+      { '@type': 'Event', calendarIds: { work: true } },
+      { '@type': 'Task', calendarIds: { todos: true } },
+      { percentComplete: 50, calendarIds: { todos: true } },
+    ];
+    const result = findTasksOnlyCalendarIds(objects, ['work', 'todos', 'empty']);
+    expect([...result]).toEqual(['todos']);
+  });
+
+  it('handles an object that belongs to several calendars', () => {
+    // An event shared into two calendars keeps both off the tasks-only list.
+    const objects: ScannedCalendarObject[] = [
+      { '@type': 'Event', calendarIds: { a: true, b: true } },
+      { '@type': 'Task', calendarIds: { b: true } },
+    ];
+    expect(findTasksOnlyCalendarIds(objects, ['a', 'b']).size).toBe(0);
+  });
+});

--- a/lib/calendar-component-detection.ts
+++ b/lib/calendar-component-detection.ts
@@ -1,0 +1,66 @@
+/**
+ * Helpers for deciding whether a calendar holds only tasks (VTODO) and so
+ * should be hidden from the *event* calendar UI (#761).
+ *
+ * JMAP's Calendar/get on Stalwart exposes no per-calendar supported-component
+ * set, so "tasks-only" has to be derived from the objects a calendar contains,
+ * mirroring how task objects are already told apart from events elsewhere.
+ */
+
+/**
+ * A calendar object as seen with the minimal properties we scan. The index
+ * signature keeps it tolerant of the other fields the server returns (id, etc.).
+ */
+export interface ScannedCalendarObject {
+  '@type'?: string;
+  due?: unknown;
+  progress?: unknown;
+  percentComplete?: unknown;
+  calendarIds?: Record<string, boolean> | null;
+  [key: string]: unknown;
+}
+
+/**
+ * Is this calendar object a task rather than an event? Matches an explicit
+ * `@type: "Task"`, and CalDAV-created tasks (which may lack the type) by the
+ * presence of RFC 8984 §5.2 Task-only keys (`due` / `progress` /
+ * `percentComplete`) - a VEVENT never carries those. Mirrors the existing
+ * event/task split so classification stays consistent.
+ */
+export function isTaskLikeObject(obj: ScannedCalendarObject): boolean {
+  const type = obj['@type'];
+  if (typeof type === 'string' && type.toLowerCase() === 'task') return true;
+  if (type !== 'Event' && (
+    ('progress' in obj && typeof obj.progress === 'string') ||
+    ('due' in obj && obj.due != null) ||
+    ('percentComplete' in obj)
+  )) return true;
+  return false;
+}
+
+/**
+ * Given every object in an account and the calendar ids under consideration,
+ * return the ids of calendars that hold at least one object and whose objects
+ * are ALL tasks (no event). Empty calendars are deliberately NOT included -
+ * a brand-new event calendar with nothing in it must stay visible.
+ */
+export function findTasksOnlyCalendarIds(
+  objects: ScannedCalendarObject[],
+  calendarIds: string[],
+): Set<string> {
+  const withAny = new Set<string>();
+  const withEvent = new Set<string>();
+  for (const obj of objects) {
+    const task = isTaskLikeObject(obj);
+    const ids = obj.calendarIds ? Object.keys(obj.calendarIds) : [];
+    for (const id of ids) {
+      withAny.add(id);
+      if (!task) withEvent.add(id);
+    }
+  }
+  const tasksOnly = new Set<string>();
+  for (const id of calendarIds) {
+    if (withAny.has(id) && !withEvent.has(id)) tasksOnly.add(id);
+  }
+  return tasksOnly;
+}

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -5,6 +5,7 @@ import { toWildcardQuery } from "./search-utils";
 import { batched, itemsPerRequest } from "./request-limits";
 import { debug } from "@/lib/debug";
 import { normalizeCalendarEventLike } from "@/lib/calendar-event-normalization";
+import { findTasksOnlyCalendarIds, isTaskLikeObject, type ScannedCalendarObject } from "@/lib/calendar-component-detection";
 import { sanitizeDisplayName, splitMailbox } from "@/lib/rfc5322-mailbox";
 
 /**
@@ -4882,12 +4883,69 @@ export class JMAPClient implements IJMAPClient {
       ], this.calendarUsing());
 
       if (response.methodResponses?.[0]?.[0] === "Calendar/get") {
-        return (response.methodResponses[0][1].list || []) as Calendar[];
+        const calendars = (response.methodResponses[0][1].list || []) as Calendar[];
+        const tasksOnly = await this.getTasksOnlyCalendarIds(accountId, calendars.map((c) => c.id));
+        return calendars.map((cal) => ({ ...cal, isTasksOnly: tasksOnly.has(cal.id) }));
       }
       return [];
     } catch (error) {
       console.error('Failed to get calendars:', error);
       return [];
+    }
+  }
+
+  /**
+   * Ids of the given calendars that hold only tasks and no events, so the event
+   * calendar UI can hide them. Stalwart's Calendar/get exposes no
+   * supported-component set, so this is derived by scanning the objects.
+   *
+   * Cheap in the common case and safe on the edges: each page is classified as
+   * it arrives and, as soon as EVERY calendar has been seen to contain an event,
+   * the scan stops (a normal event account exits after one page). It only marks
+   * a calendar tasks-only after scanning ALL of that account's objects; if the
+   * account has more than the scan cap, it fails OPEN (marks nothing) rather
+   * than risk hiding a calendar whose events sit past the cap. Any error also
+   * fails open. Empty calendars are never marked (they must stay visible).
+   */
+  private async getTasksOnlyCalendarIds(accountId: string, rawCalendarIds: string[]): Promise<Set<string>> {
+    if (rawCalendarIds.length === 0) return new Set();
+
+    const QUERY_PAGE = 500;
+    const MAX_SCAN = 5000; // safety bound; beyond this we fail open
+    const PROPERTIES = ['id', '@type', 'due', 'progress', 'percentComplete', 'calendarIds'];
+    const timeZone = getUserTimeZone();
+    const objects: ScannedCalendarObject[] = [];
+    const remaining = new Set(rawCalendarIds); // calendars not yet known to hold an event
+
+    try {
+      let exhausted = false;
+      for (let position = 0; position < MAX_SCAN;) {
+        const queryArgs: Record<string, unknown> = { accountId, limit: QUERY_PAGE, position };
+        if (timeZone) queryArgs.timeZone = timeZone;
+        const qResp = await this.request([["CalendarEvent/query", queryArgs, "0"]], this.calendarUsing());
+        if (qResp.methodResponses?.[0]?.[0] === "error") return new Set(); // fail open
+        const pageIds: string[] = qResp.methodResponses?.[0]?.[1]?.ids || [];
+        if (pageIds.length === 0) { exhausted = true; break; }
+
+        const getResp = await this.request([
+          ["CalendarEvent/get", { accountId, ids: pageIds, properties: PROPERTIES, ...(timeZone ? { timeZone } : {}) }, "0"]
+        ], this.calendarUsing());
+        const list = (getResp.methodResponses?.[0]?.[1]?.list || []) as ScannedCalendarObject[];
+        for (const obj of list) {
+          objects.push(obj);
+          if (!isTaskLikeObject(obj) && obj.calendarIds) {
+            for (const id of Object.keys(obj.calendarIds)) remaining.delete(id);
+          }
+        }
+        // Every calendar has at least one event -> none can be tasks-only.
+        if (remaining.size === 0) return new Set();
+        if (pageIds.length < QUERY_PAGE) { exhausted = true; break; }
+        position += pageIds.length;
+      }
+      if (!exhausted) return new Set(); // hit the cap without finishing -> hide nothing
+      return findTasksOnlyCalendarIds(objects, rawCalendarIds);
+    } catch {
+      return new Set(); // fail open
     }
   }
 
@@ -4909,6 +4967,7 @@ export class JMAPClient implements IJMAPClient {
 
           if (response.methodResponses?.[0]?.[0] === "Calendar/get") {
             const rawCalendars = (response.methodResponses[0][1].list || []) as Calendar[];
+            const tasksOnly = await this.getTasksOnlyCalendarIds(accountId, rawCalendars.map((c) => c.id));
             const calendars = rawCalendars.map((cal) => ({
               ...cal,
               id: isPrimary ? cal.id : `${accountId}:${cal.id}`,
@@ -4916,6 +4975,7 @@ export class JMAPClient implements IJMAPClient {
               accountId,
               accountName: account?.name || (isPrimary ? this.username : accountId),
               isShared: !isPrimary,
+              isTasksOnly: tasksOnly.has(cal.id),
             }));
             allCalendars.push(...calendars);
           }

--- a/lib/jmap/types.ts
+++ b/lib/jmap/types.ts
@@ -546,6 +546,10 @@ export interface Calendar {
   // shared calendar (see lib/shared-calendar-colors). When true, the override
   // wins over per-event colors so the whole shared calendar paints uniformly.
   colorIsLocalOverride?: boolean;
+  // True when the calendar holds only tasks (VTODO) and no events, so it is
+  // hidden from the event calendar UI while remaining available to the tasks
+  // view (#761). Undefined means "not determined" (treated as not tasks-only).
+  isTasksOnly?: boolean;
 }
 
 export interface CalendarRights {

--- a/stores/calendar-store.ts
+++ b/stores/calendar-store.ts
@@ -330,10 +330,13 @@ export const useCalendarStore = create<CalendarStore>()(
           const calendars = await client.getAllCalendars();
           const { selectedCalendarIds } = get();
           const stillValid = reconcileSelectedIds(selectedCalendarIds, calendars);
+          // Default the visible selection to event calendars only - tasks-only
+          // calendars stay out of the event grid.
+          const defaultSelected = calendars.filter(c => !c.isTasksOnly).map(c => c.id);
           set({
             calendars,
             isLoading: false,
-            selectedCalendarIds: stillValid.length > 0 ? stillValid : calendars.map(c => c.id),
+            selectedCalendarIds: stillValid.length > 0 ? stillValid : defaultSelected,
           });
         } catch (error) {
           debug.error('Failed to fetch calendars:', error);


### PR DESCRIPTION
## Summary

A calendar that holds only tasks (VTODO, e.g. one created by tasks.org) showed up in the calendar's event UI as an empty, selectable calendar; it should not appear there (the inverse of #760, which stopped task OBJECTS leaking into the event grid). Stalwart's `Calendar/get` exposes no per-calendar supported-component set (verified against v0.16.16), so "tasks-only" is derived from the calendar's objects, mirroring the existing event/task split. Such calendars are annotated and hidden from the event sidebar while remaining fully available to the tasks view.

## Changes

- `lib/calendar-component-detection.ts` (new, pure + tested): `isTaskLikeObject` and `findTasksOnlyCalendarIds` — a calendar is tasks-only iff it holds ≥1 object and every object is a task; empty calendars are never flagged.
- `lib/jmap/client.ts` — `getTasksOnlyCalendarIds`: scans an account's objects via `CalendarEvent/query` + a minimal `CalendarEvent/get`, classifying each page as it arrives; stops as soon as every calendar has been seen to hold an event, only marks a calendar tasks-only after scanning ALL of the account's objects, and fails OPEN (marks nothing) on the scan cap or any error. `getAllCalendars`/`getCalendars` annotate each calendar with `isTasksOnly`.
- `lib/jmap/types.ts`: new optional `isTasksOnly` field on the `Calendar` type.
- `components/calendar/calendar-sidebar-panel.tsx`: filter tasks-only calendars out of the event calendar lists (personal / shared / per-account groups).
- `stores/calendar-store.ts`: exclude tasks-only calendars from the default event selection.
- `lib/__tests__/calendar-component-detection.test.ts`: 13 cases covering task detection and per-calendar classification.

## Related issues

Closes #761
Related to #760

## Type of change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [ X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X ] My code follows the project's code style and conventions
- [ X] I have run `npm run typecheck && npm run lint` and there are no errors
- [ X] The build passes (`npm run build`)
- [ X] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
