### PR TITLE
test: match the forced token refresh URL in the logout tests

### DIFF
--- a/stores/__tests__/auth-store-logout.test.ts
+++ b/stores/__tests__/auth-store-logout.test.ts
@@ -62,7 +62,7 @@ describe('auth-store logout redirects', () => {
       const url = String(input);
       const method = init?.method ?? 'GET';
 
-      if (url === '/api/auth/token?slot=0' && method === 'PUT') {
+      if (url === '/api/auth/token?slot=0&force=true' && method === 'PUT') {
         return { ok: false, status: 401, json: async () => ({}) };
       }
 
@@ -102,7 +102,7 @@ describe('auth-store logout redirects', () => {
       const url = String(input);
       const method = init?.method ?? 'GET';
 
-      if (url === '/api/auth/token?slot=0' && method === 'PUT') {
+      if (url === '/api/auth/token?slot=0&force=true' && method === 'PUT') {
         return { ok: false, status: 503, json: async () => ({}) };
       }
 
@@ -126,7 +126,7 @@ describe('auth-store logout redirects', () => {
     expect(replaceSpy).not.toHaveBeenCalled();
 
     const countPuts = () => fetchMock.mock.calls.filter(
-      ([input, init]) => String(input) === '/api/auth/token?slot=0' && init?.method === 'PUT',
+      ([input, init]) => String(input) === '/api/auth/token?slot=0&force=true' && init?.method === 'PUT',
     ).length;
 
     // A retry is armed: advancing past the ~30 s window fires a second PUT.
@@ -149,7 +149,7 @@ describe('auth-store logout redirects', () => {
       const url = String(input);
       const method = init?.method ?? 'GET';
 
-      if (url === '/api/auth/token?slot=0' && method === 'PUT') {
+      if (url === '/api/auth/token?slot=0&force=true' && method === 'PUT') {
         return new Promise((resolve) => { resolveInFlight = resolve; });
       }
       if (method === 'DELETE') {
@@ -175,7 +175,7 @@ describe('auth-store logout redirects', () => {
 
     // The failure lands after the sign-out - no retry may be re-armed.
     const countPuts = () => fetchMock.mock.calls.filter(
-      ([input, init]) => String(input) === '/api/auth/token?slot=0' && init?.method === 'PUT',
+      ([input, init]) => String(input) === '/api/auth/token?slot=0&force=true' && init?.method === 'PUT',
     ).length;
     expect(countPuts()).toBe(1);
     await vi.advanceTimersByTimeAsync(600_000);
@@ -189,7 +189,7 @@ describe('auth-store logout redirects', () => {
       const url = String(input);
       const method = init?.method ?? 'GET';
 
-      if (url === '/api/auth/token?slot=0' && method === 'PUT') {
+      if (url === '/api/auth/token?slot=0&force=true' && method === 'PUT') {
         throw new TypeError('Failed to fetch');
       }
 


### PR DESCRIPTION
## Summary

`refreshAccessToken` now skips the server-side token cache by default and appends `force=true` to its PUT (part of the shorter auth waterfall). The logout redirect tests still mock the bare slot URL, so every refresh hits the mock's unexpected-call guard — three tests fail on `main`. This brings the mocks in line with the new URL.

## Changes

- Match the PUT on `/api/auth/token?slot=0&force=true` in the fetch mocks and call-count filters of `stores/__tests__/auth-store-logout.test.ts`; the DELETE paths are unchanged.

## Related issues

None — test-only follow-up to the auth waterfall change.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

No UI involved — test-only change.

## Notes for reviewers

- Reproduce on `main`: `npx vitest run stores/__tests__/auth-store-logout.test.ts` fails 3 of 6 with "Unexpected fetch call: PUT /api/auth/token?slot=0&force=true"; 6/6 green with this change.
- The `force=true` default itself looks intentional (documented inline in `refreshAccessToken`); this PR only aligns the tests.