### PR TITLE
fix: guard crypto.randomUUID for insecure origins (toast store, message-id, contact uid)

### DIFF
--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -4861,7 +4861,7 @@ export class JMAPClient implements IJMAPClient {
           "new-contact": {
             ...contactData,
             //  Stalwart stores the card without one if omitted (#644)
-            uid: contactData.uid || `urn:uuid:${crypto.randomUUID()}`,
+            uid: contactData.uid || `urn:uuid:${generateUUID()}`,
             addressBookIds,
           }
         }

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -1,3 +1,4 @@
+import { generateUUID } from '@/lib/utils';
 import type { Email, Mailbox, StateChange, AccountStates, Thread, Identity, EmailAddress, ContactCard, AddressBook, AddressBookRights, VacationResponse, Calendar, CalendarRights, CalendarEvent, CalendarEventFilter, CalendarTask, FileNode, FileNodeFilter, FileNodeRights, Principal, PushSubscription, EmailSubmission, ScheduledEmail, SendEmailResult, SharedAccount } from "./types";
 import type { SieveScript, SieveCapabilities } from "./sieve-types";
 import type { IJMAPClient, KeywordDiscoveryResult, KeywordInfo, KeywordMigration } from "./client-interface";
@@ -514,7 +515,11 @@ function stripMessageIdBrackets(id: string): string {
 function generateMessageId(fromEmail: string): string {
   const at = fromEmail.lastIndexOf('@');
   const domain = at > 0 ? fromEmail.slice(at + 1) : 'localhost';
-  return `${Date.now().toString(36)}.${crypto.randomUUID()}@${domain}`;
+  // FTM fix (2026-08-22): crypto.randomUUID() only exists in SECURE contexts (https/localhost).
+  // On a plain-http LAN origin it is undefined, so this line threw AFTER the draft was saved and
+  // BEFORE EmailSubmission/set — send silently failed with drafts piling up. generateUUID() from
+  // lib/utils falls back to crypto.getRandomValues, which insecure contexts do provide.
+  return `${Date.now().toString(36)}.${generateUUID()}@${domain}`;
 }
 
 /**

--- a/stores/toast-store.ts
+++ b/stores/toast-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { Toast, ToastAction } from "@/components/ui/toast";
+import { generateUUID } from "@/lib/utils";
 
 interface ToastStore {
   toasts: Toast[];
@@ -12,7 +13,11 @@ export const useToastStore = create<ToastStore>((set) => ({
   toasts: [],
 
   addToast: (toast) => {
-    const id = crypto.randomUUID();
+    // FTM fix (2026-08-22): crypto.randomUUID() only exists in SECURE contexts
+    // (https/localhost). On a plain-http LAN origin it is undefined, so EVERY
+    // toast crashed -- and took the caller's post-success path down with it
+    // (calendar save: the success toast threw before the dialog-close ran).
+    const id = generateUUID();
     const newToast: Toast = {
       ...toast,
       id,


### PR DESCRIPTION
Fixes #887 (calendar Save reports failure while the event is created; duplicates on retry) and the same-class silent compose-Send failure.

## Root cause
`crypto.randomUUID` is `[SecureContext]`-gated — on a plain-http LAN origin (a common self-hosted pilot deployment) it is `undefined`, and three call sites called it unguarded:

- **`stores/toast-store.ts` `addToast()`** — every `toast.success`/`toast.error` threw `TypeError: crypto.randomUUID is not a function`. In `handleSaveEvent` the success toast runs before the dialog-close, so a *successful* `CalendarEvent/set` was followed by a throw; the catch's `toast.error` threw again uncaught; the dialog stayed open reporting failure while the server had the event, and user retries created duplicates.
- **`lib/jmap/client.ts` `generateMessageId()`** — compose Send failed silently after the draft save, before `EmailSubmission` was ever issued (drafts piled up).
- **`lib/jmap/client.ts` `createContact`** uid fallback — contact creation without a uid crashed pre-request.

## Fix
All three now use the guarded `generateUUID()` already in `lib/utils.ts` (typeof-check, falling back to a v4 UUID built from `crypto.getRandomValues`, which insecure contexts do provide).

## Verification
Headless-Chromium reproduction on an insecure origin (`isSecureContext === false`), logged into a real JMAP server (Stalwart 0.16):
- **Pre-fix:** one Save click → uncaught `TypeError` at `Object.addToast` (via `toast.error`), dialog stays open, server has exactly 1 new event.
- **Post-fix:** same click → dialog closes, "Event created" toast renders, no page errors, server has exactly 1 new event.
- Compose Send on-device (iPhone/iPad PWA over LAN http): confirmed sending after the `generateMessageId` guard.

Not touched, flagged for a follow-up: unguarded `crypto.subtle.digest` in `lib/oauth/pkce.ts` and `lib/plugin-sandbox/bundle-integrity.ts` (same class, separate feature paths), and `navigator.clipboard` absence on insecure origins in the copy-link paths (try/caught; degrades gracefully once toasts work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtFkcUA8VM2XAKZKzptpqy