### PR TITLE
Hide Admin UI for non-system Stalwart admins

### DIFF
--- a/app/(main)/admin/layout.tsx
+++ b/app/(main)/admin/layout.tsx
@@ -86,6 +86,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   const [authenticated, setAuthenticated] = useState<boolean | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
   const [isStalwartAdmin, setIsStalwartAdmin] = useState(false);
+  const [isSystemAdmin, setIsSystemAdmin] = useState(false);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const { appLogoLightUrl, appLogoDarkUrl, loginLogoLightUrl, loginLogoDarkUrl } = useConfig();
   const filesEnabled = usePolicyStore((s) => s.isFeatureEnabled('filesEnabled'));
@@ -121,6 +122,13 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     async function checkAuth() {
       try {
         const jmapHeaders = getActiveAccountSlotHeaders();
+        const checkSystemAdmin = async (): Promise<boolean> => {
+          const systemRes = await apiFetch('/api/admin/system-admin', { headers: jmapHeaders }).catch(() => null);
+          if (!systemRes?.ok) return false;
+          const systemData = await systemRes.json().catch(() => ({ isSystemAdmin: false }));
+          return systemData?.isSystemAdmin === true;
+        };
+
         const res = await apiFetch('/api/admin/auth', { headers: jmapHeaders });
         const data = await res.json();
         if (cancelled) return;
@@ -135,6 +143,16 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
         }
 
         if (data.authenticated) {
+          if (stalwartAdmin) {
+            const systemAdmin = await checkSystemAdmin();
+            if (cancelled) return;
+            if (!systemAdmin) {
+              setAuthenticated(false);
+              router.replace('/');
+              return;
+            }
+            setIsSystemAdmin(true);
+          }
           setAuthenticated(true);
           return;
         }
@@ -148,7 +166,15 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
           });
           if (cancelled) return;
           if (loginRes.ok) {
+            const systemAdmin = await checkSystemAdmin();
+            if (cancelled) return;
+            if (!systemAdmin) {
+              setAuthenticated(false);
+              router.replace('/');
+              return;
+            }
             setAuthenticated(true);
+            setIsSystemAdmin(true);
             return;
           }
           const body = await loginRes.json().catch(() => ({}));
@@ -409,7 +435,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
             <div className="py-12 text-center text-sm text-muted-foreground animate-pulse">
               Loading admin panel…
             </div>
-          ) : authenticated ? (
+          ) : authenticated && (!isStalwartAdmin || isSystemAdmin) ? (
             children
           ) : null}
         </div>

--- a/app/(main)/admin/layout.tsx
+++ b/app/(main)/admin/layout.tsx
@@ -122,7 +122,9 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     async function checkAuth() {
       try {
         const jmapHeaders = getActiveAccountSlotHeaders();
+        const hasActiveSlot = Boolean(jmapHeaders['X-JMAP-Cookie-Slot']);
         const checkSystemAdmin = async (): Promise<boolean> => {
+          if (!hasActiveSlot) return false;
           const systemRes = await apiFetch('/api/admin/system-admin', { headers: jmapHeaders }).catch(() => null);
           if (!systemRes?.ok) return false;
           const systemData = await systemRes.json().catch(() => ({ isSystemAdmin: false }));
@@ -143,7 +145,10 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
         }
 
         if (data.authenticated) {
-          if (stalwartAdmin) {
+          // If this admin session is being used from a logged-in webmail account
+          // slot, enforce Stalwart system-admin status even when an admin cookie
+          // already exists (prevents cross-account cookie privilege leakage).
+          if (hasActiveSlot) {
             const systemAdmin = await checkSystemAdmin();
             if (cancelled) return;
             if (!systemAdmin) {
@@ -151,6 +156,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
               router.replace('/');
               return;
             }
+            setIsStalwartAdmin(true);
             setIsSystemAdmin(true);
           }
           setAuthenticated(true);

--- a/app/api/admin/system-admin/route.ts
+++ b/app/api/admin/system-admin/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdminAuth } from '@/lib/admin/session';
+import { getStalwartCredentials } from '@/lib/stalwart/credentials';
+import { logger } from '@/lib/logger';
+
+const JMAP_TIMEOUT_MS = 10_000;
+
+async function postJmap<T>(serverUrl: string, authHeader: string, body: unknown): Promise<T | null> {
+  const response = await fetchWithTimeout(`${serverUrl}/jmap/`, {
+    method: 'POST',
+    headers: {
+      Authorization: authHeader,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) return null;
+  return await response.json() as T;
+}
+
+async function fetchWithTimeout(url: string, init: Parameters<typeof fetch>[1]): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), JMAP_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * GET /api/admin/system-admin
+ *
+ * Returns whether the currently authenticated Stalwart-backed admin session
+ * belongs to a system admin (not tenant/domain-scoped admin).
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await requireAdminAuth(request);
+    if ('error' in auth) return auth.error;
+
+    const creds = await getStalwartCredentials(request);
+    if (!creds) {
+      return NextResponse.json({ isSystemAdmin: false }, { headers: { 'Cache-Control': 'no-store' } });
+    }
+
+    const sessionRes = await fetchWithTimeout(`${creds.serverUrl}/.well-known/jmap`, {
+      method: 'GET',
+      headers: { Authorization: creds.authHeader },
+    });
+    if (!sessionRes.ok) {
+      return NextResponse.json({ isSystemAdmin: false }, { headers: { 'Cache-Control': 'no-store' } });
+    }
+
+    const session = await sessionRes.json() as {
+      primaryAccounts?: Record<string, string>;
+    };
+    const accountId = session.primaryAccounts?.['urn:stalwart:jmap']
+      ?? session.primaryAccounts?.['urn:ietf:params:jmap:mail']
+      ?? (session.primaryAccounts ? Object.values(session.primaryAccounts)[0] : undefined);
+
+    if (!accountId) {
+      return NextResponse.json({ isSystemAdmin: false }, { headers: { 'Cache-Control': 'no-store' } });
+    }
+
+    const data = await postJmap<{
+      methodResponses?: Array<[string, {
+        list?: Array<{
+          domainId?: string | null;
+          roles?: {
+            ['@type']?: string;
+            roleIds?: Record<string, boolean>;
+          } | null;
+        }>;
+      }, string]>;
+    }>(creds.serverUrl, creds.authHeader, {
+      using: ['urn:ietf:params:jmap:core', 'urn:stalwart:jmap'],
+      methodCalls: [['x:Account/get', { accountId, ids: [accountId] }, '0']],
+    });
+
+    if (!data) {
+      return NextResponse.json({ isSystemAdmin: false }, { headers: { 'Cache-Control': 'no-store' } });
+    }
+
+    const first = data.methodResponses?.[0];
+    const account = first && first[0] === 'x:Account/get' ? first[1]?.list?.[0] : undefined;
+    const roleType = String(account?.roles?.['@type'] ?? '').toLowerCase();
+    const hasDomainScope = typeof account?.domainId === 'string' && account.domainId.length > 0;
+
+    // In this deployment, true system admins return `roles.@type = Admin`
+    // even though `domainId` can still be populated.
+    const isSystemRole = roleType === 'admin';
+    const isTenantRole = roleType.includes('tenant');
+
+    let customRoleIsSystemAdmin = false;
+    if (roleType === 'custom') {
+      const roleIds = Object.keys(account?.roles?.roleIds ?? {});
+      if (roleIds.length > 0) {
+        const roleData = await postJmap<{
+          methodResponses?: Array<[string, {
+            list?: Array<{
+              name?: string | null;
+              description?: string | null;
+            }>;
+          }, string]>;
+        }>(creds.serverUrl, creds.authHeader, {
+          using: ['urn:ietf:params:jmap:core', 'urn:stalwart:jmap'],
+          methodCalls: [['x:Role/get', { accountId, ids: roleIds }, '0']],
+        });
+
+        const roleList = roleData?.methodResponses?.[0]?.[0] === 'x:Role/get'
+          ? roleData.methodResponses[0][1]?.list ?? []
+          : [];
+
+        customRoleIsSystemAdmin = roleList.some((role) => {
+          const roleName = String(role.name ?? '').toLowerCase();
+          const roleDescription = String(role.description ?? '').toLowerCase();
+          return roleName.includes('system administrator') || roleDescription.includes('system administrator');
+        });
+      }
+    }
+
+    const isSystemAdmin = isSystemRole || customRoleIsSystemAdmin || (!hasDomainScope && !isTenantRole);
+
+    return NextResponse.json({ isSystemAdmin }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    logger.error('System admin check failed', { error: error instanceof Error ? error.message : 'Unknown error' });
+    return NextResponse.json({ isSystemAdmin: false }, { headers: { 'Cache-Control': 'no-store' } });
+  }
+}

--- a/components/layout/navigation-rail.tsx
+++ b/components/layout/navigation-rail.tsx
@@ -204,7 +204,7 @@ export function NavigationRail({
   const calendarEnabled = usePolicyStore((s) => s.isFeatureEnabled('calendarEnabled'));
   const visibleSidebarApps = sidebarAppsEnabled ? sidebarApps : [];
   const inboxUnread = mailboxes.find(m => m.role === "inbox")?.unreadEmails || 0;
-  const [isStalwartAdmin, setIsStalwartAdmin] = useState(false);
+  const [isStalwartSystemAdmin, setIsStalwartSystemAdmin] = useState(false);
   const hasUpdate = useUpdateStore(selectHasUpdate);
   const updateSeverity = useUpdateStore((s) => s.status?.severity);
   const startUpdatePolling = useUpdateStore((s) => s.startPolling);
@@ -277,17 +277,25 @@ export function NavigationRail({
     if (!headers['X-JMAP-Cookie-Slot']) return;
     apiFetch('/api/admin/auth', { headers })
       .then(res => res.json())
-      .then(data => {
+      .then(async (data) => {
         if (cancelled || !data.stalwartAdmin) return;
-        setIsStalwartAdmin(true);
-        if (!data.authenticated) {
-          // Pre-create admin session so /admin works even after full page navigation
-          apiFetch('/api/admin/auth', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...headers },
-            body: JSON.stringify({ stalwartAuth: true }),
-          }).catch(() => {});
-        }
+
+        const ensureSession = data.authenticated
+          ? Promise.resolve()
+          : apiFetch('/api/admin/auth', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json', ...headers },
+              body: JSON.stringify({ stalwartAuth: true }),
+            }).then(() => undefined);
+
+        await ensureSession.catch(() => undefined);
+        if (cancelled) return;
+
+        const systemRes = await apiFetch('/api/admin/system-admin', { headers }).catch(() => null);
+        if (!systemRes || !systemRes.ok) return;
+        const systemData = await systemRes.json().catch(() => ({ isSystemAdmin: false }));
+        if (cancelled) return;
+        setIsStalwartSystemAdmin(systemData?.isSystemAdmin === true);
       })
       .catch(() => {});
     return () => { cancelled = true; };
@@ -409,7 +417,7 @@ export function NavigationRail({
         })}
 
         {/* Admin (Stalwart admins) - hard nav because /admin lives outside the [locale] tree */}
-        {isStalwartAdmin && (
+        {isStalwartSystemAdmin && (
           <a
             href={`${getPathPrefix()}/admin`}
             className={cn(
@@ -596,7 +604,7 @@ export function NavigationRail({
 
       {/* Footer: Admin + Settings + Help + Storage Quota + Sign Out + Push Status */}
       <div className="mt-auto flex flex-col items-center gap-2 pb-3 px-1">
-        {isStalwartAdmin && (
+        {isStalwartSystemAdmin && (
           <a
             href={`${getPathPrefix()}/admin`}
             className="flex items-center justify-center w-10 h-10 rounded-md transition-colors text-muted-foreground hover:text-foreground hover:bg-muted relative"


### PR DESCRIPTION
## Summary
Restrict Bulwark Admin UI visibility and access so only Stalwart system administrators can see/use it.

## Changes
- Add new endpoint `GET /api/admin/system-admin` to determine whether the current Stalwart-authenticated admin session is a system admin.
- Update navigation rail to show Admin entry only when `isSystemAdmin` is true.
- Update `/admin` layout auth flow to redirect non-system Stalwart admins away from admin pages.
- Improve system-admin detection logic for Stalwart role nuances:
  - Treat `roles.@type = Admin` as system admin.
  - For `roles.@type = Custom`, resolve role IDs via `x:Role/get` and treat as system admin only when role metadata indicates `System Administrator`.

## Validation
- Typecheck passed.
- ESLint passed for changed files.
- Live role verification against Stalwart:
  - `admin@mailserver.mn` -> system admin
  - `bg@frappe.mn` -> tenant admin

## Scope
Minimal scoped change across:
- `app/api/admin/system-admin/route.ts` (new)
- `components/layout/navigation-rail.tsx`
- `app/(main)/admin/layout.tsx`