### PR TITLE
fix(settings): give the Layout tab its own title instead of Appearance's

### DIFF
--- a/components/settings/layout-settings.tsx
+++ b/components/settings/layout-settings.tsx
@@ -116,7 +116,12 @@ function MailLayoutPreview({
 }
 
 export function LayoutSettings() {
+  // Every item on this page is keyed under `settings.appearance` for historical
+  // reasons, so `t` stays on that namespace. Only the section header moves to
+  // `settings.layout` — otherwise this tab renders the exact same title and
+  // description as the Appearance tab and the two become indistinguishable.
   const t = useTranslations('settings.appearance');
+  const tLayout = useTranslations('settings.layout');
   const tEmail = useTranslations('settings.email_behavior');
   const { toolbarPosition, showToolbarLabels, hideAccountSwitcher, showRailAccountList, enableUnifiedMailbox, includeGroupInUnified, unifiedCrossAccount, allMailFolderIds, enableCrossUnreadView, enableCrossStarredView, enableCrossAllView, colorfulSidebarIcons, tintListRowsByTag, showFolderTotalCount, faviconUnreadBadge, mailLayout, proInterface, updateSetting } = useSettingsStore();
   const { isSettingLocked, isSettingHidden, isFeatureEnabled } = usePolicyStore();
@@ -167,7 +172,7 @@ export function LayoutSettings() {
     : null;
 
   return (
-    <SettingsSection title={t('title')} description={t('description')}>
+    <SettingsSection title={tLayout('title')} description={tLayout('description')}>
       {!isSettingHidden('mailLayout') && (
       <SettingItem label={tEmail('mail_layout.label')} description={tEmail('mail_layout.description')} locked={isSettingLocked('mailLayout')}>
         <div className="w-[22rem] max-w-full">

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1022,6 +1022,10 @@
         "description": "Show an All mail entry in the Unified Mailbox listing all mail across the selected folders."
       }
     },
+    "layout": {
+      "title": "Layout",
+      "description": "Arrange the reading pane, toolbar, sidebar and unified mailbox"
+    },
     "keywords": {
       "title": "Email Tags",
       "description": "Define tags to organize your emails. These are stored as JMAP keywords on the server.",


### PR DESCRIPTION
### What

Settings → **Layout** renders the header `Appearance` / *Customize the look and feel of your webmail* — byte for byte what Settings → **Appearance** renders. `LayoutSettings` reads every string from the `settings.appearance` namespace, including the section title, so once you are on the page there is nothing telling the two tabs apart.

### Why it matters

Real case that prompted this: looking for **Unified Mailbox → All mail** (to make search span every folder). You open Appearance, the page says "Appearance", you find theme / font size / density / avatar toggles, and you conclude the setting does not exist. It is one tab below, under an identical heading.

The sidebar highlight is the only cue, and it is easy to miss on a wide screen where the two tabs sit next to each other under the same `APPEARANCE` group.

### Fix

Only the section header moves to a new `settings.layout` namespace:

```diff
-    <SettingsSection title={t('title')} description={t('description')}>
+    <SettingsSection title={tLayout('title')} description={tLayout('description')}>
```

Deliberately minimal:

- every **item** on the page keeps its `settings.appearance` key, so no existing translation in any of the 30+ locales is invalidated;
- only `en/common.json` gains the two new strings — locales without `settings.layout` fall back to English via `mergeMessages`, so nothing renders a raw key like `settings.layout.title`.

### Checks

- `npx tsc --noEmit` — clean
- `npx eslint components/settings/layout-settings.tsx` — clean
- `npx vitest run` on the neighbouring settings/store suites — 12 passed
