### PR TITLE
fix: keep a draft's attachments through editing, saving and sending

### DIFF
--- a/components/email/__tests__/draft-attachments.test.tsx
+++ b/components/email/__tests__/draft-attachments.test.tsx
@@ -1,0 +1,234 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { EmailComposer } from '../email-composer';
+
+// ─── Heavy component mocks (mirrors composer-close-guard.test.tsx) ───────────
+
+vi.mock('@/components/email/rich-text-editor', () => ({
+  RichTextEditor: () => React.createElement('div', { 'data-testid': 'rich-text-editor' }),
+}));
+
+vi.mock('@/components/plugins/plugin-slot', () => ({ PluginSlot: () => null }));
+vi.mock('@/components/identity/sub-address-helper', () => ({ SubAddressHelper: () => null }));
+vi.mock('@/components/templates/template-picker', () => ({ TemplatePicker: () => null }));
+vi.mock('@/components/templates/template-form', () => ({ TemplateForm: () => null }));
+vi.mock('@/components/files/file-preview-modal', () => ({ FilePreviewModal: () => null }));
+vi.mock('@/hooks/use-focus-trap', () => ({
+  useFocusTrap: () => ({ current: null }),
+}));
+vi.mock('@/hooks/use-pro-multi-account-identities', () => ({
+  useProMultiAccountIdentities: () => ({ enabled: false, groups: [], allIdentities: [] }),
+  stripCrossAccountIdentityPrefix: (id: string) => ({ localAccountId: null, rawId: id }),
+}));
+
+// ─── Store mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('@/stores/auth-store', () => {
+  const state = {
+    client: null,
+    identities: [],
+    primaryIdentity: null,
+    isAuthenticated: false,
+    isDemoMode: false,
+    activeAccountId: null,
+    connectionLost: false,
+    getClientForAccount: () => undefined,
+    getAllConnectedClients: () => new Map(),
+    syncIdentities: () => {},
+    refreshIdentities: async () => {},
+  };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  hook.setState = (p: Partial<typeof state>) => Object.assign(state, p);
+  return { useAuthStore: hook };
+});
+
+vi.mock('@/stores/identity-store', () => {
+  const state = {
+    identities: [{ id: 'id-me', email: 'me@example.com', name: 'Me' }],
+    defaultIdentityId: 'id-me',
+  };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  hook.setState = (p: Partial<typeof state>) => Object.assign(state, p);
+  return { useIdentityStore: hook };
+});
+
+vi.mock('@/stores/account-store', () => {
+  const state = { accounts: [], getAccountById: () => undefined };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  hook.setState = (p: Partial<typeof state>) => Object.assign(state, p);
+  return { useAccountStore: hook };
+});
+
+vi.mock('@/stores/email-store', () => {
+  const state = {
+    draftSaveEnabled: false,
+    sendRawEmail: async () => ({ sent: true }),
+  };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  hook.setState = (p: Partial<typeof state>) => Object.assign(state, p);
+  return { useEmailStore: hook };
+});
+
+vi.mock('@/stores/settings-store', () => {
+  const state = {
+    timeFormat: '24h',
+    plainTextMode: false,
+    subAddressDelimiter: '+',
+    autoSelectReplyIdentity: true,
+    attachmentReminderEnabled: false,
+    attachmentReminderKeywords: [],
+    emptySubjectWarningEnabled: true,
+    sendDelaySeconds: 0,
+    signaturePosition: 'above_quote',
+    signatureSeparatorEnabled: false,
+    requestReadReceiptDefault: false,
+    addTrustedSender: () => {},
+    trustedSendersAddressBook: null,
+    updateSetting: () => {},
+  };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  hook.setState = (p: Partial<typeof state>) => Object.assign(state, p);
+  return { useSettingsStore: hook };
+});
+
+vi.mock('@/stores/contact-store', () => {
+  const state = {
+    contacts: [],
+    getAutocomplete: async () => [],
+    addToTrustedSendersBook: async () => {},
+  };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  hook.setState = (p: Partial<typeof state>) => Object.assign(state, p);
+  return { useContactStore: hook };
+});
+
+vi.mock('@/stores/template-store', () => {
+  const state = { templates: [], addTemplate: async () => {} };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  hook.setState = (p: Partial<typeof state>) => Object.assign(state, p);
+  return { useTemplateStore: hook };
+});
+
+// ─── Misc dependency mocks ────────────────────────────────────────────────────
+
+vi.mock('@/stores/toast-store', () => ({
+  toast: { info: () => {}, error: () => {}, success: () => {} },
+}));
+
+vi.mock('@/lib/plugin-hooks', () => ({
+  emailHooks: {
+    onComposerOpen: { call: async () => [] },
+    onRecipientChange: { call: async () => [] },
+    getRecipientSuggestions: { call: async () => [] },
+    onRecipientChipsChange: { transform: async (chips: unknown) => chips },
+    onDraftChange: { emit: () => {} },
+    onBeforeDraftAutoSave: { transform: async (draft: unknown) => draft },
+    onBeforeEmailSend: { intercept: async () => true },
+    onComposeSend: { intercept: async () => true },
+    onTransformOutgoingEmail: { transform: async (email: unknown) => email },
+  },
+  contactHooks: {
+    search: { call: async () => [] },
+    onProvideRecipientSuggestions: { transform: async (initial: unknown) => initial },
+  },
+}));
+
+vi.mock('@/lib/email-sanitization', () => ({
+  sanitizeSignatureHtml: (v: string) => v,
+  sanitizeEmailHtml: (v: string) => v,
+  parseHtmlSafely: (html: string) => new DOMParser().parseFromString(html, 'text/html'),
+}));
+
+vi.mock('@/lib/email-threading', () => ({
+  computeReplyThreadingHeaders: () => ({ inReplyTo: [], references: [] }),
+}));
+vi.mock('@/lib/signature-utils', () => ({
+  appendPlainTextSignature: (body: string) => body,
+  getPlainTextSignature: () => '',
+}));
+vi.mock('@/lib/sub-addressing', () => ({ generateSubAddress: () => '' }));
+vi.mock('@/lib/debug', () => ({ debug: { log: () => {}, warn: () => {}, error: () => {} } }));
+vi.mock('@/components/email/quoted-html', () => ({
+  buildQuotedHtmlBlock: () => '',
+  serializeEditorContent: () => '',
+}));
+vi.mock('@/lib/template-utils', () => ({ substitutePlaceholders: (s: string) => s }));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+/**
+ * Re-opening a draft must carry its already-uploaded parts into the composer
+ * (#XXX): they render as attachment chips and are re-attached by blobId on the
+ * next save/send. Without this, editing a draft silently stripped its files.
+ */
+
+function draftWith(attachments: Array<Record<string, unknown>>) {
+  return {
+    to: 'bob@example.com',
+    cc: '',
+    bcc: '',
+    subject: 'Invoice draft',
+    body: '<p>see attachment</p>',
+    showCc: false,
+    showBcc: false,
+    selectedIdentityId: 'id-me',
+    subAddressTag: '',
+    mode: 'compose' as const,
+    draftId: 'draft-1',
+    attachments,
+  };
+}
+
+describe('re-opened draft attachments', () => {
+  it('renders the draft parts as attachment chips', () => {
+    render(
+      <EmailComposer
+        initialData={draftWith([
+          { blobId: 'blob-1', name: 'Rechnung_2026-1055.pdf', type: 'application/pdf', size: 245390 },
+          { blobId: 'blob-2', name: 'notes.txt', type: 'text/plain', size: 120 },
+        ])}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Rechnung_2026-1055.pdf')).toBeInTheDocument();
+    expect(screen.getByText('notes.txt')).toBeInTheDocument();
+  });
+
+  it('skips inline cid images and parts without a blobId', () => {
+    render(
+      <EmailComposer
+        initialData={draftWith([
+          { blobId: 'blob-1', name: 'kept.pdf', type: 'application/pdf', size: 1000 },
+          // Embedded in the HTML body - listing it would duplicate the image.
+          { blobId: 'blob-2', name: 'logo.png', type: 'image/png', size: 500, cid: 'logo@x', disposition: 'inline' },
+          // Nothing to re-attach without a blobId; a dead chip would drop on save.
+          { name: 'ghost.bin', type: 'application/octet-stream', size: 1 },
+        ])}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('kept.pdf')).toBeInTheDocument();
+    expect(screen.queryByText('logo.png')).not.toBeInTheDocument();
+    expect(screen.queryByText('ghost.bin')).not.toBeInTheDocument();
+  });
+
+  it('an empty carried list stays empty (no forward fallback for drafts)', () => {
+    render(<EmailComposer initialData={draftWith([])} onClose={vi.fn()} />);
+    expect(screen.queryByText(/\.pdf|\.txt/)).not.toBeInTheDocument();
+  });
+});

--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -118,6 +118,13 @@ export interface ComposerDraftData {
   mode: 'compose' | 'reply' | 'replyAll' | 'forward';
   replyTo?: EmailComposerProps['replyTo'];
   draftId: string | null;
+  /**
+   * Already-uploaded parts the session carries - a re-opened draft's files or
+   * a restored stash. Referenced by blobId; the save/send path re-attaches
+   * them, so dropping this list would silently strip the files from the
+   * stored draft on the next save.
+   */
+  attachments?: Array<{ blobId?: string; name?: string; type?: string; size?: number; cid?: string; disposition?: string }>;
   /** When set, overrides the header From: - sent through the selected identity's envelope. */
   fromOverrideEmail?: string;
   fromOverrideName?: string;
@@ -522,23 +529,31 @@ export function EmailComposer({
   // so this is the only way to distinguish the two.
   const saveFailedRef = useRef(false);
   const [attachments, setAttachments] = useState<ComposerAttachment[]>(() => {
-    if (mode === 'forward' && replyTo?.attachments?.length) {
-      // cids the quoted body renders as <img>; those parts are re-attached
+    // Parts the session already owns: a re-opened draft (or a restored stash)
+    // carries them in initialData - an explicit empty list stays empty -
+    // while forwarding re-attaches the original message's parts. Dropping
+    // them here means the next save replaces the stored draft without its
+    // files.
+    const carried = initialData?.attachments
+      ?? (mode === 'forward' ? replyTo?.attachments : undefined);
+    if (carried?.length) {
+      // cids the quoted/draft body renders as <img>; those parts are re-attached
       // inline by the send path, so listing them here would duplicate them.
       // Covers parts the type/disposition test below misses - Foxmail embeds
       // inline images as octet-stream with no inline disposition (#543).
       const embeddedCids = collectInlineImageCids(body);
-      return replyTo.attachments
-        // Skip inline cid-referenced images - they're embedded in the forwarded HTML body
-        // (matches the viewer's hideInlineImageAttachments logic).
-        .filter(att => !(att.cid && (
+      return carried
+        // Skip inline cid-referenced images - they're embedded in the HTML body
+        // (matches the viewer's hideInlineImageAttachments logic). Parts
+        // without a blobId cannot be re-attached and would drop on save.
+        .filter(att => att.blobId && !(att.cid && (
           embeddedCids.has(att.cid) ||
           (att.disposition === 'inline' && (att.type || '').startsWith('image/'))
         )))
         .map(att => ({
           name: att.name || 'attachment',
           type: att.type || 'application/octet-stream',
-          size: att.size,
+          size: att.size ?? 0,
           blobId: att.blobId,
         }));
     }
@@ -954,8 +969,13 @@ export function EmailComposer({
   const bccStr = formatRecipientList(withInput(bcc, bccInput));
 
   // Keep a ref to current state for the unmount save
-  const stateRef = useRef({ to: toStr, cc: ccStr, bcc: bccStr, subject, body, showCc, showBcc, selectedIdentityId, subAddressTag, draftId, fromOverrideEnabled, fromOverrideEmail, fromOverrideName });
-  stateRef.current = { to: toStr, cc: ccStr, bcc: bccStr, subject, body, showCc, showBcc, selectedIdentityId, subAddressTag, draftId, fromOverrideEnabled, fromOverrideEmail, fromOverrideName };
+  // Only fully uploaded parts are stashed - a restored session can re-attach
+  // by blobId, while an in-flight upload has nothing restorable yet.
+  const stashableAttachments = useMemo(() => attachments
+    .filter(a => a.blobId && !a.uploading)
+    .map(a => ({ blobId: a.blobId, name: a.name, type: a.type, size: a.size })), [attachments]);
+  const stateRef = useRef({ to: toStr, cc: ccStr, bcc: bccStr, subject, body, showCc, showBcc, selectedIdentityId, subAddressTag, draftId, fromOverrideEnabled, fromOverrideEmail, fromOverrideName, attachments: stashableAttachments });
+  stateRef.current = { to: toStr, cc: ccStr, bcc: bccStr, subject, body, showCc, showBcc, selectedIdentityId, subAddressTag, draftId, fromOverrideEnabled, fromOverrideEmail, fromOverrideName, attachments: stashableAttachments };
 
   // Track initial values for dirty detection (captured once on first render)
   const initialValuesRef = useRef({ to: toStr, cc: ccStr, bcc: bccStr, subject, body, attachmentCount: attachments.length });
@@ -1579,7 +1599,12 @@ export function EmailComposer({
     // composed bodies (not the raw editor body) means a signature that changed
     // under an unchanged body - switching identity, toggling the separator -
     // still triggers a re-save.
-    const currentData = JSON.stringify({ to: toAddresses, cc: ccAddresses, bcc: bccAddresses, subject, body: draftHtmlBody ?? draftTextBody, attachments: uploadedAttachments, identityId: selectedIdentityId, subAddressTag });
+    // Attachments are hashed WITHOUT their blobIds: every save rotates the
+    // part blobIds (destroy+create) and the post-save remap writes the fresh
+    // ids back into state - hashing them would make each save dirty the next
+    // one, an endless save loop. Name/type/size still catch every real
+    // add/remove/replace.
+    const currentData = JSON.stringify({ to: toAddresses, cc: ccAddresses, bcc: bccAddresses, subject, body: draftHtmlBody ?? draftTextBody, attachments: uploadedAttachments.map(a => ({ name: a.name, type: a.type, size: a.size })), identityId: selectedIdentityId, subAddressTag });
 
     // Only save if data has changed
     if (currentData === lastSavedDataRef.current) {
@@ -1643,6 +1668,34 @@ export function EmailComposer({
       lastSavedDataRef.current = currentData;
       setSaveStatus('saved');
       saveFailedRef.current = false;
+
+      // A linked blob dies with the message it belongs to, and this save just
+      // destroyed the previous draft - the attachment state still points at
+      // the old message's parts. Re-point it at the freshly created draft's
+      // parts, or the NEXT save (and a later send) references dead blobs and
+      // fails with blobNotFound. Positional mapping: createDraft attaches in
+      // list order; abort on any mismatch rather than risk re-pointing a chip
+      // at the wrong part.
+      if (uploadedAttachments.length) {
+        try {
+          const savedDraft = await composerClient.getEmail(savedDraftId);
+          const freshParts = savedDraft?.attachments ?? [];
+          setAttachments(prev => {
+            const stable = prev.filter(a => a.blobId && !a.uploading);
+            if (stable.length !== freshParts.length) return prev;
+            if (stable.some((a, i) => freshParts[i].size !== a.size)) return prev;
+            let i = 0;
+            return prev.map(att =>
+              att.blobId && !att.uploading
+                ? { ...att, blobId: freshParts[i++].blobId }
+                : att
+            );
+          });
+        } catch (error) {
+          // The stale ids stay in place; the next save reports the failure.
+          debug.error('Failed to refresh draft attachment blobIds:', error);
+        }
+      }
 
       // Reset status after 2 seconds
       setTimeout(() => setSaveStatus('idle'), 2000);
@@ -2147,7 +2200,7 @@ export function EmailComposer({
       setScheduleValue('');
       setScheduleError('');
       // Clear ref so unmount effect doesn't re-save
-      stateRef.current = { to: '', cc: '', bcc: '', subject: '', body: '', showCc: false, showBcc: false, selectedIdentityId: null, subAddressTag: '', draftId: null, fromOverrideEnabled: false, fromOverrideEmail: '', fromOverrideName: '' };
+      stateRef.current = { to: '', cc: '', bcc: '', subject: '', body: '', showCc: false, showBcc: false, selectedIdentityId: null, subAddressTag: '', draftId: null, fromOverrideEnabled: false, fromOverrideEmail: '', fromOverrideName: '', attachments: [] };
     } catch (err) {
       debug.error('Failed to send email:', err);
       // A timeout is not a clean failure: the submission may have reached the
@@ -2206,7 +2259,7 @@ export function EmailComposer({
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current);
     }
-    stateRef.current = { to: '', cc: '', bcc: '', subject: '', body: '', showCc: false, showBcc: false, selectedIdentityId: null, subAddressTag: '', draftId: null, fromOverrideEnabled: false, fromOverrideEmail: '', fromOverrideName: '' };
+    stateRef.current = { to: '', cc: '', bcc: '', subject: '', body: '', showCc: false, showBcc: false, selectedIdentityId: null, subAddressTag: '', draftId: null, fromOverrideEnabled: false, fromOverrideEmail: '', fromOverrideName: '', attachments: [] };
     emitClose();
   };
 
@@ -2231,7 +2284,7 @@ export function EmailComposer({
         toast.error(t('save_failed'));
         explicitCloseRef.current = false;
       } else {
-        stateRef.current = { to: '', cc: '', bcc: '', subject: '', body: '', showCc: false, showBcc: false, selectedIdentityId: null, subAddressTag: '', draftId: null, fromOverrideEnabled: false, fromOverrideEmail: '', fromOverrideName: '' };
+        stateRef.current = { to: '', cc: '', bcc: '', subject: '', body: '', showCc: false, showBcc: false, selectedIdentityId: null, subAddressTag: '', draftId: null, fromOverrideEnabled: false, fromOverrideEmail: '', fromOverrideName: '', attachments: [] };
       }
     } finally {
       emitClose();
@@ -2248,7 +2301,7 @@ export function EmailComposer({
     if (draftId && onDiscardDraft) {
       onDiscardDraft(draftId);
     }
-    stateRef.current = { to: '', cc: '', bcc: '', subject: '', body: '', showCc: false, showBcc: false, selectedIdentityId: null, subAddressTag: '', draftId: null, fromOverrideEnabled: false, fromOverrideEmail: '', fromOverrideName: '' };
+    stateRef.current = { to: '', cc: '', bcc: '', subject: '', body: '', showCc: false, showBcc: false, selectedIdentityId: null, subAddressTag: '', draftId: null, fromOverrideEnabled: false, fromOverrideEmail: '', fromOverrideName: '', attachments: [] };
     emitClose();
   };
 

--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -1757,6 +1757,9 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
       subAddressTag: '',
       mode: 'compose',
       draftId: draft.id,
+      // The draft's already-uploaded parts - without them the next save
+      // replaces the stored draft without its files.
+      attachments: draft.attachments,
     });
     setComposerMode('compose');
     setShowComposer(true);

--- a/components/pro/pro-email-tab-body.tsx
+++ b/components/pro/pro-email-tab-body.tsx
@@ -324,6 +324,9 @@ export function ProEmailTabBody({ tabId, data }: ProEmailTabBodyProps) {
         subAddressTag: '',
         mode: 'compose',
         draftId: email.id,
+        // The draft's already-uploaded parts - without them the next save
+        // replaces the stored draft without its files.
+        attachments: email.attachments,
       },
     });
     closeTab(tabId);

--- a/lib/__tests__/jmap-send-draft-cleanup.test.ts
+++ b/lib/__tests__/jmap-send-draft-cleanup.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { JMAPClient } from '../jmap/client';
+
+/**
+ * Sending an edited draft must never destroy it before the send is confirmed:
+ * JMAP method calls are not transactional, so a destroy riding in the same
+ * request as a failing create/submission still executes - the draft is gone
+ * AND nothing was sent (total-loss report, 20.8.2026, blobNotFound on a
+ * stale attachment blobId). The cleanup has to be a separate request issued
+ * only after the send succeeded.
+ */
+
+function createClient(): JMAPClient {
+  const client = new JMAPClient('https://jmap.example.com', 'user@example.com', 'pass');
+  Object.assign(client, {
+    apiUrl: 'https://jmap.example.com/api',
+    accountId: 'account-1',
+    username: 'user@example.com',
+  });
+  return client;
+}
+
+interface CapturedRequest {
+  methodCalls: Array<[string, Record<string, unknown>, string]>;
+}
+
+function mockSendFlow(opts: { failCreate?: boolean } = {}) {
+  const captured: CapturedRequest[] = [];
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+    const body = JSON.parse((init as { body: string }).body) as CapturedRequest;
+    captured.push(body);
+    const idx = captured.length - 1;
+
+    let payload: unknown;
+    if (idx === 0) {
+      payload = {
+        methodResponses: [[
+          'Mailbox/get',
+          { list: [
+            { id: 'mb-drafts', name: 'Drafts', role: 'drafts' },
+            { id: 'mb-sent', name: 'Sent', role: 'sent' },
+          ] },
+          '0',
+        ]],
+      };
+    } else if (idx === 1) {
+      payload = {
+        methodResponses: [[
+          'Identity/get',
+          { list: [{ id: 'identity-1', email: 'user@example.com', mayDelete: false }] },
+          '0',
+        ]],
+      };
+    } else if (idx === 2) {
+      const createKey = Object.keys(
+        (body.methodCalls[0][1] as { create: Record<string, unknown> }).create,
+      )[0];
+      payload = opts.failCreate
+        ? {
+            methodResponses: [[
+              'Email/set',
+              { notCreated: { [createKey]: { type: 'blobNotFound', description: 'blobId x does not exist on this server' } } },
+              '0',
+            ]],
+          }
+        : {
+            methodResponses: [
+              ['Email/set', { created: { [createKey]: { id: 'sent-1' } } }, '0'],
+              ['EmailSubmission/set', { created: { '1': { id: 'sub-1' } } }, '1'],
+            ],
+          };
+    } else {
+      // The follow-up draft-cleanup request.
+      payload = { methodResponses: [['Email/set', { destroyed: ['draft-old'] }, '0']] };
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify(payload)),
+      json: () => Promise.resolve(payload),
+    } as Response;
+  });
+  return captured;
+}
+
+const hasDestroy = (req: CapturedRequest) =>
+  req.methodCalls.some(([name, args]) => name === 'Email/set' && 'destroy' in args);
+
+describe('sendEmail draft cleanup (total-loss guard)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('destroys the edited draft only after the confirmed send, in its own request', async () => {
+    const client = createClient();
+    const captured = mockSendFlow();
+
+    await client.sendEmail(
+      ['r@example.com'], 'subj', 'body',
+      undefined, undefined, 'identity-1', 'user@example.com',
+      'draft-old',
+    );
+
+    // No destroy rides along with the create/submission batch.
+    expect(hasDestroy(captured[2])).toBe(false);
+    // The cleanup is a separate follow-up request targeting the old draft.
+    expect(captured.length).toBeGreaterThan(3);
+    expect(captured[3].methodCalls[0][0]).toBe('Email/set');
+    expect((captured[3].methodCalls[0][1] as { destroy?: string[] }).destroy).toEqual(['draft-old']);
+  });
+
+  it('keeps the draft untouched when the send fails', async () => {
+    const client = createClient();
+    const captured = mockSendFlow({ failCreate: true });
+
+    await expect(client.sendEmail(
+      ['r@example.com'], 'subj', 'body',
+      undefined, undefined, 'identity-1', 'user@example.com',
+      'draft-old',
+    )).rejects.toThrow(/blobNotFound|blobId/);
+
+    // Not a single destroy was issued in any request.
+    for (const req of captured) {
+      expect(hasDestroy(req)).toBe(false);
+    }
+  });
+});

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -2990,32 +2990,21 @@ export class JMAPClient implements IJMAPClient {
       return { [submissionId]: create };
     };
 
-    if (draftId) {
-      // Destroy the old draft and create a new email with the final body
-      methodCalls.push(["Email/set", {
-        accountId: this.accountId,
-        destroy: [draftId],
-      }, "0"]);
-      methodCalls.push(["Email/set", {
-        accountId: targetAccountId,
-        create: { [emailId]: emailCreate },
-      }, "1"]);
-      methodCalls.push(["EmailSubmission/set", {
-        accountId: this.getSubmissionAccountId(targetAccountId),
-        create: buildSubmissionCreate("1"),
-        onSuccessUpdateEmail,
-      }, "2"]);
-    } else {
-      methodCalls.push(["Email/set", {
-        accountId: targetAccountId,
-        create: { [emailId]: emailCreate },
-      }, "0"]);
-      methodCalls.push(["EmailSubmission/set", {
-        accountId: this.getSubmissionAccountId(targetAccountId),
-        create: buildSubmissionCreate("1"),
-        onSuccessUpdateEmail,
-      }, "1"]);
-    }
+    // When editing a draft, its destruction deliberately does NOT ride in
+    // this request: JMAP method calls and Email/set operations are
+    // independent, not transactional, so a destroy alongside a failing
+    // create/submission would still execute - losing the draft together
+    // with the failed send (total-loss report, 20.8.). The old draft is
+    // destroyed in a separate request below, only after the send succeeded.
+    methodCalls.push(["Email/set", {
+      accountId: targetAccountId,
+      create: { [emailId]: emailCreate },
+    }, "0"]);
+    methodCalls.push(["EmailSubmission/set", {
+      accountId: this.getSubmissionAccountId(targetAccountId),
+      create: buildSubmissionCreate("1"),
+      onSuccessUpdateEmail,
+    }, "1"]);
 
     const response = await this.request(methodCalls);
 
@@ -3081,6 +3070,27 @@ export class JMAPClient implements IJMAPClient {
           emailSubmissionId = result.created['1'].id;
           serverSendAt = result.created['1'].sendAt;
         }
+      }
+    }
+
+    // The send is confirmed (the loop above throws on any create/submission
+    // failure) - now clean up the edited draft. Best-effort: a failed cleanup
+    // leaves an orphan draft row surfaced via filingError, never a lost
+    // message.
+    if (draftId) {
+      try {
+        const destroyResponse = await this.request([["Email/set", {
+          accountId: this.accountId,
+          destroy: [draftId],
+        }, "0"]]);
+        const destroyResult = destroyResponse.methodResponses?.[0]?.[1];
+        if (destroyResult?.notDestroyed && Object.keys(destroyResult.notDestroyed).length) {
+          console.error('[sendEmail] old draft cleanup notDestroyed:', JSON.stringify(destroyResult.notDestroyed));
+          filingError = filingError ?? 'old draft cleanup failed';
+        }
+      } catch (error) {
+        console.error('[sendEmail] old draft cleanup failed:', error);
+        filingError = filingError ?? 'old draft cleanup failed';
       }
     }
 


### PR DESCRIPTION
## Summary

Re-opening a draft for editing silently stripped its files: the composer never received the draft's already-uploaded parts, so the next save replaced the stored draft without them. Fixing the carry-over surfaced two deeper problems on the way to a working flow — rotating blob ids and a send path that could destroy the draft even when the send failed (observed as a total loss: draft gone, nothing sent, after a `blobNotFound`).

## Changes

- Carry the draft's parts through `ComposerDraftData.attachments` into the composer (classic and Pro draft path; inline cid images and blobId-less parts filtered like the forward path), and include completed uploads in the unmount stash so a suspended session resumes with its files.
- Stalwart part blob ids are linked to their message, and every autosave is a destroy+create — the carried ids die with the first save and the second save (or a later send) fails with `blobNotFound`. After each successful save the attachment state is re-pointed at the freshly created draft's parts (positional mapping with a size sanity check; on mismatch the old ids stay and the next save surfaces the failure instead of re-pointing a chip at the wrong part).
- The autosave dirty-check hashes attachments by name/type/size only — the rotating blob ids otherwise dirty every comparison and the save/remap cycle loops forever ("draft saved" flashing endlessly).
- `sendEmail` no longer sends the old draft's destroy alongside the create/submission: JMAP method calls are not transactional, so a failing create still executed the destroy — the draft was lost together with the failed send. The draft is now destroyed in a separate follow-up request only after the response confirms the send; a failed cleanup surfaces via the existing `filingError` warning (orphan draft row instead of a lost message).

## Related issues

Closes #849

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

No new UI — re-opened drafts simply show their attachment chips again, and editing/sending a draft behaves as expected. Verified live against a real Stalwart (edit → autosave → autosave → send: attachment arrives, exactly one save per change, draft cleaned up).

## Notes for reviewers

- The two commits are deliberately separate: the composer-side attachment story, and the client-side send-path guard — the latter protects every draft send, not just the attachment case.
- Deliberately unchanged: `createDraft`'s single-request create+destroy for autosave (a failed autosave loses only the previous saved revision while the composer still holds the content; two-phase would double autosave traffic), and inline `cid:` images in re-opened drafts (a pre-existing gap — preserving them needs cid plumbing through the whole save path).
- New tests: draft-attachment carry/filtering in the composer, and two client-level guards pinning that no destroy rides in the send request and none is issued when the send fails.
