### PR TITLE
feat(push): group new-mail notifications per account instead of one per message

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -145,22 +145,31 @@ async function handlePush(event) {
     return;
   }
 
+  // Group per account under one shared tag so a burst of new mail collapses
+  // into a single, self-updating notification instead of one toast per message
+  // (Android renders one notification per unique tag, which is why 50 arrivals
+  // used to stack 50 toasts). The newest message is the headline and a
+  // Gmail-style "+N more" line carries the rest, counted from the account's
+  // unread total.
+  const groupTag = "bulwark-mail:" + (accountId || "default");
   let title;
   let body;
-  let tag = "bulwark-mail";
-  let data = { kind: "mail-list" };
+  let data = { kind: "mail-list", accountId };
 
   if (email) {
     const sender = email.from && email.from[0];
     const senderName = (sender && sender.name) || (sender && sender.email) || "New mail";
     title = senderName + (accountLabel ? ` (${accountLabel})` : "");
     body = email.subject || email.preview || "(no subject)";
-    tag = "bulwark-mail:" + email.id;
-    data = {
-      kind: "email",
-      emailId: email.id,
-      threadId: email.threadId,
-    };
+    const more = unreadTotal > 1 ? unreadTotal - 1 : 0;
+    if (more > 0) {
+      // Several unread: this is a group. Keep the newest as the headline, add
+      // the "+N more" count, and open the inbox (not one message) on click.
+      body += "\n" + (more === 1 ? "+1 more message" : `+${more} more messages`);
+    } else {
+      // Exactly one unread: deep-link straight to that message on click.
+      data = { kind: "email", emailId: email.id, threadId: email.threadId };
+    }
   } else {
     title = accountLabel ? `New mail (${accountLabel})` : "New mail";
     body = unreadTotal > 1 ? `${unreadTotal} unread messages` : "You have new mail";
@@ -168,7 +177,9 @@ async function handlePush(event) {
 
   await self.registration.showNotification(title, {
     body,
-    tag,
+    // Shared per-account tag: each new push replaces the account's single
+    // notification rather than adding another.
+    tag: groupTag,
     // Branded app icon via the PWA-icon endpoint (admin-configured, else the
     // built-in default). The static /icon-192x192.png ignored admin branding.
     icon: `${BASE_PATH}/api/pwa-icon/192`,


### PR DESCRIPTION
## Problem
On a PWA, every email push shows a notification with a **unique** tag (`bulwark-mail:<id>`). Android renders one notification per unique tag, so a burst of mail stacks one toast per message — 50 arrivals = 50 toasts.

## Fix
Use a **shared per-account tag** (`bulwark-mail:<accountId>`) so each push replaces that account's single notification instead of adding another. The newest message stays the headline; a Gmail-style **"+N more messages"** line (counted from the account's unread total already returned by `/api/push/preview`) carries the rest. A single unread still deep-links to that message on click; a group opens the inbox. One file: `public/sw.js`.

## Notes
- Grouping is per email account, mirroring Gmail's per-source grouping.
- No cross-push state — the count comes from `preview.unreadTotal`, so it reflects the account's unread total.
- Installed PWAs pick this up after the service worker updates (next launch).
