### PR TITLE
fix: carry draft attachments in the Pro draft tab too

### DIFF
--- a/components/pro/pro-email-tab-body.tsx
+++ b/components/pro/pro-email-tab-body.tsx
@@ -324,6 +324,10 @@ export function ProEmailTabBody({ tabId, data }: ProEmailTabBodyProps) {
         subAddressTag: '',
         mode: 'compose',
         draftId: email.id,
+        // The draft's already-uploaded parts - the classic path carries them
+        // since #849; without this the Pro draft tab still opened the
+        // composer without its files and the next save stripped them.
+        attachments: email.attachments,
       },
     });
     closeTab(tabId);


### PR DESCRIPTION
## Summary

5d2b937a fixed #849 for the classic draft path: a re-opened draft carries its already-uploaded parts into the composer. The Pro draft tab builds its own `initialData` and still omits `email.attachments` — editing a draft from a Pro tab keeps opening the composer without its files, and the next save strips them from the stored draft.

## Changes

- Pass `email.attachments` through the Pro draft tab's `initialData`; the composer's existing initializer, blob-id remap and dirty-check from 5d2b937a handle everything else.

## Related issues

Related to #849 (closes the remaining Pro-mode gap of that fix).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

No new UI — the Pro draft tab simply shows the draft's attachment chips again, like the classic path does since 5d2b937a.

## Notes for reviewers

- One-line data change; all machinery it relies on (initializer filtering, post-save blob-id remap, name/type/size dirty hash) landed with 5d2b937a and is already covered by its tests.
- Verified with `npm run typecheck`, `npm run lint`, `npm run build` and the full `npx vitest run`.