### PR TITLE
fix: route scheduled sends to the account that owns the submission

### DIFF
--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -67,7 +67,7 @@ import { toast } from "@/stores/toast-store";
 import { debug } from "@/lib/debug";
 import { AccountSwitcher } from "./account-switcher";
 import { useIsEmbedded } from "@/hooks/use-is-embedded";
-import { buildSettingsPath } from "@/lib/deep-links";
+import { buildSettingsPath, SCHEDULED_MAILBOX_ID, scopedScheduledMailboxId } from "@/lib/deep-links";
 import { useTour } from "@/components/tour/tour-provider";
 
 interface SidebarProps {
@@ -90,6 +90,12 @@ interface SidebarProps {
   onImportEmail?: (mailboxId: string) => void;
   onRefreshMailboxes?: () => void;
   scheduledTotal?: number;
+  /** Pending scheduled-send counts per JMAP account, for shared-account rows. */
+  scheduledTotalByAccount?: Record<string, number>;
+  /** JMAP account the scheduled view is currently narrowed to, if any. The
+   *  store keeps one virtual scheduled mailbox id, so the active shared row is
+   *  identified by this scope rather than by selectedMailbox alone. */
+  scheduledAccountScope?: string | null;
   showScheduledMailbox?: boolean;
   /** True when the unified view spans multiple login accounts (cross-account).
    *  Drives the section header: "All accounts" when true, else "Unified Mailbox". */
@@ -314,6 +320,7 @@ function SidebarRow({
       data-folder-name={testName ?? undefined}
       data-mailbox-id={testMailboxId ?? undefined}
       data-shared={testShared ? 'true' : undefined}
+      data-selected={isSelected ? 'true' : undefined}
       style={{ paddingBlock: 'var(--density-sidebar-py)' }}
       className={cn(
         "group w-full flex items-center max-lg:min-h-[44px] text-sm transition-colors duration-150",
@@ -783,6 +790,8 @@ export function Sidebar({
   onImportEmail,
   onRefreshMailboxes,
   scheduledTotal = 0,
+  scheduledTotalByAccount,
+  scheduledAccountScope = null,
   showScheduledMailbox = false,
   crossAccountActive = false,
   showCrossUnread = false,
@@ -989,21 +998,36 @@ export function Sidebar({
       })
     : [];
 
-  const renderScheduledRow = (key: string) => showScheduledMailbox ? (
-    <SidebarRow
-      key={key}
-      icon={<CalendarClock className="w-4 h-4 flex-shrink-0 text-sky-600 dark:text-sky-400" />}
-      label={t('scheduled')}
-      depth={0}
-      isSelected={!selectedKeyword && selectedMailbox === '__scheduled__'}
-      total={scheduledTotal}
-      onClick={() => onMailboxSelect?.('__scheduled__')}
-      isCollapsed={isCollapsed}
-      testRole="scheduled"
-      testName="scheduled"
-      testMailboxId="__scheduled__"
-    />
-  ) : null;
+  // Scheduled row. Without an account it is the combined view (the user's own
+  // tree); with one it scopes the list to that shared account's scheduled mail,
+  // which lives in the shared JMAP account rather than the primary one (#801).
+  const renderScheduledRow = (key: string, account?: { accountId?: string; depth?: number }) => {
+    if (!showScheduledMailbox) return null;
+    const accountId = account?.accountId;
+    const mailboxId = accountId ? scopedScheduledMailboxId(accountId) : SCHEDULED_MAILBOX_ID;
+    const count = accountId
+      ? (scheduledTotalByAccount?.[accountId] ?? 0)
+      : scheduledTotal;
+    // selectedMailbox is always the plain virtual id, so the *scope* decides
+    // which of these rows is the active one.
+    const isScheduledSelected = selectedMailbox === SCHEDULED_MAILBOX_ID
+      && (scheduledAccountScope ?? null) === (accountId ?? null);
+    return (
+      <SidebarRow
+        key={key}
+        icon={<CalendarClock className="w-4 h-4 flex-shrink-0 text-sky-600 dark:text-sky-400" />}
+        label={t('scheduled')}
+        depth={account?.depth ?? 0}
+        isSelected={!selectedKeyword && isScheduledSelected}
+        total={count}
+        onClick={() => onMailboxSelect?.(mailboxId)}
+        isCollapsed={isCollapsed}
+        testRole="scheduled"
+        testName="scheduled"
+        testMailboxId={mailboxId}
+      />
+    );
+  };
 
   const getUnifiedIcon = (role: UnifiedMailboxRole) => {
     switch (role) {
@@ -1362,20 +1386,29 @@ export function Sidebar({
                           ? (e) => handleSharedAccountContextMenu(e, menuAccountId)
                           : undefined}
                       />
-                      {accountExpanded && !isCollapsed && account.children.map((child) => (
-                        <MailboxTreeItem
-                          key={child.id}
-                          node={child}
-                          selectedMailbox={selectedKeyword ? "" : selectedMailbox}
-                          expandedFolders={expandedFolders}
-                          onMailboxSelect={onMailboxSelect}
-                          onToggleExpand={handleToggleExpand}
-                          isCollapsed={isCollapsed}
-                          onUnreadFilterClick={onUnreadFilterClick}
-                          colorful={colorfulSidebarIcons}
-                          onContextMenu={handleMailboxContextMenu}
-                        />
-                      ))}
+                      {accountExpanded && !isCollapsed && (
+                        <>
+                          {account.children.map((child) => (
+                            <Fragment key={child.id}>
+                              <MailboxTreeItem
+                                node={child}
+                                selectedMailbox={selectedKeyword ? "" : selectedMailbox}
+                                expandedFolders={expandedFolders}
+                                onMailboxSelect={onMailboxSelect}
+                                onToggleExpand={handleToggleExpand}
+                                isCollapsed={isCollapsed}
+                                onUnreadFilterClick={onUnreadFilterClick}
+                                colorful={colorfulSidebarIcons}
+                                onContextMenu={handleMailboxContextMenu}
+                              />
+                              {child.role === 'drafts' && menuAccountId
+                                && renderScheduledRow(`${account.id}-scheduled`, { accountId: menuAccountId })}
+                            </Fragment>
+                          ))}
+                          {menuAccountId && !account.children.some((child) => child.role === 'drafts')
+                            && renderScheduledRow(`${account.id}-scheduled`, { accountId: menuAccountId })}
+                        </>
+                      )}
                     </div>
                   );
                 })}

--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -99,6 +99,7 @@ import { buildForwardAsAttachmentPayload } from "@/lib/forward-as-attachment";
 import { getEffectiveLocale } from '@/i18n/detect-locale';
 import {
   SCHEDULED_MAILBOX_ID,
+  parseScheduledMailboxId,
   appPath,
   buildMailPath,
   parseMailPath,
@@ -366,9 +367,11 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
     unifiedRole,
     scheduledEmails,
     scheduledTotal,
+    scheduledTotalByAccount,
     scheduledHasMore,
     isLoadingScheduled,
     isScheduledView,
+    scheduledAccountScope,
     setScheduledView,
     fetchScheduledEmails,
     loadMoreScheduledEmails,
@@ -437,8 +440,23 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
   const showCrossUnread = enableUnifiedMailbox && crossUnreadGate && enableCrossUnreadView;
   const showCrossStarred = enableUnifiedMailbox && crossStarredGate && enableCrossStarredView;
   const showCrossAll = enableUnifiedMailbox && crossAllGate && enableCrossAllView;
-  const activeEmails = isScheduledView ? scheduledEmails : emails;
-  const activeHasMore = isScheduledView ? scheduledHasMore : hasMoreEmails;
+  // A shared account's "Scheduled" row narrows the (account-aggregated)
+  // scheduled list to that account; the own row shows everything.
+  const scopedScheduledEmails = useMemo(
+    () => scheduledAccountScope
+      ? scheduledEmails.filter(email => email.scheduledAccountId === scheduledAccountScope)
+      : scheduledEmails,
+    [scheduledEmails, scheduledAccountScope],
+  );
+  const activeEmails = isScheduledView ? scopedScheduledEmails : emails;
+  // In an account-scoped scheduled view the visible rows are a filtered subset
+  // of the loaded page, so "has more" must reflect that account's own total
+  // rather than the combined one — otherwise the list looks complete while
+  // later pages still hold mail for this account (or vice versa).
+  const scopedScheduledHasMore = scheduledAccountScope
+    ? scopedScheduledEmails.length < (scheduledTotalByAccount?.[scheduledAccountScope] ?? 0)
+    : scheduledHasMore;
+  const activeHasMore = isScheduledView ? scopedScheduledHasMore : hasMoreEmails;
   const activeIsLoading = isScheduledView ? isLoadingScheduled : isLoading;
   const includeGroupInUnified = useSettingsStore((s) => s.includeGroupInUnified);
   const unifiedCrossAccount = useSettingsStore((s) => s.unifiedCrossAccount);
@@ -1789,6 +1807,8 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
                     pending.emailId!,
                     pending.identityId!,
                     new Date(Date.now() + 1000).toISOString(),
+                    // Shared-identity sends live in the shared account (#801).
+                    pending.submissionAccountId,
                   );
                   clearPendingUndoSend();
                   if (isScheduledView) await fetchScheduledEmails(client);
@@ -2262,14 +2282,17 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
   };
 
   const handleMailboxSelect = async (mailboxId: string) => {
-    if (mailboxId === SCHEDULED_MAILBOX_ID) {
+    // A shared account's Scheduled row arrives as "__scheduled__:<accountId>";
+    // the store only ever sees the plain virtual id plus the account scope.
+    const scheduledSelection = parseScheduledMailboxId(mailboxId);
+    if (scheduledSelection.isScheduled) {
       if (!delayedSendSupported) {
         setScheduledView(false);
         return;
       }
       if (isUnifiedView) exitUnifiedView();
-      setScheduledView(true);
-      selectMailbox(mailboxId);
+      setScheduledView(true, scheduledSelection.accountId);
+      selectMailbox(SCHEDULED_MAILBOX_ID);
       selectEmail(null);
       clearSelection();
       if (isMobile) {
@@ -3261,6 +3284,8 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
               selectedMailbox={selectedMailbox}
               selectedKeyword={selectedKeyword}
               scheduledTotal={scheduledTotal}
+              scheduledTotalByAccount={scheduledTotalByAccount}
+              scheduledAccountScope={scheduledAccountScope}
               showScheduledMailbox={delayedSendSupported}
               crossAccountActive={crossAccountActive}
               showCrossUnread={showCrossUnread}

--- a/integration/tests/11-shared-scheduled-send.spec.ts
+++ b/integration/tests/11-shared-scheduled-send.spec.ts
@@ -1,0 +1,181 @@
+import { test, expect } from '@playwright/test';
+import { ACCOUNTS, GROUP } from './helpers/config';
+import { JmapClient } from './helpers/jmap';
+import { login, forceSync, folderRow, expandSharedFolders } from './helpers/app';
+
+/**
+ * Issue #801 — a delayed ("scheduled") send composed from a shared/group
+ * identity is created in the *shared* JMAP account, because sendEmail routes
+ * the EmailSubmission to the identity's account. Every read/write on the
+ * scheduled surface, however, asked the *primary* submission account only:
+ *
+ *   getScheduledEmails / cancelEmailSubmission / rescheduleEmailSubmission
+ *       -> getSubmissionAccountId()   // no argument = primary account
+ *
+ * The message is therefore accepted and stays pending on the server — it *will*
+ * be delivered at sendAt — while the UI cannot list it, cancel it, or
+ * reschedule it. Silent unrecallable mail, which is worse than a failed send.
+ *
+ * Stalwart advertises `urn:ietf:params:jmap:submission` (with FUTURERELEASE) on
+ * group accounts as well as personal ones, so scheduling from a shared address
+ * is legitimate and expected to work.
+ */
+const member = ACCOUNTS[GROUP.team.memberOf];
+const { team } = GROUP;
+
+/** Six hours out: comfortably inside Stalwart's maxDelayedSend (30 days). */
+function sendAtSoon(): { iso: string; holdFor: number } {
+  const holdFor = 6 * 60 * 60;
+  return { iso: new Date(Date.now() + holdFor * 1000).toISOString(), holdFor };
+}
+
+async function scheduleFromShared(client: JmapClient, subject: string) {
+  const sharedAccountId = client.accountIdByName(team.email);
+
+  const identityRes = await client.request([
+    ['Identity/get', { accountId: sharedAccountId }, '0'],
+  ]);
+  const identityId = (identityRes.methodResponses[0][1].list as Array<{ id: string; email: string }>)
+    .find((i) => i.email === team.email)!.id;
+
+  const mailboxRes = await client.request([['Mailbox/get', { accountId: sharedAccountId }, '0']]);
+  const draftsId = (mailboxRes.methodResponses[0][1].list as Array<{ id: string; role: string | null }>)
+    .find((m) => m.role === 'drafts')!.id;
+
+  const { holdFor } = sendAtSoon();
+  const res = await client.request([
+    ['Email/set', {
+      accountId: sharedAccountId,
+      create: {
+        e1: {
+          mailboxIds: { [draftsId]: true },
+          keywords: { $draft: true },
+          from: [{ email: team.email }],
+          to: [{ email: ACCOUNTS.bob.email }],
+          subject,
+          bodyValues: { '1': { value: 'scheduled from a shared identity' } },
+          textBody: [{ partId: '1', type: 'text/plain' }],
+        },
+      },
+    }, '0'],
+    ['EmailSubmission/set', {
+      accountId: sharedAccountId,
+      create: {
+        s1: {
+          emailId: '#e1',
+          identityId,
+          envelope: {
+            mailFrom: { email: team.email, parameters: { HOLDFOR: String(holdFor) } },
+            rcptTo: [{ email: ACCOUNTS.bob.email }],
+          },
+        },
+      },
+    }, '1'],
+  ]);
+
+  const created = res.methodResponses[1][1].created?.s1;
+  expect(res.methodResponses[1][1].notCreated ?? null).toBeNull();
+  expect(created?.id).toBeTruthy();
+  return { sharedAccountId, submissionId: created.id as string };
+}
+
+test.describe('Scheduled send from a shared account (issue #801)', () => {
+  test('the shared account advertises delayed send in its own right', async () => {
+    // Guard for everything below: if Stalwart stopped exposing submission on
+    // group accounts, the bug and the fix are both moot.
+    const client = await JmapClient.connect(member.email, member.password);
+    const sharedAccountId = client.accountIdByName(team.email);
+    const session = await client.sessionAccountCapabilities(sharedAccountId);
+    const submission = session['urn:ietf:params:jmap:submission'] as
+      | { maxDelayedSend?: number; submissionExtensions?: Record<string, unknown> }
+      | undefined;
+
+    expect(submission, 'shared account exposes submission').toBeTruthy();
+    expect(submission!.maxDelayedSend ?? 0).toBeGreaterThan(0);
+    expect(Object.keys(submission!.submissionExtensions ?? {})).toContain('FUTURERELEASE');
+  });
+
+  test('a shared-account submission is invisible to the primary account', async () => {
+    // Server-truth control: this is the whole mechanism of the bug, independent
+    // of the app. The submission exists — but not where the app used to look.
+    const client = await JmapClient.connect(member.email, member.password);
+    const { sharedAccountId, submissionId } = await scheduleFromShared(client, `it-801-server-${Date.now()}`);
+
+    const inShared = await client.request([
+      ['EmailSubmission/get', { accountId: sharedAccountId, ids: [submissionId], properties: ['id', 'undoStatus'] }, '0'],
+    ]);
+    expect(inShared.methodResponses[0][1].list).toHaveLength(1);
+    expect(inShared.methodResponses[0][1].list[0].undoStatus).toBe('pending');
+
+    const inPrimary = await client.request([
+      ['EmailSubmission/get', { accountId: client.accountId, ids: [submissionId], properties: ['id'] }, '0'],
+    ]);
+    expect(inPrimary.methodResponses[0][1].list).toHaveLength(0);
+    expect(inPrimary.methodResponses[0][1].notFound).toContain(submissionId);
+
+    // ...and cancelling it through the primary account is a no-op that reports
+    // no error to the user, which is why the mail used to go out anyway.
+    const badCancel = await client.request([
+      ['EmailSubmission/set', { accountId: client.accountId, update: { [submissionId]: { undoStatus: 'canceled' } } }, '0'],
+    ]);
+    expect(badCancel.methodResponses[0][1].updated ?? null).toBeNull();
+    expect(badCancel.methodResponses[0][1].notUpdated?.[submissionId]?.type).toBe('notFound');
+
+    // Clean up through the owning account so the mail never leaves.
+    await client.request([
+      ['EmailSubmission/set', { accountId: sharedAccountId, update: { [submissionId]: { undoStatus: 'canceled' } } }, '0'],
+    ]);
+  });
+
+  test('the Scheduled view lists mail scheduled from the shared account', async ({ page }) => {
+    const client = await JmapClient.connect(member.email, member.password);
+    const subject = `it-801-ui-${Date.now()}`;
+    const { sharedAccountId, submissionId } = await scheduleFromShared(client, subject);
+
+    try {
+      await login(page, member);
+      await forceSync(page);
+
+      // The user's own Scheduled folder aggregates every submission account she
+      // can reach, so the shared message shows up there. Before the fix this
+      // list only ever queried her primary account and stayed empty.
+      await folderRow(page, { role: 'scheduled' }).click();
+      await expect(page.getByText(subject)).toBeVisible({ timeout: 30000 });
+    } finally {
+      await client.request([
+        ['EmailSubmission/set', { accountId: sharedAccountId, update: { [submissionId]: { undoStatus: 'canceled' } } }, '0'],
+      ]);
+    }
+  });
+
+  test('the shared account gets its own Scheduled row, scoped to its mail', async ({ page }) => {
+    const client = await JmapClient.connect(member.email, member.password);
+    const subject = `it-801-scope-${Date.now()}`;
+    const { sharedAccountId, submissionId } = await scheduleFromShared(client, subject);
+
+    try {
+      await login(page, member);
+      await forceSync(page);
+      await expandSharedFolders(page, team.email);
+
+      const sharedScheduled = page.locator(`[data-mailbox-id="__scheduled__:${sharedAccountId}"]`);
+      await expect(sharedScheduled).toBeVisible({ timeout: 30000 });
+
+      await sharedScheduled.click();
+      await expect(page.getByText(subject)).toBeVisible({ timeout: 30000 });
+
+      // The clicked row must be the highlighted one. The store keeps a single
+      // virtual "__scheduled__" mailbox id for both rows, so selection is
+      // driven by the account scope — get that wrong and the user's own
+      // Scheduled row lights up while the shared one's list is shown.
+      await expect(sharedScheduled).toHaveAttribute('data-selected', 'true');
+      await expect(
+        page.locator('[data-mailbox-id="__scheduled__"]'),
+      ).not.toHaveAttribute('data-selected', 'true');
+    } finally {
+      await client.request([
+        ['EmailSubmission/set', { accountId: sharedAccountId, update: { [submissionId]: { undoStatus: 'canceled' } } }, '0'],
+      ]);
+    }
+  });
+});

--- a/integration/tests/helpers/jmap.ts
+++ b/integration/tests/helpers/jmap.ts
@@ -76,6 +76,18 @@ export class JmapClient {
     return c;
   }
 
+  /**
+   * `accountCapabilities` of one account as advertised in the JMAP session.
+   * Read live rather than cached at connect(), so a test can assert on what
+   * the server says about a shared account (e.g. delayed-send support).
+   */
+  async sessionAccountCapabilities(accountId: string): Promise<Record<string, unknown>> {
+    const res = await fetch(`${JMAP_URL}/jmap/session`, { headers: { Authorization: this.authHeader } });
+    if (!res.ok) throw new Error(`JMAP session failed: ${res.status}`);
+    const session = await res.json();
+    return session.accounts?.[accountId]?.accountCapabilities ?? {};
+  }
+
   /** Names (email addresses) of the shared/group accounts this user can access,
    *  i.e. everything in the session except the user's own primary account. */
   sharedAccountNames(): string[] {

--- a/lib/deep-links.ts
+++ b/lib/deep-links.ts
@@ -32,6 +32,23 @@ import type { CalendarViewMode } from '@/stores/calendar-store';
 /** Sentinel mailbox id for the virtual "Scheduled" view (see the mail page). */
 export const SCHEDULED_MAILBOX_ID = '__scheduled__';
 
+/**
+ * Sidebar-only id for a shared account's "Scheduled" row. The store keeps a
+ * single virtual scheduled mailbox (SCHEDULED_MAILBOX_ID); the account is
+ * carried alongside it as a view scope, so this suffixed form never reaches
+ * the store or a deep link.
+ */
+export const scopedScheduledMailboxId = (accountId: string) => `${SCHEDULED_MAILBOX_ID}:${accountId}`;
+
+/** Splits a (possibly account-scoped) scheduled id into its parts. */
+export function parseScheduledMailboxId(mailboxId: string): { isScheduled: boolean; accountId: string | null } {
+  if (mailboxId === SCHEDULED_MAILBOX_ID) return { isScheduled: true, accountId: null };
+  if (mailboxId.startsWith(`${SCHEDULED_MAILBOX_ID}:`)) {
+    return { isScheduled: true, accountId: mailboxId.slice(SCHEDULED_MAILBOX_ID.length + 1) || null };
+  }
+  return { isScheduled: false, accountId: null };
+}
+
 // ---------------------------------------------------------------------------
 // URL assembly
 // ---------------------------------------------------------------------------

--- a/lib/jmap/client-interface.ts
+++ b/lib/jmap/client-interface.ts
@@ -234,9 +234,9 @@ export interface IJMAPClient {
 
   sendRawEmail(blob: Blob, identityId: string, sentMailboxId: string, draftMailboxId?: string, delayedUntil?: string, envelopeRecipients?: string[]): Promise<SendEmailResult>;
   submitRawEmail(blob: Blob, identityId: string, delayedUntil?: string, envelopeRecipients?: string[]): Promise<SendEmailResult>;
-  getScheduledEmails(limit?: number, position?: number): Promise<{ emails: ScheduledEmail[]; hasMore: boolean; total: number; nextPosition: number }>;
-  cancelEmailSubmission(submissionId: string): Promise<void>;
-  rescheduleEmailSubmission(submissionId: string, emailId: string, identityId: string, delayedUntil: string): Promise<SendEmailResult>;
+  getScheduledEmails(limit?: number, position?: number): Promise<{ emails: ScheduledEmail[]; hasMore: boolean; total: number; totalByAccount?: Record<string, number>; nextPosition: number }>;
+  cancelEmailSubmission(submissionId: string, accountId?: string): Promise<void>;
+  rescheduleEmailSubmission(submissionId: string, emailId: string, identityId: string, delayedUntil: string, accountId?: string): Promise<SendEmailResult>;
   /** `sentMailboxId` is accepted for backwards compatibility but ignored: the message is placed in Drafts only. */
   restoreEmailToDraft(emailId: string, draftMailboxId: string, sentMailboxId?: string): Promise<void>;
 

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -3084,13 +3084,18 @@ export class JMAPClient implements IJMAPClient {
       }
     }
 
+    // The account the submission was created in — the shared account when
+    // sending from a shared identity. Returned so undo/send-now can address it
+    // directly instead of searching for it. See #801.
+    const submissionAccountId = this.getSubmissionAccountId(targetAccountId);
+
     if (delayedUntil && emailSubmissionId && !serverSendAt) {
-      serverSendAt = await this.getEmailSubmissionSendAt(emailSubmissionId);
+      serverSendAt = await this.getEmailSubmissionSendAt(emailSubmissionId, submissionAccountId);
     }
 
     return delayedUntil
-      ? { scheduled: true, emailId: createdEmailId, emailSubmissionId, sendAt: serverSendAt, filingError }
-      : { scheduled: false, emailId: createdEmailId, emailSubmissionId, filingError };
+      ? { scheduled: true, emailId: createdEmailId, emailSubmissionId, sendAt: serverSendAt, submissionAccountId, filingError }
+      : { scheduled: false, emailId: createdEmailId, emailSubmissionId, submissionAccountId, filingError };
   }
 
   /**
@@ -3950,10 +3955,10 @@ export class JMAPClient implements IJMAPClient {
     return Math.ceil((time - now) / 1000);
   }
 
-  private async getEmailSubmissionSendAt(submissionId: string): Promise<string | undefined> {
+  private async getEmailSubmissionSendAt(submissionId: string, accountId?: string): Promise<string | undefined> {
     const response = await this.request([
       ['EmailSubmission/get', {
-        accountId: this.getSubmissionAccountId(),
+        accountId: accountId ?? await this.resolveSubmissionAccountId(submissionId),
         ids: [submissionId],
         properties: ['sendAt', 'undoStatus'],
       }, '0'],
@@ -3962,10 +3967,10 @@ export class JMAPClient implements IJMAPClient {
     return submission?.sendAt;
   }
 
-  private async getEmailSubmissionEnvelope(submissionId: string): Promise<{ rcptTo?: Array<{ email: string }> } | undefined> {
+  private async getEmailSubmissionEnvelope(submissionId: string, accountId?: string): Promise<{ rcptTo?: Array<{ email: string }> } | undefined> {
     const response = await this.request([
       ['EmailSubmission/get', {
-        accountId: this.getSubmissionAccountId(),
+        accountId: accountId ?? await this.resolveSubmissionAccountId(submissionId),
         ids: [submissionId],
         properties: ['envelope'],
       }, '0'],
@@ -3985,6 +3990,52 @@ export class JMAPClient implements IJMAPClient {
       return accountId;
     }
     return submissionPrimary || accountId || this.accountId;
+  }
+
+  /**
+   * Every account whose submissions this session can see: the primary
+   * submission account plus each shared/group account that advertises the
+   * submission capability in its own right.
+   *
+   * A delayed send composed from a shared identity is created in the *shared*
+   * account (sendEmail passes the target account to getSubmissionAccountId),
+   * so a scheduled-mail lookup that only ever asks the primary account misses
+   * it entirely: the message stays pending on the server and goes out at
+   * sendAt, but the UI cannot list, cancel or reschedule it. See #801.
+   */
+  private getSubmissionAccountIds(): string[] {
+    const ids: string[] = [];
+    const primary = this.getSubmissionAccountId();
+    if (primary) ids.push(primary);
+    for (const [accountId, account] of Object.entries(this.session?.accounts ?? {})) {
+      if (ids.includes(accountId)) continue;
+      if (account?.accountCapabilities?.['urn:ietf:params:jmap:submission']) ids.push(accountId);
+    }
+    return ids;
+  }
+
+  /**
+   * Locate the account that actually holds a submission. Shared-account
+   * submissions are invisible to (and not updatable through) the primary
+   * account, which answers `notFound`. Resolved by asking each submission
+   * account in turn, primary first.
+   */
+  private async resolveSubmissionAccountId(submissionId: string): Promise<string> {
+    const accountIds = this.getSubmissionAccountIds();
+    if (accountIds.length <= 1) return accountIds[0] ?? this.getSubmissionAccountId();
+    for (const accountId of accountIds) {
+      try {
+        const response = await this.request([
+          ['EmailSubmission/get', { accountId, ids: [submissionId], properties: ['id'] }, '0'],
+        ]);
+        const list = response.methodResponses?.[0]?.[1]?.list as Array<{ id?: string }> | undefined;
+        if (list?.length) return accountId;
+      } catch {
+        // An account that cannot answer for this submission is simply not the
+        // owner; keep looking rather than failing the whole operation.
+      }
+    }
+    return this.getSubmissionAccountId();
   }
 
   private getSubmissionCapability(accountId?: string): SubmissionCapability | undefined {
@@ -7087,13 +7138,17 @@ export class JMAPClient implements IJMAPClient {
       }
     }
 
+    // These raw/S-MIME paths submit through the primary submission account, so
+    // report that as the owning account rather than leaving it unset.
+    const submissionAccountId = this.getSubmissionAccountId();
+
     if (delayedUntil && emailSubmissionId && !serverSendAt) {
-      serverSendAt = await this.getEmailSubmissionSendAt(emailSubmissionId);
+      serverSendAt = await this.getEmailSubmissionSendAt(emailSubmissionId, submissionAccountId);
     }
 
     return delayedUntil
-      ? { scheduled: true, emailId, emailSubmissionId, sendAt: serverSendAt, isSmime: true }
-      : { scheduled: false, emailId, emailSubmissionId, isSmime: true };
+      ? { scheduled: true, emailId, emailSubmissionId, sendAt: serverSendAt, submissionAccountId, isSmime: true }
+      : { scheduled: false, emailId, emailSubmissionId, submissionAccountId, isSmime: true };
   }
 
   /**
@@ -7167,84 +7222,121 @@ export class JMAPClient implements IJMAPClient {
       }
     }
 
+    const submissionAccountId = this.getSubmissionAccountId();
+
     if (delayedUntil && emailSubmissionId && !serverSendAt) {
-      serverSendAt = await this.getEmailSubmissionSendAt(emailSubmissionId);
+      serverSendAt = await this.getEmailSubmissionSendAt(emailSubmissionId, submissionAccountId);
     }
 
     return delayedUntil
-      ? { scheduled: true, emailSubmissionId, sendAt: serverSendAt, isSmime: true }
-      : { scheduled: false, emailSubmissionId, isSmime: true };
+      ? { scheduled: true, emailSubmissionId, sendAt: serverSendAt, submissionAccountId, isSmime: true }
+      : { scheduled: false, emailSubmissionId, submissionAccountId, isSmime: true };
   }
 
-  async getScheduledEmails(limit = 50, position = 0): Promise<{ emails: ScheduledEmail[]; hasMore: boolean; total: number; nextPosition: number }> {
-    if (!this.hasDelayedSend()) {
+  async getScheduledEmails(limit = 50, position = 0): Promise<{ emails: ScheduledEmail[]; hasMore: boolean; total: number; totalByAccount?: Record<string, number>; nextPosition: number }> {
+    // Scheduled mail composed from a shared identity lives in the shared
+    // account, so gate on *any* reachable submission account supporting
+    // delayed send rather than only the primary one.
+    const submissionAccountIds = this.getSubmissionAccountIds()
+      .filter(accountId => this.hasDelayedSend(accountId));
+    if (submissionAccountIds.length === 0) {
       return { emails: [], hasMore: false, total: 0, nextPosition: position };
     }
 
     const now = Date.now();
     const pageSize = Math.max(limit, 50);
     const submissions: EmailSubmission[] = [];
-    let rawPosition = 0;
-    let rawTotal = 0;
+    // Which account each submission came from — needed to fetch its Email from
+    // the right account below, and to route later cancel/reschedule calls.
+    const accountBySubmissionId = new Map<string, string>();
 
-    do {
-      const queryResponse = await this.request([
-        ['EmailSubmission/query', {
-          accountId: this.getSubmissionAccountId(),
-          limit: pageSize,
-          position: rawPosition,
-        }, '0'],
-      ]);
+    for (const submissionAccountId of submissionAccountIds) {
+      let rawPosition = 0;
+      let rawTotal = 0;
 
-      const query = queryResponse.methodResponses?.[0]?.[1] as { ids?: string[]; total?: number; position?: number } | undefined;
-      const ids = query?.ids ?? [];
-      rawTotal = query?.total ?? rawPosition + ids.length;
-      if (ids.length === 0) break;
+      do {
+        const queryResponse = await this.request([
+          ['EmailSubmission/query', {
+            accountId: submissionAccountId,
+            limit: pageSize,
+            position: rawPosition,
+          }, '0'],
+        ]);
 
-      const submissionResponse = await this.request([
-        ['EmailSubmission/get', {
-          accountId: this.getSubmissionAccountId(),
-          ids,
-          properties: ['id', 'emailId', 'identityId', 'threadId', 'sendAt', 'undoStatus', 'deliveryStatus'],
-        }, '0'],
-      ]);
+        const query = queryResponse.methodResponses?.[0]?.[1] as { ids?: string[]; total?: number; position?: number } | undefined;
+        const ids = query?.ids ?? [];
+        rawTotal = query?.total ?? rawPosition + ids.length;
+        if (ids.length === 0) break;
 
-      submissions.push(...((submissionResponse.methodResponses?.[0]?.[1]?.list ?? []) as EmailSubmission[])
-        .filter(submission => {
-          if (submission.undoStatus !== 'pending' || !submission.sendAt) return false;
-          const sendAtTime = new Date(submission.sendAt).getTime();
-          return Number.isFinite(sendAtTime) && sendAtTime > now;
-        }));
+        const submissionResponse = await this.request([
+          ['EmailSubmission/get', {
+            accountId: submissionAccountId,
+            ids,
+            properties: ['id', 'emailId', 'identityId', 'threadId', 'sendAt', 'undoStatus', 'deliveryStatus'],
+          }, '0'],
+        ]);
 
-      rawPosition += ids.length;
-    } while (rawPosition < rawTotal);
+        const pending = ((submissionResponse.methodResponses?.[0]?.[1]?.list ?? []) as EmailSubmission[])
+          .filter(submission => {
+            if (submission.undoStatus !== 'pending' || !submission.sendAt) return false;
+            const sendAtTime = new Date(submission.sendAt).getTime();
+            return Number.isFinite(sendAtTime) && sendAtTime > now;
+          });
+        for (const submission of pending) accountBySubmissionId.set(submission.id, submissionAccountId);
+        submissions.push(...pending);
+
+        rawPosition += ids.length;
+      } while (rawPosition < rawTotal);
+    }
 
     submissions.sort((a, b) => new Date(a.sendAt || '').getTime() - new Date(b.sendAt || '').getTime());
     const total = submissions.length;
+    // Per-account totals over ALL pending submissions, not just the page below,
+    // so a shared account's badge stays correct past the first page.
+    const totalByAccount: Record<string, number> = {};
+    for (const submission of submissions) {
+      const accountId = accountBySubmissionId.get(submission.id);
+      if (accountId) totalByAccount[accountId] = (totalByAccount[accountId] ?? 0) + 1;
+    }
     const pageSubmissions = submissions.slice(position, position + limit);
     const nextPosition = position + pageSubmissions.length;
 
     if (pageSubmissions.length === 0) {
-      return { emails: [], hasMore: false, total, nextPosition };
+      return { emails: [], hasMore: false, total, totalByAccount, nextPosition };
     }
 
-    const emailResponse = await this.request([
-      ['Email/get', {
-        accountId: this.accountId,
-        ids: pageSubmissions.map(submission => submission.emailId),
-        properties: [
-          'id', 'threadId', 'mailboxIds', 'keywords', 'size', 'receivedAt', 'from', 'to', 'cc', 'bcc', 'replyTo',
-          'subject', 'preview', 'textBody', 'htmlBody', 'bodyValues', 'attachments', 'hasAttachment', 'sentAt',
-          'messageId', 'inReplyTo', 'references', 'headers', 'blobId', 'bodyStructure',
-        ],
-        fetchTextBodyValues: true,
-        fetchHTMLBodyValues: true,
-        fetchAllBodyValues: true,
-        maxBodyValueBytes: 256000,
-      }, '0'],
-    ]);
+    // The submission's Email lives in the same account as the submission, so a
+    // shared-account scheduled message must be fetched from there — asking the
+    // primary account returns nothing and the row would be dropped below.
+    const emailIdsByAccount = new Map<string, string[]>();
+    for (const submission of pageSubmissions) {
+      const accountId = accountBySubmissionId.get(submission.id) ?? this.accountId;
+      const bucket = emailIdsByAccount.get(accountId);
+      if (bucket) bucket.push(submission.emailId);
+      else emailIdsByAccount.set(accountId, [submission.emailId]);
+    }
 
-    const emailById = new Map(((emailResponse.methodResponses?.[0]?.[1]?.list ?? []) as Email[]).map(email => [email.id, email]));
+    const emailById = new Map<string, Email>();
+    for (const [accountId, ids] of emailIdsByAccount) {
+      const emailResponse = await this.request([
+        ['Email/get', {
+          accountId,
+          ids,
+          properties: [
+            'id', 'threadId', 'mailboxIds', 'keywords', 'size', 'receivedAt', 'from', 'to', 'cc', 'bcc', 'replyTo',
+            'subject', 'preview', 'textBody', 'htmlBody', 'bodyValues', 'attachments', 'hasAttachment', 'sentAt',
+            'messageId', 'inReplyTo', 'references', 'headers', 'blobId', 'bodyStructure',
+          ],
+          fetchTextBodyValues: true,
+          fetchHTMLBodyValues: true,
+          fetchAllBodyValues: true,
+          maxBodyValueBytes: 256000,
+        }, '0'],
+      ]);
+      for (const email of ((emailResponse.methodResponses?.[0]?.[1]?.list ?? []) as Email[])) {
+        emailById.set(email.id, email);
+      }
+    }
     const emails = pageSubmissions
       .map((submission): ScheduledEmail | null => {
         const email = emailById.get(submission.emailId);
@@ -7257,6 +7349,7 @@ export class JMAPClient implements IJMAPClient {
           scheduledIdentityId: submission.identityId,
           scheduledUndoStatus: submission.undoStatus,
           scheduledDeliveryStatus: submission.deliveryStatus,
+          scheduledAccountId: accountBySubmissionId.get(submission.id),
           isScheduled: true,
           isSmimeScheduled: isSmimeEmail(email),
         };
@@ -7264,13 +7357,17 @@ export class JMAPClient implements IJMAPClient {
       .filter((email): email is ScheduledEmail => email !== null)
       .sort((a, b) => new Date(a.scheduledSendAt).getTime() - new Date(b.scheduledSendAt).getTime());
 
-    return { emails, hasMore: nextPosition < total, total, nextPosition };
+    return { emails, hasMore: nextPosition < total, total, totalByAccount, nextPosition };
   }
 
-  async cancelEmailSubmission(submissionId: string): Promise<void> {
+  async cancelEmailSubmission(submissionId: string, accountId?: string): Promise<void> {
+    // A submission created from a shared identity belongs to the shared
+    // account; cancelling it through the primary account answers `notFound`
+    // and the message would still go out. See #801.
+    const submissionAccountId = accountId ?? await this.resolveSubmissionAccountId(submissionId);
     const response = await this.request([
       ['EmailSubmission/set', {
-        accountId: this.getSubmissionAccountId(),
+        accountId: submissionAccountId,
         update: { [submissionId]: { undoStatus: 'canceled' } },
       }, '0'],
     ]);
@@ -7281,14 +7378,18 @@ export class JMAPClient implements IJMAPClient {
     }
   }
 
-  async rescheduleEmailSubmission(submissionId: string, emailId: string, identityId: string, delayedUntil: string): Promise<SendEmailResult> {
-    const holdForSeconds = this.validateDelayedUntil(delayedUntil);
-    const mailboxes = await this.getMailboxes();
+  async rescheduleEmailSubmission(submissionId: string, emailId: string, identityId: string, delayedUntil: string, accountId?: string): Promise<SendEmailResult> {
+    // Keep the replacement in the same account as the original: a shared
+    // submission rescheduled through the primary account would be recreated
+    // in the wrong account (and the original left running). See #801.
+    const submissionAccountId = accountId ?? await this.resolveSubmissionAccountId(submissionId);
+    const holdForSeconds = this.validateDelayedUntil(delayedUntil, submissionAccountId);
+    const mailboxes = await this.getMailboxes(submissionAccountId);
     const draftsMailbox = mailboxes.find(mb => mb.role === 'drafts');
     const sentMailbox = mailboxes.find(mb => mb.role === 'sent');
     const identities = await this.getIdentities();
     const identity = identities.find(item => item.id === identityId);
-    const existingEnvelope = await this.getEmailSubmissionEnvelope(submissionId);
+    const existingEnvelope = await this.getEmailSubmissionEnvelope(submissionId, submissionAccountId);
     const email = existingEnvelope?.rcptTo?.length ? undefined : await this.getEmail(emailId);
     const envelopeRecipients = existingEnvelope?.rcptTo?.length
       ? existingEnvelope.rcptTo
@@ -7296,7 +7397,7 @@ export class JMAPClient implements IJMAPClient {
     const envelope = createDelayedSubmissionEnvelope(identity?.email || this.username, holdForSeconds, envelopeRecipients);
     const response = await this.request([
       ['EmailSubmission/set', {
-        accountId: this.getSubmissionAccountId(),
+        accountId: submissionAccountId,
         create: { replacement: { emailId, identityId, ...(envelope ? { envelope } : {}) } },
         ...(draftsMailbox && sentMailbox ? {
           onSuccessUpdateEmail: {
@@ -7318,12 +7419,12 @@ export class JMAPClient implements IJMAPClient {
     if (!replacementId) {
       throw new Error('Server did not return a replacement scheduled send ID');
     }
-    const finalSendAt = serverSendAt || await this.getEmailSubmissionSendAt(replacementId);
+    const finalSendAt = serverSendAt || await this.getEmailSubmissionSendAt(replacementId, submissionAccountId);
     try {
-      await this.cancelEmailSubmission(submissionId);
+      await this.cancelEmailSubmission(submissionId, submissionAccountId);
     } catch (error) {
       try {
-        await this.cancelEmailSubmission(replacementId);
+        await this.cancelEmailSubmission(replacementId, submissionAccountId);
       } catch (cleanupError) {
         console.error('Failed to clean up replacement scheduled send after reschedule failure:', cleanupError);
       }

--- a/lib/jmap/types.ts
+++ b/lib/jmap/types.ts
@@ -85,6 +85,12 @@ export interface Email {
   scheduledIdentityId?: string;
   scheduledUndoStatus?: 'pending' | 'final' | 'canceled';
   scheduledDeliveryStatus?: Record<string, DeliveryStatus>;
+  /**
+   * JMAP account that owns the EmailSubmission. Set when the scheduled send
+   * lives in a shared/group account rather than the primary submission
+   * account, so cancel/reschedule can be routed back to it.
+   */
+  scheduledAccountId?: string;
   isScheduled?: boolean;
   isSmimeScheduled?: boolean;
 }
@@ -95,6 +101,13 @@ export interface SendEmailResult {
   emailSubmissionId?: string;
   sendAt?: string;
   isSmime?: boolean;
+  /**
+   * JMAP account the EmailSubmission was created in. Differs from the primary
+   * submission account when sending from a shared/group identity, and lets a
+   * later undo / send-now / cancel address the right account without having to
+   * search for it.
+   */
+  submissionAccountId?: string;
   /**
    * Set when the submission succeeded but a post-send step was rejected
    * (the implicit onSuccessUpdateEmail filing patch, or destroying the
@@ -109,6 +122,7 @@ export interface ScheduledEmail extends Email {
   scheduledIdentityId: string;
   scheduledUndoStatus: 'pending' | 'final' | 'canceled';
   scheduledDeliveryStatus?: Record<string, DeliveryStatus>;
+  scheduledAccountId?: string;
   isScheduled: true;
   isSmimeScheduled: boolean;
 }

--- a/stores/email-store.ts
+++ b/stores/email-store.ts
@@ -18,6 +18,8 @@ type ScheduledSubmissionMetadata = {
   sendAt: string;
   identityId: string;
   undoStatus: 'pending' | 'final' | 'canceled';
+  /** Owning JMAP account when the submission lives in a shared account. */
+  accountId?: string;
 };
 
 const VIRTUAL_SCHEDULED_MAILBOX_ID = '__scheduled__';
@@ -31,6 +33,10 @@ type PendingUndoSend = {
   /** Local account that owns the submission, when the message was sent from
    *  an identity belonging to a non-active account (#461). */
   localAccountId?: string;
+  /** JMAP account holding the submission — the shared account when the message
+   *  was sent from a shared identity (#801). Distinct from localAccountId,
+   *  which selects *which login's client* to talk to. */
+  submissionAccountId?: string;
 };
 
 interface EmailStore {
@@ -127,8 +133,15 @@ interface EmailStore {
   scheduledTotal: number;
   scheduledHasMore: boolean;
   scheduledNextPosition: number;
+  /** Pending scheduled-send counts per JMAP account (server-side, all pages). */
+  scheduledTotalByAccount: Record<string, number>;
   isLoadingScheduled: boolean;
   isScheduledView: boolean;
+  /**
+   * When set, the scheduled view is narrowed to one JMAP account — the shared
+   * account whose "Scheduled" row was clicked. null = the combined view.
+   */
+  scheduledAccountScope: string | null;
   pendingUndoSend: PendingUndoSend | null;
 
   setEmails: (emails: Email[]) => void;
@@ -282,7 +295,7 @@ interface EmailStore {
   cancelUndoSend: (client: IJMAPClient, pending: PendingUndoSend) => Promise<Email | null>;
   clearPendingUndoSend: () => void;
   refreshScheduledMetadata: (client: IJMAPClient) => Promise<void>;
-  setScheduledView: (isScheduledView: boolean) => void;
+  setScheduledView: (isScheduledView: boolean, accountScope?: string | null) => void;
 
   // Mock data for demo
   loadMockData: () => void;
@@ -338,6 +351,7 @@ function annotateScheduledEmail(
     emailSubmissionId: scheduled.submissionId,
     scheduledIdentityId: scheduled.identityId,
     scheduledUndoStatus: scheduled.undoStatus,
+    scheduledAccountId: scheduled.accountId,
     isScheduled: true,
   };
 }
@@ -1050,8 +1064,10 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
   scheduledTotal: 0,
   scheduledHasMore: false,
   scheduledNextPosition: 0,
+  scheduledTotalByAccount: {},
   isLoadingScheduled: false,
   isScheduledView: false,
+  scheduledAccountScope: null,
   pendingUndoSend: null,
 
   // Spam undo cache
@@ -1622,6 +1638,7 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
               identityId,
               sendAt: result.sendAt,
               isSmime: false,
+              submissionAccountId: result.submissionAccountId,
               // Cross-account send: undo/send-now must talk to the account that
               // holds the submission, not the active one (#461).
               localAccountId: options?.localAccountId,
@@ -1649,7 +1666,7 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
       set({
         isLoading: false,
         pendingUndoSend: result.scheduled && result.emailSubmissionId && result.sendAt
-          ? { submissionId: result.emailSubmissionId, emailId: result.emailId, identityId, sendAt: result.sendAt, isSmime: true }
+          ? { submissionId: result.emailSubmissionId, emailId: result.emailId, identityId, sendAt: result.sendAt, isSmime: true, submissionAccountId: result.submissionAccountId }
           : get().pendingUndoSend,
       });
       return result;
@@ -4020,10 +4037,11 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
     });
   },
 
-  setScheduledView: (isScheduledView) => set(state => {
+  setScheduledView: (isScheduledView, accountScope = null) => set(state => {
     const leavingScheduled = !isScheduledView && state.selectedMailbox === VIRTUAL_SCHEDULED_MAILBOX_ID;
     return {
       isScheduledView,
+      scheduledAccountScope: isScheduledView ? accountScope : null,
       selectedMailbox: isScheduledView ? VIRTUAL_SCHEDULED_MAILBOX_ID : leavingScheduled ? "" : state.selectedMailbox,
       selectedEmail: leavingScheduled ? null : state.selectedEmail,
       selectedEmailIds: leavingScheduled ? new Set<string>() : state.selectedEmailIds,
@@ -4049,6 +4067,7 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
         sendAt: email.scheduledSendAt,
         identityId: email.scheduledIdentityId,
         undoStatus: email.scheduledUndoStatus,
+        accountId: email.scheduledAccountId,
       }]));
       const pendingUndoSend = get().pendingUndoSend;
       set({
@@ -4056,6 +4075,7 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
         scheduledEmailIds,
         scheduledSubmissionByEmailId,
         scheduledTotal: result.total,
+        scheduledTotalByAccount: result.totalByAccount ?? {},
         scheduledHasMore: result.hasMore,
         scheduledNextPosition: result.nextPosition,
         isLoadingScheduled: false,
@@ -4094,8 +4114,10 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
           sendAt: email.scheduledSendAt,
           identityId: email.scheduledIdentityId,
           undoStatus: email.scheduledUndoStatus,
+          accountId: email.scheduledAccountId,
         }])),
         scheduledTotal: result.total,
+        scheduledTotalByAccount: result.totalByAccount ?? {},
         scheduledHasMore: result.hasMore,
         scheduledNextPosition: result.nextPosition,
         isLoadingScheduled: false,
@@ -4113,10 +4135,12 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
       let position = 0;
       let hasMore = true;
       let total = 0;
+      let totalByAccount: Record<string, number> = {};
       while (hasMore) {
         const page = await client.getScheduledEmails(emailsPerPage, position);
         allEmails.push(...page.emails.filter(email => !allEmails.some(existing => existing.id === email.id)));
         total = page.total;
+        totalByAccount = page.totalByAccount ?? totalByAccount;
         hasMore = page.hasMore && page.nextPosition > position;
         position = page.nextPosition;
       }
@@ -4126,6 +4150,7 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
         sendAt: email.scheduledSendAt,
         identityId: email.scheduledIdentityId,
         undoStatus: email.scheduledUndoStatus,
+        accountId: email.scheduledAccountId,
       }]));
       set({
         scheduledEmails: get().isScheduledView ? allEmails : get().scheduledEmails,
@@ -4136,6 +4161,7 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
         // still get their scheduled badges.
         emails: annotateScheduledEmails(get().emails, scheduledSubmissionByEmailId),
         scheduledTotal: total,
+        scheduledTotalByAccount: totalByAccount,
         scheduledHasMore: false,
         scheduledNextPosition: position,
         pendingUndoSend: shouldClearPendingUndoSend(pendingUndoSend, allEmails) ? null : pendingUndoSend,
@@ -4146,7 +4172,8 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
   },
 
   cancelScheduledEmail: async (client, submissionId, emailId) => {
-    await client.cancelEmailSubmission(submissionId);
+    const owner = get().scheduledEmails.find(email => email.emailSubmissionId === submissionId);
+    await client.cancelEmailSubmission(submissionId, owner?.scheduledAccountId);
     if (emailId) {
       await client.deleteEmail(emailId);
       set(state => ({
@@ -4163,7 +4190,7 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
   cancelScheduledEmailForEdit: async (client, email) => {
     const submissionId = email.emailSubmissionId;
     if (!submissionId) return null;
-    await client.cancelEmailSubmission(submissionId);
+    await client.cancelEmailSubmission(submissionId, email.scheduledAccountId);
     if (get().pendingUndoSend?.submissionId === submissionId) {
       set({ pendingUndoSend: null });
     }
@@ -4190,7 +4217,8 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
   rescheduleScheduledEmail: async (client, submissionId, emailId, identityId, delayedUntil) => {
     let result: SendEmailResult | undefined;
     try {
-      result = await client.rescheduleEmailSubmission(submissionId, emailId, identityId, delayedUntil);
+      const owner = get().scheduledEmails.find(email => email.emailSubmissionId === submissionId);
+      result = await client.rescheduleEmailSubmission(submissionId, emailId, identityId, delayedUntil, owner?.scheduledAccountId);
       const pendingUndoSend = get().pendingUndoSend;
       if (pendingUndoSend?.submissionId === submissionId) {
         set({ pendingUndoSend: { ...pendingUndoSend, submissionId: result.emailSubmissionId || submissionId, sendAt: result.sendAt || delayedUntil } });
@@ -4215,7 +4243,7 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
   },
 
   cancelUndoSend: async (client, pending) => {
-    await client.cancelEmailSubmission(pending.submissionId);
+    await client.cancelEmailSubmission(pending.submissionId, pending.submissionAccountId);
     if (pending.emailId && pending.isSmime) {
       await client.deleteEmail(pending.emailId);
       set(state => ({


### PR DESCRIPTION
### The bug

A delayed ("scheduled") send composed from a **shared/group identity** is created in the *shared* JMAP account — `sendEmail()` passes the target account to `getSubmissionAccountId()`. But every read/write on the scheduled surface asked the **primary** submission account only:

```
getScheduledEmails / cancelEmailSubmission / rescheduleEmailSubmission
    -> getSubmissionAccountId()   // no argument = primary account
```

So a message scheduled from a shared address is accepted and stays `pending` on the server — **it will be delivered at `sendAt`** — while the UI cannot list it, cancel it, or reschedule it.

Worse, cancelling *appears* to work. `EmailSubmission/set` against the primary account answers `notFound` under `notUpdated`, which the client never surfaced, so the user sees no error and the mail goes out anyway. Silently unrecallable mail is a good deal worse than a failed send.

This is the same root cause as #800 (a shared mailbox not carrying its account context), on the scheduled-send path.

### Why scheduling from a shared address is legitimate

Stalwart advertises `urn:ietf:params:jmap:submission` on group accounts as well as personal ones, with `FUTURERELEASE` and a non-zero `maxDelayedSend`:

```
e  carol@example.org  isPersonal=True   maxDelayedSend=2592000  ext={'FUTURERELEASE': [], ...}
f  team@example.org   isPersonal=False  maxDelayedSend=2592000  ext={'FUTURERELEASE': [], ...}
```

The server is happy to schedule it. Only the client's account-blind lookups were broken.

### The fix

**Data layer**

* `getSubmissionAccountIds()` enumerates every submission-capable account. `getScheduledEmails()` queries each, tags every result with its owning account, and fetches each submission's `Email` from that same account (it lives beside the submission, not in the primary account). It also returns per-account totals computed over *all* pending submissions, so a badge stays correct past the first page.
* `resolveSubmissionAccountId()` locates a submission's owning account so cancel/reschedule — and the `sendAt`/envelope helpers — act on the right one. Callers that already know the account pass it and skip the lookup.
* `sendEmail()` reports the submission's account in `SendEmailResult`, and the pending-undo record carries it. The **"Undo send" / "Send now"** toast actions know only a submission id, so without this they'd fall back to probing every shared account sequentially inside the undo window.
* The delayed-send gate considers any reachable submission account rather than only the primary one.

**UI**

* Each shared account gets its own **Scheduled** sidebar row, scoped to that account; the own row keeps showing the combined view. The scope travels *beside* the virtual mailbox id, so the store's single `__scheduled__` id is unchanged. It also drives which row renders as selected and whether the scoped list has more to load.

### Testing

`integration/tests/11-shared-scheduled-send.spec.ts`, against a real Stalwart:

* Two **server-truth** tests pin the mechanism — the submission is invisible to the primary account, and cancelling through it is a silent `notFound` no-op.
* Two **UI** tests cover the fix — the combined list, the scoped row, and which row is highlighted.

Control experiment: with the fix reverted and the app rebuilt, both UI tests fail while the two server-truth tests still pass (they assert server behaviour, not app behaviour). The selection assertion was likewise verified by reintroducing that specific bug and confirming it goes red.

Verified on Stalwart **0.16.7** and **0.16.18**. Note that 0.16.7 does not echo `sendAt` on create while 0.16.18 does; the existing `getEmailSubmissionSendAt` fallback covers it, and is now account-aware too.

### One thing deliberately left alone

`delayedSendSupported` in `mail-app.tsx` gates the whole scheduled UI on `client.hasDelayedSend()` — the primary account. A deployment granting delayed send *only* to a shared account would hide the rows. Not reachable on Stalwart, which grants `FUTURERELEASE` uniformly, and widening that gate would change behaviour for non-shared users beyond this bug's scope. Happy to fold it in if you'd prefer.
