### PR TITLE
fix: clear the viewer when sending destroys the displayed draft

### DIFF
--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -1537,6 +1537,15 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
       const result = await sendEmail(sendClient, data.to, data.subject, data.body, data.cc, data.bcc, data.identityId, data.fromEmail, data.draftId, data.fromName, data.htmlBody, data.attachments, data.inReplyTo, data.references, data.delayedUntil, data.envelopeMailFrom, { requestReadReceipt: data.requestReadReceipt, localAccountId: data.localAccountId });
       submitted = true;
       setShowComposer(false);
+      // Sending an edited draft destroys it server-side - and every autosave
+      // before that already replaced it under a fresh id (createDraft is a
+      // destroy+create). If the email on display is the draft this session
+      // was opened from, or its latest autosaved successor, clear the
+      // selection like a delete does.
+      if (selectedEmail && (selectedEmail.id === data.draftId || selectedEmail.id === pendingDraft?.draftId)) {
+        selectEmail(null);
+        if (isMobile) setActiveView('list');
+      }
       if (result.filingError) {
         // The mail went out, but a post-send step (filing to Sent /
         // removing the old draft) was rejected - warn instead of staying


### PR DESCRIPTION
## Summary

Sending an edited draft destroys it server-side, but the viewer kept rendering the deleted message after the composer closed: the mailbox list refreshed (row gone, counter down) while `selectedEmail` still pointed at the destroyed draft — an "Edit" banner over a message that no longer exists.

## Changes

- After a confirmed send, clear the selection like a delete does — and return to the list on mobile — when the email on display is the draft the compose session was opened from **or** its latest autosaved successor. (Autosave replaces the draft under a fresh id on every save, so matching the sent `draftId` alone would miss whenever an autosave ran in between.)

## Related issues

None filed — found while dogfooding draft editing.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

No new UI — after sending an edited draft the viewer simply empties (mobile returns to the list) instead of showing the destroyed draft. Verified live against a real Stalwart.

## Notes for reviewers

- The guard only fires when the *displayed* email is the sent draft — composing a new mail (whose autosave also carries a draftId) while reading an unrelated message never clears the selection.
- Verified with `npm run typecheck`, `npm run lint`, `npm run build` and the full `npx vitest run`.