### PR TITLE
fix: keep the fresh-compose tab title clear of the selected email subject

### DIFF
--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -94,7 +94,7 @@ import { plainTextToComposerBody, getQuoteBodies } from "@/lib/email-composer-ut
 import { appLifecycleHooks, uiHooks, routerHooks, toastHooks, emailHooks } from "@/lib/plugin-hooks";
 import { emailToReadView } from "@/lib/plugin-projection";
 import { buildQuoteHeader } from "@/lib/quote-header";
-import { buildReplySubject, buildForwardSubject } from "@/lib/subject-prefix";
+import { buildComposeTabTitle, buildReplySubject } from "@/lib/subject-prefix";
 import { buildForwardAsAttachmentPayload } from "@/lib/forward-as-attachment";
 import { getEffectiveLocale } from '@/i18n/detect-locale';
 import {
@@ -904,17 +904,14 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
     } : undefined);
 
     const effectiveMode = pendingDraft?.mode ?? composerMode;
-    const baseSubject = (pendingDraft?.subject?.trim() || selectedEmail?.subject?.trim()) ?? '';
-    let title = t('email_composer.new_message');
-    if (baseSubject) {
-      if (effectiveMode === 'reply' || effectiveMode === 'replyAll') {
-        title = buildReplySubject(baseSubject, t('email_composer.prefix.reply'));
-      } else if (effectiveMode === 'forward') {
-        title = buildForwardSubject(baseSubject, t('email_composer.prefix.forward'));
-      } else {
-        title = baseSubject;
-      }
-    }
+    const title = buildComposeTabTitle({
+      mode: effectiveMode,
+      draftSubject: pendingDraft?.subject,
+      sourceSubject: selectedEmail?.subject,
+      replyPrefix: t('email_composer.prefix.reply'),
+      forwardPrefix: t('email_composer.prefix.forward'),
+      fallback: t('email_composer.new_message'),
+    });
 
     useProTabStore.getState().openComposeTab({
       sessionId: composerSessionId + 1,

--- a/lib/__tests__/subject-prefix.test.ts
+++ b/lib/__tests__/subject-prefix.test.ts
@@ -3,6 +3,7 @@ import {
   stripSubjectPrefixes,
   buildReplySubject,
   buildForwardSubject,
+  buildComposeTabTitle,
 } from '@/lib/subject-prefix';
 
 describe('stripSubjectPrefixes', () => {
@@ -52,5 +53,35 @@ describe('buildReplySubject / buildForwardSubject', () => {
   it('prepends to a clean subject and returns the bare prefix for empty input', () => {
     expect(buildReplySubject('foo', 'AW:')).toBe('AW: foo');
     expect(buildReplySubject('', 'AW:')).toBe('AW:');
+  });
+});
+
+describe('buildComposeTabTitle', () => {
+  const prefixes = { replyPrefix: 'Re:', forwardPrefix: 'Fwd:', fallback: 'New message' };
+
+  it('never inherits the selected email subject for a fresh compose (#856)', () => {
+    expect(buildComposeTabTitle({ mode: 'compose', sourceSubject: 'Invoice August 2026', ...prefixes }))
+      .toBe('New message');
+  });
+
+  it('uses the draft subject for a fresh compose when one exists (mailto, draft edit)', () => {
+    expect(buildComposeTabTitle({ mode: 'compose', draftSubject: 'Lunch?', sourceSubject: 'Invoice August 2026', ...prefixes }))
+      .toBe('Lunch?');
+  });
+
+  it('derives reply and forward titles from the source subject', () => {
+    expect(buildComposeTabTitle({ mode: 'reply', sourceSubject: 'Invoice August 2026', ...prefixes }))
+      .toBe('Re: Invoice August 2026');
+    expect(buildComposeTabTitle({ mode: 'replyAll', sourceSubject: 'AW: Invoice', ...prefixes }))
+      .toBe('Re: Invoice');
+    expect(buildComposeTabTitle({ mode: 'forward', sourceSubject: 'Invoice', ...prefixes }))
+      .toBe('Fwd: Invoice');
+  });
+
+  it('prefers a resumed draft subject over the source and falls back when both are blank', () => {
+    expect(buildComposeTabTitle({ mode: 'reply', draftSubject: 'Re: edited', sourceSubject: 'Original', ...prefixes }))
+      .toBe('Re: edited');
+    expect(buildComposeTabTitle({ mode: 'reply', sourceSubject: '   ', ...prefixes }))
+      .toBe('New message');
   });
 });

--- a/lib/subject-prefix.ts
+++ b/lib/subject-prefix.ts
@@ -119,3 +119,26 @@ export function buildForwardSubject(subject: string | undefined | null, prefix: 
   const stripped = stripSubjectPrefixes(subject);
   return stripped ? `${prefix} ${stripped}` : prefix;
 }
+
+/**
+ * Working title for a compose tab. Reply and forward derive it from the
+ * message they act on; a fresh compose must NOT inherit the subject of
+ * whatever email happens to be selected in the list (#856) - it starts on
+ * the fallback ("New message") until a draft subject exists.
+ */
+export function buildComposeTabTitle(opts: {
+  mode: 'compose' | 'reply' | 'replyAll' | 'forward';
+  draftSubject?: string | null;
+  sourceSubject?: string | null;
+  replyPrefix: string;
+  forwardPrefix: string;
+  fallback: string;
+}): string {
+  const draft = opts.draftSubject?.trim() ?? '';
+  const source = opts.mode === 'compose' ? '' : (opts.sourceSubject?.trim() ?? '');
+  const base = draft || source;
+  if (!base) return opts.fallback;
+  if (opts.mode === 'reply' || opts.mode === 'replyAll') return buildReplySubject(base, opts.replyPrefix);
+  if (opts.mode === 'forward') return buildForwardSubject(base, opts.forwardPrefix);
+  return base;
+}


### PR DESCRIPTION
## Summary

In Pro mode, clicking **New Email** while a message was selected in the list opened the compose tab with that message's subject as its title — e.g. "Invoice August 2026" for a completely unrelated new draft (#856). The bridge that turns a compose intent into a tab derived its working title from the draft subject or, failing that, the selected email's subject regardless of mode. For reply/forward the selected email is the message being acted on; for a fresh compose it is just whatever happens to be highlighted.

## Changes

- Extract the title rule into `buildComposeTabTitle` (next to `buildReplySubject`/`buildForwardSubject` in `lib/subject-prefix.ts`): a fresh compose only ever uses its own draft subject (mailto drafts, resumed drafts) and otherwise starts on the "New message" fallback; reply/reply-all/forward keep deriving `Re:`/`Fwd:` titles from the source message.
- Use it in the Pro-mode compose bridge in `mail-app.tsx`.
- Unit tests for the full mode matrix, including the reported repro.

## Related issues

Closes #856

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

No new UI — the compose tab simply starts on the existing "New message" label instead of an unrelated subject. Typing a subject already renames the tab live (that part worked before and is untouched), which also covers the dynamic-title behavior the issue asks for.

## Notes for reviewers

- Why it only happened *sometimes*: the compose tab body corrects its title on mount, so the stale title survived only when the body didn't render immediately. This fix removes the wrong title at its source, the only place that opens `compose`-mode tabs.
- The same title rule still exists in two more hand-rolled shapes: the five reply/forward openers in `pro-email-tab-body.tsx` (which produce "Re: New message" for subjectless sources, unlike the bridge's bare fallback) and the mount-time correction in `pro-compose-tab-body.tsx` (which briefly shows a reply's raw subject without "Re:"). Both predate this change. Happy to follow up and unify all of them on `buildComposeTabTitle` — it just needs a call on the subjectless-source wording, so I kept it out of this bugfix.
- Verified with `npm run typecheck`, `npm run lint`, `npm run build` and the full `npx vitest run`.