### PR TITLE
feat: add admin-enforced org and domain email signatures

### DIFF
--- a/app/(main)/admin/_tabs/signatures.tsx
+++ b/app/(main)/admin/_tabs/signatures.tsx
@@ -1,0 +1,546 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Save, Loader2, Plus, Trash2, PenLine } from 'lucide-react';
+import type { OrgSignaturePolicy, SettingsPolicy } from '@/lib/admin/types';
+import { DEFAULT_ORG_SIGNATURE_POLICY, DEFAULT_POLICY } from '@/lib/admin/types';
+import { apiFetch } from '@/lib/browser-navigation';
+import { sanitizeSignatureHtmlForDisplay } from '@/lib/email-sanitization';
+import {
+  isValidSenderDomain,
+  normalizeSenderDomain,
+  resolveEffectiveSignature,
+  resolveOrgSignatureContent,
+  resolveOrgSignatureTemplate,
+} from '@/lib/org-signatures';
+
+const SAMPLE_DEFAULTS = {
+  name: 'Sample User',
+  email: 'sample.user@example.com',
+};
+
+export function SignaturesTab() {
+  const [policy, setPolicy] = useState<SettingsPolicy>({ ...DEFAULT_POLICY });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [sampleName, setSampleName] = useState(SAMPLE_DEFAULTS.name);
+  const [sampleEmail, setSampleEmail] = useState(SAMPLE_DEFAULTS.email);
+  const [newDomain, setNewDomain] = useState('');
+  const [newBrandDomain, setNewBrandDomain] = useState('');
+  const [newBrandName, setNewBrandName] = useState('');
+
+  const org = policy.orgSignature ?? { ...DEFAULT_ORG_SIGNATURE_POLICY };
+  const brandNames = policy.domainBrandNames ?? {};
+
+  useEffect(() => {
+    void fetchPolicy();
+  }, []);
+
+  async function fetchPolicy() {
+    setLoading(true);
+    try {
+      const res = await apiFetch('/api/admin/policy');
+      if (res.ok) {
+        setPolicy(await res.json());
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function patchOrg(patch: Partial<OrgSignaturePolicy>) {
+    setPolicy((prev) => ({
+      ...prev,
+      orgSignature: {
+        ...(prev.orgSignature ?? DEFAULT_ORG_SIGNATURE_POLICY),
+        ...patch,
+      },
+    }));
+    setDirty(true);
+    setMessage(null);
+  }
+
+  function patchInstanceTemplate(field: 'htmlTemplate' | 'textTemplate', value: string) {
+    patchOrg({
+      instance: {
+        htmlTemplate: org.instance?.htmlTemplate ?? '',
+        textTemplate: org.instance?.textTemplate ?? '',
+        [field]: value,
+      },
+    });
+  }
+
+  function setBrandName(domain: string, value: string) {
+    const normalized = normalizeSenderDomain(domain);
+    setPolicy((prev) => {
+      const next = { ...(prev.domainBrandNames ?? {}) };
+      if (!value.trim()) delete next[normalized];
+      else next[normalized] = value.trim();
+      return { ...prev, domainBrandNames: next };
+    });
+    setDirty(true);
+    setMessage(null);
+  }
+
+  function addBrandEntry() {
+    const domain = normalizeSenderDomain(newBrandDomain);
+    const name = newBrandName.trim();
+    if (!isValidSenderDomain(domain) || !name) return;
+    setBrandName(domain, name);
+    setNewBrandDomain('');
+    setNewBrandName('');
+  }
+
+  function addDomainTemplate() {
+    const domain = normalizeSenderDomain(newDomain);
+    if (!isValidSenderDomain(domain)) return;
+    patchOrg({
+      perDomain: {
+        ...(org.perDomain ?? {}),
+        [domain]: org.perDomain?.[domain] ?? { htmlTemplate: '', textTemplate: '' },
+      },
+    });
+    setNewDomain('');
+  }
+
+  function removeDomainTemplate(domain: string) {
+    const next = { ...(org.perDomain ?? {}) };
+    delete next[domain];
+    patchOrg({ perDomain: next });
+  }
+
+  function patchDomainTemplate(
+    domain: string,
+    field: 'htmlTemplate' | 'textTemplate',
+    value: string,
+  ) {
+    const current = org.perDomain?.[domain] ?? { htmlTemplate: '', textTemplate: '' };
+    patchOrg({
+      perDomain: {
+        ...(org.perDomain ?? {}),
+        [domain]: { ...current, [field]: value },
+      },
+    });
+  }
+
+  const previewContext = useMemo(
+    () => ({ name: sampleName.trim(), email: sampleEmail.trim() }),
+    [sampleName, sampleEmail],
+  );
+
+  const previewTemplate = useMemo(
+    () => resolveOrgSignatureTemplate(org, previewContext.email),
+    [org, previewContext.email],
+  );
+
+  const previewOrgOnly = useMemo(() => {
+    if (!previewTemplate) return null;
+    return resolveOrgSignatureContent(previewTemplate, previewContext, brandNames);
+  }, [previewTemplate, previewContext, brandNames]);
+
+  const previewMerged = useMemo(() => {
+    const sampleUser = {
+      htmlSignature: '<p>User signature line</p>',
+      textSignature: 'User signature line',
+    };
+    const merged = resolveEffectiveSignature(sampleUser, previewContext, org, brandNames);
+    return merged;
+  }, [org, previewContext, brandNames]);
+
+  async function handleSave() {
+    setSaving(true);
+    setMessage(null);
+    try {
+      const res = await apiFetch('/api/admin/policy', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(policy),
+      });
+      if (res.ok) {
+        setDirty(false);
+        setMessage({ type: 'success', text: 'Signature policy saved.' });
+        await fetchPolicy();
+      } else {
+        const body = await res.json().catch(() => ({}));
+        setMessage({ type: 'error', text: body.error || 'Failed to save policy.' });
+      }
+    } catch {
+      setMessage({ type: 'error', text: 'Failed to save policy.' });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="py-12 text-center text-sm text-muted-foreground">
+        <Loader2 className="w-5 h-5 animate-spin inline-block me-2" />
+        Loading signature policy…
+      </div>
+    );
+  }
+
+  const domainTemplates = Object.keys(org.perDomain ?? {}).sort();
+  const brandDomains = Object.keys(brandNames).sort();
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Org Signatures</h1>
+          <p className="text-sm text-muted-foreground mt-1 max-w-2xl">
+            Enforce HTML/plain signatures at compose time. Templates support placeholders such as{' '}
+            <code className="text-xs bg-muted px-1 rounded">{'{{display.name}}'}</code>,{' '}
+            <code className="text-xs bg-muted px-1 rounded">{'{{email}}'}</code>, and{' '}
+            <code className="text-xs bg-muted px-1 rounded">{'{{brand.name}}'}</code>{' '}
+            (from the brand map keyed by sender email domain).
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={!dirty || saving}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium disabled:opacity-50"
+        >
+          {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+          Save
+        </button>
+      </div>
+
+      {message && (
+        <div
+          className={`rounded-md border px-4 py-3 text-sm ${
+            message.type === 'success'
+              ? 'border-green-500/40 bg-green-500/10 text-green-700 dark:text-green-400'
+              : 'border-destructive/40 bg-destructive/10 text-destructive'
+          }`}
+        >
+          {message.text}
+        </div>
+      )}
+
+      <section className="rounded-lg border border-border p-4 space-y-4">
+        <label className="flex items-center gap-3">
+          <input
+            type="checkbox"
+            checked={org.enabled}
+            onChange={(e) => patchOrg({ enabled: e.target.checked })}
+            className="rounded border-input"
+          />
+          <span className="text-sm font-medium">Enable org-enforced signatures</span>
+        </label>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="block text-sm">
+            <span className="font-medium">Scope</span>
+            <select
+              value={org.scope}
+              onChange={(e) => patchOrg({ scope: e.target.value as OrgSignaturePolicy['scope'] })}
+              className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            >
+              <option value="instance">Instance-wide (same template for all domains)</option>
+              <option value="per_domain">Per sender domain</option>
+            </select>
+          </label>
+
+          <label className="block text-sm">
+            <span className="font-medium">Merge with user signatures</span>
+            <select
+              value={org.mergeMode}
+              onChange={(e) => patchOrg({ mergeMode: e.target.value as OrgSignaturePolicy['mergeMode'] })}
+              className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            >
+              <option value="replace">Org signature only (ignore user signature)</option>
+              <option value="append">Append org signature after user signature</option>
+              <option value="fallback">Use org signature only when user has none</option>
+            </select>
+          </label>
+        </div>
+
+        {org.mergeMode === 'replace' && (
+          <p className="text-xs text-muted-foreground">
+            Users cannot edit HTML or plain-text signatures in the identity editor while this mode is active.
+          </p>
+        )}
+      </section>
+
+      {org.scope === 'instance' ? (
+        <section className="rounded-lg border border-border p-4 space-y-4">
+          <h2 className="text-lg font-medium">Instance-wide template</h2>
+          <TemplateEditor
+            html={org.instance?.htmlTemplate ?? ''}
+            text={org.instance?.textTemplate ?? ''}
+            onHtmlChange={(value) => patchInstanceTemplate('htmlTemplate', value)}
+            onTextChange={(value) => patchInstanceTemplate('textTemplate', value)}
+          />
+        </section>
+      ) : (
+        <section className="rounded-lg border border-border p-4 space-y-4">
+          <h2 className="text-lg font-medium">Per-domain templates</h2>
+          <p className="text-sm text-muted-foreground">
+            Templates apply when the selected identity&apos;s email address matches the domain.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <input
+              type="text"
+              value={newDomain}
+              onChange={(e) => setNewDomain(e.target.value)}
+              placeholder="example.com"
+              className="rounded-md border border-input bg-background px-3 py-2 text-sm min-w-[12rem]"
+            />
+            <button
+              type="button"
+              onClick={addDomainTemplate}
+              className="inline-flex items-center gap-1 px-3 py-2 rounded-md border border-border text-sm hover:bg-muted"
+            >
+              <Plus className="w-4 h-4" />
+              Add domain
+            </button>
+          </div>
+          {domainTemplates.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No domain templates configured yet.</p>
+          ) : (
+            domainTemplates.map((domain) => (
+              <div key={domain} className="rounded-md border border-border p-3 space-y-3">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-mono text-sm">{domain}</span>
+                  <button
+                    type="button"
+                    onClick={() => removeDomainTemplate(domain)}
+                    className="text-muted-foreground hover:text-destructive"
+                    aria-label={`Remove ${domain}`}
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
+                <TemplateEditor
+                  html={org.perDomain?.[domain]?.htmlTemplate ?? ''}
+                  text={org.perDomain?.[domain]?.textTemplate ?? ''}
+                  onHtmlChange={(value) => patchDomainTemplate(domain, 'htmlTemplate', value)}
+                  onTextChange={(value) => patchDomainTemplate(domain, 'textTemplate', value)}
+                />
+              </div>
+            ))
+          )}
+        </section>
+      )}
+
+      <section className="rounded-lg border border-border p-4 space-y-4">
+        <h2 className="text-lg font-medium">Brand names</h2>
+        <p className="text-sm text-muted-foreground">
+          Map sender email domains to a display brand for <code className="text-xs bg-muted px-1 rounded">{'{{brand.name}}'}</code>.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <input
+            type="text"
+            value={newBrandDomain}
+            onChange={(e) => setNewBrandDomain(e.target.value)}
+            placeholder="example.com"
+            className="rounded-md border border-input bg-background px-3 py-2 text-sm min-w-[10rem]"
+          />
+          <input
+            type="text"
+            value={newBrandName}
+            onChange={(e) => setNewBrandName(e.target.value)}
+            placeholder="Example Brand"
+            className="rounded-md border border-input bg-background px-3 py-2 text-sm min-w-[12rem]"
+          />
+          <button
+            type="button"
+            onClick={addBrandEntry}
+            className="inline-flex items-center gap-1 px-3 py-2 rounded-md border border-border text-sm hover:bg-muted"
+          >
+            <Plus className="w-4 h-4" />
+            Add
+          </button>
+        </div>
+        {brandDomains.length > 0 && (
+          <div className="space-y-2">
+            {brandDomains.map((domain) => (
+              <div key={domain} className="flex items-center gap-2">
+                <span className="font-mono text-sm w-40 shrink-0">{domain}</span>
+                <input
+                  type="text"
+                  value={brandNames[domain] ?? ''}
+                  onChange={(e) => setBrandName(domain, e.target.value)}
+                  className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                />
+                <button
+                  type="button"
+                  onClick={() => setBrandName(domain, '')}
+                  className="text-muted-foreground hover:text-destructive"
+                  aria-label={`Remove brand for ${domain}`}
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-lg border border-border p-4 space-y-4">
+        <h2 className="text-lg font-medium">Reply signature placement</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="block text-sm">
+            <span className="font-medium">Position in replies/forwards</span>
+            <select
+              value={org.replySignaturePosition ?? 'above_quote'}
+              onChange={(e) =>
+                patchOrg({
+                  replySignaturePosition: e.target.value as 'above_quote' | 'below_quote',
+                })
+              }
+              className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            >
+              <option value="above_quote">Above quoted text</option>
+              <option value="below_quote">Below quoted text</option>
+            </select>
+          </label>
+          <label className="flex items-center gap-3 mt-6 md:mt-8">
+            <input
+              type="checkbox"
+              checked={org.lockReplySignaturePosition ?? false}
+              onChange={(e) => patchOrg({ lockReplySignaturePosition: e.target.checked })}
+              className="rounded border-input"
+            />
+            <span className="text-sm">Lock for users (hide composer setting)</span>
+          </label>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              checked={org.signatureSeparatorEnabled !== false}
+              onChange={(e) => patchOrg({ signatureSeparatorEnabled: e.target.checked })}
+              className="rounded border-input"
+            />
+            <span className="text-sm">Include &quot;-- &quot; separator before signature</span>
+          </label>
+          <label className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              checked={org.lockSignatureSeparator ?? false}
+              onChange={(e) => patchOrg({ lockSignatureSeparator: e.target.checked })}
+              className="rounded border-input"
+            />
+            <span className="text-sm">Lock separator setting for users</span>
+          </label>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-border p-4 space-y-4">
+        <div className="flex items-center gap-2">
+          <PenLine className="w-4 h-4 text-muted-foreground" />
+          <h2 className="text-lg font-medium">Preview (sample identity)</h2>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Admins may not have a regular mail identity. Enter a sample sender to preview template output.
+        </p>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="block text-sm">
+            <span className="font-medium">Display name</span>
+            <input
+              type="text"
+              value={sampleName}
+              onChange={(e) => setSampleName(e.target.value)}
+              className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="font-medium">Email address</span>
+            <input
+              type="email"
+              value={sampleEmail}
+              onChange={(e) => setSampleEmail(e.target.value)}
+              className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            />
+          </label>
+        </div>
+
+        {!org.enabled ? (
+          <p className="text-sm text-muted-foreground">Enable org signatures to see a preview.</p>
+        ) : !previewTemplate ? (
+          <p className="text-sm text-amber-600 dark:text-amber-400">
+            No template applies to this sample email domain. Add a matching domain template or switch to instance-wide scope.
+          </p>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            <PreviewPanel title="Org template only" html={previewOrgOnly?.html} text={previewOrgOnly?.text} />
+            <PreviewPanel
+              title={`Effective (${org.mergeMode}) with sample user signature`}
+              html={previewMerged.htmlSignature ?? undefined}
+              text={previewMerged.textSignature ?? undefined}
+            />
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function TemplateEditor({
+  html,
+  text,
+  onHtmlChange,
+  onTextChange,
+}: {
+  html: string;
+  text: string;
+  onHtmlChange: (value: string) => void;
+  onTextChange: (value: string) => void;
+}) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <label className="block text-sm">
+        <span className="font-medium">HTML template</span>
+        <textarea
+          value={html}
+          onChange={(e) => onHtmlChange(e.target.value)}
+          rows={8}
+          className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono"
+        />
+      </label>
+      <label className="block text-sm">
+        <span className="font-medium">Plain-text template</span>
+        <textarea
+          value={text}
+          onChange={(e) => onTextChange(e.target.value)}
+          rows={8}
+          className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono"
+        />
+      </label>
+    </div>
+  );
+}
+
+function PreviewPanel({
+  title,
+  html,
+  text,
+}: {
+  title: string;
+  html?: string;
+  text?: string;
+}) {
+  return (
+    <div className="rounded-md border border-border p-3 space-y-2">
+      <h3 className="text-sm font-medium">{title}</h3>
+      {html ? (
+        <div
+          className="prose prose-sm dark:prose-invert max-w-none border rounded p-2 bg-muted/40"
+          dangerouslySetInnerHTML={{ __html: sanitizeSignatureHtmlForDisplay(html) }}
+        />
+      ) : (
+        <p className="text-xs text-muted-foreground">No HTML output</p>
+      )}
+      {text ? (
+        <pre className="text-xs whitespace-pre-wrap rounded border bg-muted/40 p-2">{text}</pre>
+      ) : (
+        <p className="text-xs text-muted-foreground">No plain-text output</p>
+      )}
+    </div>
+  );
+}

--- a/app/(main)/admin/layout.tsx
+++ b/app/(main)/admin/layout.tsx
@@ -24,6 +24,7 @@ import {
   Store,
   Menu,
   X,
+  PenLine,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useConfig } from '@/hooks/use-config';
@@ -55,6 +56,7 @@ const NAV_GROUPS: ReadonlyArray<{
       { tab: 'branding', label: 'Branding', icon: Palette },
       { tab: 'auth', label: 'Authentication', icon: Shield },
       { tab: 'policy', label: 'Policy', icon: Scale },
+      { tab: 'signatures', label: 'Signatures', icon: PenLine },
     ],
   },
   {

--- a/app/(main)/admin/page.tsx
+++ b/app/(main)/admin/page.tsx
@@ -7,6 +7,7 @@ import { SettingsTab } from './_tabs/settings';
 import { BrandingTab } from './_tabs/branding';
 import { AuthTab } from './_tabs/auth';
 import { PolicyTab } from './_tabs/policy';
+import { SignaturesTab } from './_tabs/signatures';
 import { PluginsTab } from './_tabs/plugins';
 import { ThemesTab } from './_tabs/themes';
 import { MarketplaceTab } from './_tabs/marketplace';
@@ -39,6 +40,7 @@ export default function AdminPage() {
     case 'branding': return <BrandingTab />;
     case 'auth': return <AuthTab />;
     case 'policy': return <PolicyTab />;
+    case 'signatures': return <SignaturesTab />;
     case 'plugins': return <PluginsTab />;
     case 'themes': return <ThemesTab />;
     case 'marketplace': return <MarketplaceTab />;

--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -63,6 +63,11 @@ import type { Editor } from "@tiptap/react";
 import { htmlToPlainText as htmlToPlainTextShared } from "@/lib/html-to-text";
 import { fileStorage } from "@/lib/plugin-storage";
 import { usePolicyStore } from "@/stores/policy-store";
+import {
+  buildComposerSignatureIdentity,
+  getEffectiveSignaturePosition,
+  getEffectiveSignatureSeparator,
+} from "@/lib/org-signatures";
 
 /**
  * Derives the text/plain alternative from the composer's HTML body, preserving
@@ -305,6 +310,10 @@ export function EmailComposer({
   const sendDelaySeconds = useSettingsStore((state) => state.sendDelaySeconds);
   const signaturePosition = useSettingsStore((state) => state.signaturePosition);
   const signatureSeparatorEnabled = useSettingsStore((state) => state.signatureSeparatorEnabled);
+  const orgSignaturePolicy = usePolicyStore((state) => state.policy.orgSignature);
+  const domainBrandNames = usePolicyStore((state) => state.policy.domainBrandNames ?? {});
+  const effectiveSignaturePosition = getEffectiveSignaturePosition(signaturePosition, orgSignaturePolicy);
+  const effectiveSignatureSeparator = getEffectiveSignatureSeparator(signatureSeparatorEnabled, orgSignaturePolicy);
   const requestReadReceiptDefault = useSettingsStore((state) => state.requestReadReceiptDefault);
   const activeIdentities = useIdentityStore((s) => s.identities);
   // Pro shell: surface identities from every connected account, grouped
@@ -329,13 +338,16 @@ export function EmailComposer({
   const initialCurrentIdentityForSig = initialData?.selectedIdentityId
     ? identities.find((i) => i.id === initialData.selectedIdentityId) || primaryIdentity
     : primaryIdentity;
-  const initialSignatureIdentity = (initialCurrentIdentityForSig?.htmlSignature || initialCurrentIdentityForSig?.textSignature)
-    ? initialCurrentIdentityForSig
-    : primaryIdentity;
-  const hasInitialSignature = !!(initialSignatureIdentity?.htmlSignature || initialSignatureIdentity?.textSignature);
+  const initialSignatureIdentity = buildComposerSignatureIdentity(
+    initialCurrentIdentityForSig,
+    primaryIdentity,
+    orgSignaturePolicy,
+    domainBrandNames,
+  );
+  const hasInitialSignature = !!initialSignatureIdentity;
   const shouldEmbedSignatureAboveQuote =
     (mode === 'reply' || mode === 'replyAll' || mode === 'forward') &&
-    signaturePosition === 'above_quote' &&
+    effectiveSignaturePosition === 'above_quote' &&
     hasInitialSignature;
   // New-mail composes always embed the signature into the editor body so it's
   // editable/removable (the previous read-only preview below the editor was
@@ -379,7 +391,7 @@ export function EmailComposer({
       // editable. Fixes #329 (A,B).
       if (mode === 'compose') {
         if (!shouldEmbedSignatureInNewMail) return prefix;
-        const sep = signatureSeparatorEnabled ? '\n\n-- \n' : '\n\n';
+        const sep = effectiveSignatureSeparator ? '\n\n-- \n' : '\n\n';
         return `${prefix}${sep}${getPlainTextSignature(initialSignatureIdentity)}`;
       }
       if (!replyTo?.body && !replyTo?.htmlBody) return prefix;
@@ -401,7 +413,7 @@ export function EmailComposer({
       // drafting area and the quoted content so it reads naturally as a
       // closing for the reply body. Send-time append is skipped - see
       // shouldEmbedSignatureAboveQuote.
-      const plainSep = signatureSeparatorEnabled ? '\n\n-- \n' : '\n\n';
+      const plainSep = effectiveSignatureSeparator ? '\n\n-- \n' : '\n\n';
       const signatureBlock = shouldEmbedSignatureAboveQuote
         ? `${plainSep}${getPlainTextSignature(initialSignatureIdentity)}`
         : '';
@@ -429,7 +441,7 @@ export function EmailComposer({
       const composePrefix = prefix || '<p></p>';
       const embedded = buildEmbeddedSignatureHtml(initialSignatureIdentity, {
         embed: true,
-        separator: signatureSeparatorEnabled,
+        separator: effectiveSignatureSeparator,
       });
       return `${composePrefix}${embedded}`;
     }
@@ -446,7 +458,7 @@ export function EmailComposer({
 
     const signatureBlock = buildEmbeddedSignatureHtml(initialSignatureIdentity, {
       embed: shouldEmbedSignatureAboveQuote,
-      separator: signatureSeparatorEnabled,
+      separator: effectiveSignatureSeparator,
     });
 
     // Plugin override (resolved at composer open via onBuildQuoteHeader).
@@ -647,26 +659,24 @@ export function EmailComposer({
     ? (useAuthStore.getState().getClientForAccount(currentIdentityParts.localAccountId) ?? client)
     : client;
   const currentIdentityRawId = currentIdentityParts.rawId ?? currentIdentity?.id;
-  // Alias identities often lack a configured signature - fall back to the primary
-  // identity's signature so replies (which auto-select a matching alias) still
-  // populate the user's signature.
-  const signatureIdentity = (currentIdentity?.htmlSignature || currentIdentity?.textSignature)
-    ? currentIdentity
-    : primaryIdentity;
+  const signatureIdentity = useMemo(
+    () => buildComposerSignatureIdentity(currentIdentity, primaryIdentity, orgSignaturePolicy, domainBrandNames),
+    [currentIdentity, primaryIdentity, orgSignaturePolicy, domainBrandNames],
+  );
 
   // Hold the TipTap editor instance so we can swap the embedded signature
   // when the user switches identity in "above quote" mode without rebuilding
   // the whole body (which would lose user edits to the surrounding draft).
   const editorRef = useRef<Editor | null>(null);
   const prevSignatureIdentityIdRef = useRef<string | null | undefined>(signatureIdentity?.id);
-  const prevSignatureSeparatorRef = useRef<boolean>(signatureSeparatorEnabled);
+  const prevSignatureSeparatorRef = useRef<boolean>(effectiveSignatureSeparator);
 
   useEffect(() => {
     const editor = editorRef.current;
     const identityChanged = prevSignatureIdentityIdRef.current !== signatureIdentity?.id;
-    const separatorChanged = prevSignatureSeparatorRef.current !== signatureSeparatorEnabled;
+    const separatorChanged = prevSignatureSeparatorRef.current !== effectiveSignatureSeparator;
     prevSignatureIdentityIdRef.current = signatureIdentity?.id;
-    prevSignatureSeparatorRef.current = signatureSeparatorEnabled;
+    prevSignatureSeparatorRef.current = effectiveSignatureSeparator;
     if (!editor) return;
     if (!identityChanged && !separatorChanged) return;
     if (plainTextMode) return;
@@ -674,7 +684,7 @@ export function EmailComposer({
     // always embeds (see getInitialBody), so swap on identity change there too.
     const isReplyLike = mode === 'reply' || mode === 'replyAll' || mode === 'forward';
     if (!isReplyLike && mode !== 'compose') return;
-    if (isReplyLike && signaturePosition !== 'above_quote') return;
+    if (isReplyLike && effectiveSignaturePosition !== 'above_quote') return;
 
     // serializeEditorContent (not getHTML) so a QuotedHtml island's verbatim
     // body isn't lost during the signature splice + setContent round-trip.
@@ -688,7 +698,7 @@ export function EmailComposer({
 
     const newSignature = buildEmbeddedSignatureHtml(signatureIdentity, {
       embed: true,
-      separator: signatureSeparatorEnabled,
+      separator: effectiveSignatureSeparator,
     });
     if (!newSignature) return;
 
@@ -734,7 +744,7 @@ export function EmailComposer({
     // would re-run on unrelated identity-field changes and re-splice the
     // signature into the live editor.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [signatureIdentity?.id, signatureIdentity?.htmlSignature, signatureIdentity?.textSignature, signatureSeparatorEnabled, signaturePosition, mode, plainTextMode]);
+  }, [signatureIdentity?.id, signatureIdentity?.htmlSignature, signatureIdentity?.textSignature, effectiveSignatureSeparator, effectiveSignaturePosition, mode, plainTextMode]);
 
   useEffect(() => {
     const handleClickOutsideSendMenu = (event: MouseEvent) => {
@@ -965,7 +975,7 @@ export function EmailComposer({
   const signatureAlreadyInBody =
     shouldEmbedSignatureInNewMail ||
     ((mode === 'reply' || mode === 'replyAll' || mode === 'forward') &&
-      signaturePosition === 'above_quote') ||
+      effectiveSignaturePosition === 'above_quote') ||
     bodyCarriesSignature;
 
   const getAutocomplete = useContactStore((s) => s.getAutocomplete);
@@ -1277,7 +1287,7 @@ export function EmailComposer({
           });
         } else {
           setBody((prev) => plainTextBodyHasSignature(prev, signatureIdentity)
-            ? appendPlainTextSignature(bodyContent, signatureIdentity, { separator: signatureSeparatorEnabled })
+            ? appendPlainTextSignature(bodyContent, signatureIdentity, { separator: effectiveSignatureSeparator })
             : bodyContent);
         }
       } else {
@@ -1333,7 +1343,7 @@ export function EmailComposer({
     }
 
     setShowTemplatePicker(false);
-  }, [mode, plainTextMode, signatureIdentity, signatureSeparatorEnabled]);
+  }, [mode, plainTextMode, signatureIdentity, effectiveSignatureSeparator]);
 
   useEffect(() => {
     const handleTemplateKey = (e: KeyboardEvent) => {
@@ -1621,13 +1631,13 @@ export function EmailComposer({
       ? ''
       : buildEmbeddedSignatureHtml(signatureIdentity, {
           embed: true,
-          separator: signatureSeparatorEnabled,
+          separator: effectiveSignatureSeparator,
         });
     const draftHtmlBody = plainTextMode ? undefined : `${body}${draftSignatureHtml}`;
     const draftTextBody = plainTextMode
       ? (signatureAlreadyInBody
           ? body
-          : appendPlainTextSignature(body, signatureIdentity, { separator: signatureSeparatorEnabled }))
+          : appendPlainTextSignature(body, signatureIdentity, { separator: effectiveSignatureSeparator }))
       : htmlToPlainText(draftHtmlBody!);
 
     // Create a hash of current data to compare with last saved. Hashing the
@@ -2069,7 +2079,7 @@ export function EmailComposer({
     // Build HTML signature block (used only in rich text mode)
     const buildSignatureHtml = (): string => {
       if (signatureAlreadyInBody) return '';
-      const sep = signatureSeparatorEnabled ? `<br><br>-- <br>` : `<br><br>`;
+      const sep = effectiveSignatureSeparator ? `<br><br>-- <br>` : `<br><br>`;
       if (signatureIdentity?.htmlSignature) {
         return `${sep}${sanitizeSignatureHtml(signatureIdentity.htmlSignature)}`;
       }
@@ -2085,7 +2095,7 @@ export function EmailComposer({
       : null;
 
     // In plain text mode, send text/plain only (no HTML body)
-    const signatureOpts = { separator: signatureSeparatorEnabled };
+    const signatureOpts = { separator: effectiveSignatureSeparator };
     const finalBody = plainTextMode
       ? (signatureAlreadyInBody ? body : appendPlainTextSignature(body, signatureIdentity, signatureOpts))
       : (signatureAlreadyInBody ? htmlToPlainText(body) : appendPlainTextSignature(htmlToPlainText(body), signatureIdentity, signatureOpts));
@@ -2851,13 +2861,13 @@ export function EmailComposer({
           : plainTextMode ? (
           getPlainTextSignature(signatureIdentity) ? (
             <div className="px-4 pb-3 text-sm leading-6 text-muted-foreground break-words whitespace-pre-wrap font-mono">
-              {signatureSeparatorEnabled ? '-- \n' : ''}{getPlainTextSignature(signatureIdentity)}
+              {effectiveSignatureSeparator ? '-- \n' : ''}{getPlainTextSignature(signatureIdentity)}
             </div>
           ) : null
         ) : composerSignatureHtml ? (
           <div
             className="px-4 pb-3 text-sm leading-6 text-foreground break-words [&_a]:text-primary [&_a]:underline-offset-2 [&_a:hover]:underline"
-            dangerouslySetInnerHTML={{ __html: `${signatureSeparatorEnabled ? '<div>-- </div>' : ''}${composerSignatureHtml}` }}
+            dangerouslySetInnerHTML={{ __html: `${effectiveSignatureSeparator ? '<div>-- </div>' : ''}${composerSignatureHtml}` }}
           />
         ) : null}
       </div>

--- a/components/identity/identity-form.tsx
+++ b/components/identity/identity-form.tsx
@@ -7,6 +7,8 @@ import { Input } from '@/components/ui/input';
 import type { Identity, EmailAddress } from '@/lib/jmap/types';
 import { sanitizeSignatureHtml, sanitizeSignatureHtmlForDisplay } from '@/lib/email-sanitization';
 import { getEmailValidationError, validateEmailList } from '@/lib/validation';
+import { usePolicyStore } from '@/stores/policy-store';
+import { shouldLockIdentitySignatures } from '@/lib/org-signatures';
 
 // Stalwarts JMAP Identity/set caps signature fields at 2047 UTF-8 bytes
 const SIGNATURE_MAX_BYTES = 2047;
@@ -52,6 +54,8 @@ export function IdentityForm({ identity, onSave, onCancel }: IdentityFormProps) 
   const t = useTranslations('identities.form');
   const tValidation = useTranslations('identities.validation_errors');
   const tDisplay = useTranslations('identities.display');
+  const orgSignaturePolicy = usePolicyStore((state) => state.policy.orgSignature);
+  const signaturesLocked = shouldLockIdentitySignatures(orgSignaturePolicy);
   const isEditing = !!identity;
 
   const [formData, setFormData] = useState<IdentityFormData>({
@@ -267,6 +271,12 @@ export function IdentityForm({ identity, onSave, onCancel }: IdentityFormProps) 
       </div>
 
       {/* Text Signature */}
+      {signaturesLocked ? (
+        <div className="rounded-md border border-border bg-muted/40 px-3 py-3 text-sm text-muted-foreground">
+          {t('org_signature_locked')}
+        </div>
+      ) : (
+        <>
       <div>
         <label htmlFor="identity-text-sig" className="block text-sm font-medium mb-1">
           {t('text_signature_label')}
@@ -311,6 +321,8 @@ export function IdentityForm({ identity, onSave, onCancel }: IdentityFormProps) 
           </div>
         )}
       </div>
+        </>
+      )}
 
       {/* Actions */}
       <div className="flex justify-end gap-2 pt-4">

--- a/components/settings/composing-settings.tsx
+++ b/components/settings/composing-settings.tsx
@@ -5,8 +5,15 @@ import { useTranslations } from 'next-intl';
 import { useSettingsStore } from '@/stores/settings-store';
 import type { SendDelaySeconds } from '@/stores/settings-store';
 import { useAuthStore } from '@/stores/auth-store';
+import { usePolicyStore } from '@/stores/policy-store';
 import { SettingsSection, SettingItem, Select, ToggleSwitch } from './settings-section';
 import { X } from 'lucide-react';
+import {
+  getEffectiveSignaturePosition,
+  getEffectiveSignatureSeparator,
+  isReplySignaturePositionLocked,
+  isSignatureSeparatorLocked,
+} from '@/lib/org-signatures';
 import {
   SUPPORTED_SUB_ADDRESS_DELIMITERS,
   isSupportedSubAddressDelimiter,
@@ -36,6 +43,11 @@ export function ComposingSettings() {
     updateSetting,
   } = useSettingsStore();
   const { client } = useAuthStore();
+  const orgSignaturePolicy = usePolicyStore((state) => state.policy.orgSignature);
+  const replyPositionLocked = isReplySignaturePositionLocked(orgSignaturePolicy);
+  const separatorLocked = isSignatureSeparatorLocked(orgSignaturePolicy);
+  const effectiveSignaturePosition = getEffectiveSignaturePosition(signaturePosition, orgSignaturePolicy);
+  const effectiveSignatureSeparator = getEffectiveSignatureSeparator(signatureSeparatorEnabled, orgSignaturePolicy);
   const delayedSendSupported = client?.hasDelayedSend() ?? false;
 
   return (
@@ -79,21 +91,23 @@ export function ComposingSettings() {
         </div>
       </SettingItem>
 
-      <SettingItem label={t('signature_position.label')} description={t('signature_position.description')}>
+      <SettingItem label={t('signature_position.label')} description={t('signature_position.description')} locked={replyPositionLocked}>
         <Select
-          value={signaturePosition}
+          value={effectiveSignaturePosition}
           onChange={(value) => updateSetting('signaturePosition', value as 'above_quote' | 'below_quote')}
           options={[
             { value: 'above_quote', label: t('signature_position.above_quote') },
             { value: 'below_quote', label: t('signature_position.below_quote') },
           ]}
+          disabled={replyPositionLocked}
         />
       </SettingItem>
 
-      <SettingItem label={t('signature_separator.label')} description={t('signature_separator.description')}>
+      <SettingItem label={t('signature_separator.label')} description={t('signature_separator.description')} locked={separatorLocked}>
         <ToggleSwitch
-          checked={signatureSeparatorEnabled}
+          checked={effectiveSignatureSeparator}
           onChange={(checked) => updateSetting('signatureSeparatorEnabled', checked)}
+          disabled={separatorLocked}
         />
       </SettingItem>
 

--- a/lib/__tests__/org-signatures.test.ts
+++ b/lib/__tests__/org-signatures.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildOrgSignaturePlaceholderValues,
+  extractEmailDomain,
+  normalizeDomainBrandNames,
+  normalizeOrgSignaturePolicy,
+  resolveEffectiveSignature,
+  resolveOrgSignatureContent,
+  resolveOrgSignatureTemplate,
+  shouldLockIdentitySignatures,
+  substituteOrgSignaturePlaceholders,
+} from '@/lib/org-signatures';
+import type { OrgSignaturePolicy } from '@/lib/admin/types';
+
+const basePolicy = (overrides: Partial<OrgSignaturePolicy> = {}): OrgSignaturePolicy => ({
+  enabled: true,
+  scope: 'instance',
+  mergeMode: 'replace',
+  instance: {
+    htmlTemplate: '<p>Org — {{display.name}} · {{brand.name}}</p>',
+    textTemplate: 'Org — {{display.name}} · {{brand.name}}',
+  },
+  perDomain: {},
+  ...overrides,
+});
+
+describe('org-signatures', () => {
+  it('extracts sender email domain', () => {
+    expect(extractEmailDomain('User@Example.COM')).toBe('example.com');
+    expect(extractEmailDomain('invalid')).toBeNull();
+  });
+
+  it('substitutes dotted placeholders and brand map by sender domain', () => {
+    const values = buildOrgSignaturePlaceholderValues(
+      { name: 'Alex Example', email: 'alex@acme.example.com' },
+      { 'acme.example.com': 'Acme Corp' },
+    );
+    expect(values['display.name']).toBe('Alex Example');
+    expect(values['brand.name']).toBe('Acme Corp');
+    expect(
+      substituteOrgSignaturePlaceholders('Hello {{display.name}} from {{brand.name}}', values),
+    ).toBe('Hello Alex Example from Acme Corp');
+  });
+
+  it('selects instance-wide or per-domain templates', () => {
+    const policy = basePolicy({
+      scope: 'per_domain',
+      perDomain: {
+        'example.com': {
+          htmlTemplate: '<p>Example domain sig</p>',
+          textTemplate: 'Example domain sig',
+        },
+      },
+    });
+    expect(resolveOrgSignatureTemplate(policy, 'user@example.com')?.htmlTemplate).toContain('Example domain');
+    expect(resolveOrgSignatureTemplate(policy, 'user@other.com')).toBeNull();
+    expect(resolveOrgSignatureTemplate(basePolicy(), 'user@example.com')?.htmlTemplate).toContain('Org —');
+  });
+
+  it('replace mode ignores user signature', () => {
+    const result = resolveEffectiveSignature(
+      { htmlSignature: '<p>User sig</p>', textSignature: 'User sig' },
+      { name: 'Alex', email: 'alex@example.com' },
+      basePolicy({ mergeMode: 'replace' }),
+      { 'example.com': 'Example Brand' },
+    );
+    expect(result.htmlSignature).toContain('Org — Alex');
+    expect(result.htmlSignature).not.toContain('User sig');
+  });
+
+  it('fallback mode keeps user signature when present', () => {
+    const result = resolveEffectiveSignature(
+      { textSignature: 'User sig' },
+      { name: 'Alex', email: 'alex@example.com' },
+      basePolicy({ mergeMode: 'fallback' }),
+      {},
+    );
+    expect(result.textSignature).toBe('User sig');
+  });
+
+  it('fallback mode uses org signature when user has none', () => {
+    const result = resolveEffectiveSignature(
+      {},
+      { name: 'Alex', email: 'alex@example.com' },
+      basePolicy({ mergeMode: 'fallback' }),
+      {},
+    );
+    expect(result.textSignature).toContain('Org — Alex');
+  });
+
+  it('append mode combines user and org signatures', () => {
+    const result = resolveEffectiveSignature(
+      { textSignature: 'User sig', htmlSignature: '<p>User sig</p>' },
+      { name: 'Alex', email: 'alex@example.com' },
+      basePolicy({ mergeMode: 'append' }),
+      {},
+    );
+    expect(result.textSignature).toBe('User sig\n\nOrg — Alex ·');
+    expect(result.htmlSignature).toContain('User sig');
+    expect(result.htmlSignature).toContain('Org — Alex');
+  });
+
+  it('locks identity editor only in replace mode', () => {
+    expect(shouldLockIdentitySignatures(basePolicy({ mergeMode: 'replace' }))).toBe(true);
+    expect(shouldLockIdentitySignatures(basePolicy({ mergeMode: 'append' }))).toBe(false);
+    expect(shouldLockIdentitySignatures(basePolicy({ enabled: false }))).toBe(false);
+  });
+
+  it('normalizes domain keys in brand map and per-domain templates', () => {
+    const normalized = normalizeOrgSignaturePolicy(
+      basePolicy({
+        scope: 'per_domain',
+        perDomain: {
+          'Example.COM': {
+            htmlTemplate: '<p>Domain</p>',
+            textTemplate: 'Domain',
+          },
+        },
+      }),
+    );
+    expect(normalized?.perDomain?.['example.com']?.textTemplate).toBe('Domain');
+
+    const brands = normalizeDomainBrandNames({
+      'Example.COM': 'Example Brand',
+      'bad domain': 'Skip',
+    });
+    expect(brands['example.com']).toBe('Example Brand');
+    expect(brands['bad domain']).toBeUndefined();
+  });
+
+  it('derives plain text from html when text template is empty', () => {
+    const content = resolveOrgSignatureContent(
+      { htmlTemplate: '<p>Line one</p><p>Line two</p>', textTemplate: '' },
+      { name: 'Alex', email: 'alex@example.com' },
+      {},
+    );
+    expect(content.text).toContain('Line one');
+    expect(content.text).toContain('Line two');
+  });
+});

--- a/lib/admin/config-manager.ts
+++ b/lib/admin/config-manager.ts
@@ -1,9 +1,13 @@
 import { readFile, writeFile, rename } from 'node:fs/promises';
 import { logger } from '@/lib/logger';
 import { readFileEnv } from '@/lib/read-file-env';
-import { CONFIG_ENV_MAP, DEFAULT_FEATURE_GATES, DEFAULT_POLICY, DEFAULT_THEME_POLICY, type SettingsPolicy } from './types';
+import { CONFIG_ENV_MAP, DEFAULT_FEATURE_GATES, DEFAULT_ORG_SIGNATURE_POLICY, DEFAULT_POLICY, DEFAULT_THEME_POLICY, type SettingsPolicy } from './types';
 import { ensureConfigDir, getConfigPath, assertWritable } from './paths';
 import { isValidRelayUrl, normalizeRelayUrl } from '@/lib/push-relays';
+import {
+  normalizeDomainBrandNames,
+  normalizeOrgSignaturePolicy,
+} from '@/lib/org-signatures';
 
 function parseEnvValue(value: string, type: string): unknown {
   switch (type) {
@@ -196,6 +200,8 @@ class ConfigManager {
       .filter(relay => isValidRelayUrl(relay.url));
     const defaultRelay = normalizeRelayUrl(policy.pushRelayUrl);
     policy.pushRelayUrl = isValidRelayUrl(defaultRelay) ? defaultRelay : '';
+    policy.orgSignature = normalizeOrgSignaturePolicy(policy.orgSignature) ?? { ...DEFAULT_ORG_SIGNATURE_POLICY };
+    policy.domainBrandNames = normalizeDomainBrandNames(policy.domainBrandNames);
     return policy;
   }
 

--- a/lib/admin/types.ts
+++ b/lib/admin/types.ts
@@ -109,6 +109,41 @@ export const DEFAULT_THEME_POLICY: ThemePolicy = {
   defaultThemeId: null,
 };
 
+export type OrgSignatureScope = 'instance' | 'per_domain';
+
+export type OrgSignatureMergeMode = 'replace' | 'append' | 'fallback';
+
+export interface OrgSignatureTemplate {
+  htmlTemplate: string;
+  textTemplate: string;
+}
+
+export interface OrgSignaturePolicy {
+  enabled: boolean;
+  scope: OrgSignatureScope;
+  /** replace = org only; append = user then org; fallback = org when user has none */
+  mergeMode: OrgSignatureMergeMode;
+  instance?: OrgSignatureTemplate;
+  /** Sender email domain (e.g. example.com) -> template */
+  perDomain?: Record<string, OrgSignatureTemplate>;
+  replySignaturePosition?: 'above_quote' | 'below_quote';
+  lockReplySignaturePosition?: boolean;
+  signatureSeparatorEnabled?: boolean;
+  lockSignatureSeparator?: boolean;
+}
+
+export const DEFAULT_ORG_SIGNATURE_POLICY: OrgSignaturePolicy = {
+  enabled: false,
+  scope: 'instance',
+  mergeMode: 'replace',
+  instance: { htmlTemplate: '', textTemplate: '' },
+  perDomain: {},
+  replySignaturePosition: 'above_quote',
+  lockReplySignaturePosition: false,
+  signatureSeparatorEnabled: true,
+  lockSignatureSeparator: false,
+};
+
 /** One entry of the Web Push relay list users can pick from. */
 export interface PushRelayOption {
   /** Name shown in the relay picker. Empty falls back to the URL host. */
@@ -137,6 +172,10 @@ export interface SettingsPolicy {
   pushRelayUrl?: string;
   /** When true, users are pinned to pushRelayUrl and cannot pick another relay. */
   pushRelayUrlLocked?: boolean;
+  /** Org-wide or per-domain enforced signature templates */
+  orgSignature?: OrgSignaturePolicy;
+  /** Sender email domain -> brand display name for {{brand.name}} in org signatures */
+  domainBrandNames?: Record<string, string>;
 }
 
 export const DEFAULT_POLICY: SettingsPolicy = {
@@ -150,6 +189,8 @@ export const DEFAULT_POLICY: SettingsPolicy = {
   pushRelays: [],
   pushRelayUrl: '',
   pushRelayUrlLocked: false,
+  orgSignature: { ...DEFAULT_ORG_SIGNATURE_POLICY },
+  domainBrandNames: {},
 };
 
 export interface AuditEntry {

--- a/lib/org-signatures.ts
+++ b/lib/org-signatures.ts
@@ -1,0 +1,316 @@
+import { sanitizeSignatureHtml } from '@/lib/email-sanitization';
+import { htmlToPlainText } from '@/lib/html-to-text';
+import type {
+  OrgSignatureMergeMode,
+  OrgSignaturePolicy,
+  OrgSignatureScope,
+  OrgSignatureTemplate,
+} from '@/lib/admin/types';
+
+export type SignatureSource = {
+  htmlSignature?: string;
+  textSignature?: string;
+};
+
+function normalizeSignatureInput(signature: {
+  htmlSignature?: string | null;
+  textSignature?: string | null;
+}): SignatureSource {
+  return {
+    htmlSignature: signature.htmlSignature ?? undefined,
+    textSignature: signature.textSignature ?? undefined,
+  };
+}
+
+export type SignatureIdentityContext = {
+  name?: string;
+  email?: string;
+};
+
+const PLACEHOLDER_REGEX = /\{\{([\w.]+)\}\}/g;
+
+const DOMAIN_KEY_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
+
+export function normalizeSenderDomain(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function isValidSenderDomain(value: string): boolean {
+  const normalized = normalizeSenderDomain(value);
+  return normalized.length > 0 && DOMAIN_KEY_RE.test(normalized);
+}
+
+export function extractEmailDomain(email: string | undefined | null): string | null {
+  if (!email) return null;
+  const at = email.lastIndexOf('@');
+  if (at <= 0 || at >= email.length - 1) return null;
+  const domain = normalizeSenderDomain(email.slice(at + 1));
+  return isValidSenderDomain(domain) ? domain : null;
+}
+
+export function buildOrgSignaturePlaceholderValues(
+  context: SignatureIdentityContext,
+  domainBrandNames?: Record<string, string>,
+): Record<string, string> {
+  const email = context.email?.trim() ?? '';
+  const displayName = context.name?.trim() ?? '';
+  const domain = extractEmailDomain(email);
+  const brandName = domain ? (domainBrandNames?.[domain] ?? '') : '';
+
+  return {
+    email,
+    name: displayName,
+    'display.name': displayName,
+    display_name: displayName,
+    'brand.name': brandName,
+    brand_name: brandName,
+  };
+}
+
+export function substituteOrgSignaturePlaceholders(
+  text: string,
+  values: Record<string, string>,
+): string {
+  return text.replace(PLACEHOLDER_REGEX, (full, key: string) => {
+    if (values[key] === undefined) return full;
+    return values[key];
+  });
+}
+
+export function resolveOrgSignatureTemplate(
+  policy: OrgSignaturePolicy | undefined,
+  senderEmail: string | undefined,
+): OrgSignatureTemplate | null {
+  if (!policy?.enabled) return null;
+
+  if (policy.scope === 'per_domain') {
+    const domain = extractEmailDomain(senderEmail);
+    if (!domain) return null;
+    const template = policy.perDomain?.[domain];
+    return templateHasContent(template) ? template! : null;
+  }
+
+  const instance = policy.instance;
+  return templateHasContent(instance) ? instance! : null;
+}
+
+function templateHasContent(template: OrgSignatureTemplate | undefined): boolean {
+  if (!template) return false;
+  return !!(template.htmlTemplate?.trim() || template.textTemplate?.trim());
+}
+
+export function resolveOrgSignatureContent(
+  template: OrgSignatureTemplate,
+  context: SignatureIdentityContext,
+  domainBrandNames?: Record<string, string>,
+): { html: string; text: string } {
+  const values = buildOrgSignaturePlaceholderValues(context, domainBrandNames);
+  const htmlRaw = substituteOrgSignaturePlaceholders(template.htmlTemplate ?? '', values);
+  const textRaw = substituteOrgSignaturePlaceholders(template.textTemplate ?? '', values);
+  const html = htmlRaw.trim() ? sanitizeSignatureHtml(htmlRaw) : '';
+  let text = textRaw.trim();
+  if (!text && html) {
+    text = htmlToPlainText(html);
+  }
+  return { html, text };
+}
+
+export function hasUserSignature(signature: SignatureSource): boolean {
+  return !!(signature.htmlSignature?.trim() || signature.textSignature?.trim());
+}
+
+function getUserPlainText(signature: SignatureSource): string {
+  if (signature.textSignature?.trim()) {
+    return signature.textSignature.trim();
+  }
+  if (signature.htmlSignature?.trim()) {
+    return htmlToPlainText(sanitizeSignatureHtml(signature.htmlSignature));
+  }
+  return '';
+}
+
+function mergeHtmlSignatures(userHtml: string | undefined | null, orgHtml: string): string | undefined {
+  const parts: string[] = [];
+  if (userHtml?.trim()) parts.push(sanitizeSignatureHtml(userHtml));
+  if (orgHtml.trim()) parts.push(orgHtml);
+  if (parts.length === 0) return undefined;
+  return parts.join('');
+}
+
+function mergeTextSignatures(userSignature: SignatureSource, orgText: string): string | undefined {
+  const parts: string[] = [];
+  const userText = getUserPlainText(userSignature);
+  if (userText) parts.push(userText);
+  if (orgText.trim()) parts.push(orgText.trim());
+  if (parts.length === 0) return undefined;
+  return parts.join('\n\n');
+}
+
+export function resolveEffectiveSignature(
+  userSignature: {
+    htmlSignature?: string | null;
+    textSignature?: string | null;
+  },
+  context: SignatureIdentityContext,
+  policy: OrgSignaturePolicy | undefined,
+  domainBrandNames?: Record<string, string>,
+): SignatureSource {
+  const normalizedUser = normalizeSignatureInput(userSignature);
+  const template = resolveOrgSignatureTemplate(policy, context.email);
+  if (!policy?.enabled || !template) {
+    return normalizedUser;
+  }
+
+  const org = resolveOrgSignatureContent(template, context, domainBrandNames);
+  const userHasSignature = hasUserSignature(normalizedUser);
+
+  switch (policy.mergeMode) {
+    case 'replace':
+      return {
+        htmlSignature: org.html || undefined,
+        textSignature: org.text || undefined,
+      };
+    case 'fallback':
+      if (userHasSignature) return normalizedUser;
+      return {
+        htmlSignature: org.html || undefined,
+        textSignature: org.text || undefined,
+      };
+    case 'append':
+      return {
+        htmlSignature: mergeHtmlSignatures(normalizedUser.htmlSignature, org.html),
+        textSignature: mergeTextSignatures(normalizedUser, org.text),
+      };
+    default:
+      return normalizedUser;
+  }
+}
+
+export function shouldLockIdentitySignatures(policy: OrgSignaturePolicy | undefined): boolean {
+  return !!(policy?.enabled && policy.mergeMode === 'replace');
+}
+
+export function getEffectiveSignaturePosition(
+  userPosition: 'above_quote' | 'below_quote',
+  policy: OrgSignaturePolicy | undefined,
+): 'above_quote' | 'below_quote' {
+  if (
+    policy?.enabled &&
+    policy.lockReplySignaturePosition &&
+    policy.replySignaturePosition
+  ) {
+    return policy.replySignaturePosition;
+  }
+  return userPosition;
+}
+
+export function getEffectiveSignatureSeparator(
+  userEnabled: boolean,
+  policy: OrgSignaturePolicy | undefined,
+): boolean {
+  if (policy?.enabled && policy.lockSignatureSeparator && policy.signatureSeparatorEnabled !== undefined) {
+    return policy.signatureSeparatorEnabled;
+  }
+  return userEnabled;
+}
+
+export function isReplySignaturePositionLocked(policy: OrgSignaturePolicy | undefined): boolean {
+  return !!(policy?.enabled && policy.lockReplySignaturePosition);
+}
+
+export function isSignatureSeparatorLocked(policy: OrgSignaturePolicy | undefined): boolean {
+  return !!(policy?.enabled && policy.lockSignatureSeparator);
+}
+
+export function normalizeOrgSignaturePolicy(
+  policy: OrgSignaturePolicy | undefined,
+): OrgSignaturePolicy | undefined {
+  if (!policy) return undefined;
+
+  const perDomain: Record<string, OrgSignatureTemplate> = {};
+  if (policy.perDomain && typeof policy.perDomain === 'object') {
+    for (const [rawDomain, template] of Object.entries(policy.perDomain)) {
+      const domain = normalizeSenderDomain(rawDomain);
+      if (!isValidSenderDomain(domain)) continue;
+      if (!template || typeof template !== 'object') continue;
+      perDomain[domain] = {
+        htmlTemplate: typeof template.htmlTemplate === 'string' ? template.htmlTemplate : '',
+        textTemplate: typeof template.textTemplate === 'string' ? template.textTemplate : '',
+      };
+    }
+  }
+
+  const scope: OrgSignatureScope = policy.scope === 'per_domain' ? 'per_domain' : 'instance';
+  const mergeMode: OrgSignatureMergeMode =
+    policy.mergeMode === 'append' || policy.mergeMode === 'fallback'
+      ? policy.mergeMode
+      : 'replace';
+
+  return {
+    enabled: policy.enabled === true,
+    scope,
+    mergeMode,
+    instance: policy.instance && typeof policy.instance === 'object'
+      ? {
+          htmlTemplate: typeof policy.instance.htmlTemplate === 'string' ? policy.instance.htmlTemplate : '',
+          textTemplate: typeof policy.instance.textTemplate === 'string' ? policy.instance.textTemplate : '',
+        }
+      : { htmlTemplate: '', textTemplate: '' },
+    perDomain,
+    replySignaturePosition:
+      policy.replySignaturePosition === 'below_quote' ? 'below_quote' : 'above_quote',
+    lockReplySignaturePosition: policy.lockReplySignaturePosition === true,
+    signatureSeparatorEnabled: policy.signatureSeparatorEnabled !== false,
+    lockSignatureSeparator: policy.lockSignatureSeparator === true,
+  };
+}
+
+export function normalizeDomainBrandNames(
+  value: Record<string, string> | undefined,
+): Record<string, string> {
+  if (!value || typeof value !== 'object') return {};
+  const out: Record<string, string> = {};
+  for (const [rawDomain, brand] of Object.entries(value)) {
+    const domain = normalizeSenderDomain(rawDomain);
+    if (!isValidSenderDomain(domain)) continue;
+    if (typeof brand !== 'string') continue;
+    const trimmed = brand.trim();
+    if (!trimmed) continue;
+    out[domain] = trimmed;
+  }
+  return out;
+}
+
+export function buildComposerSignatureIdentity<
+  T extends SignatureSource & { id?: string; name?: string; email?: string },
+>(
+  currentIdentity: T | null | undefined,
+  primaryIdentity: T | null | undefined,
+  orgPolicy: OrgSignaturePolicy | undefined,
+  domainBrandNames?: Record<string, string>,
+): (SignatureSource & { id?: string }) | null {
+  const contextIdentity = currentIdentity ?? primaryIdentity;
+  if (!contextIdentity) return null;
+
+  const userSource =
+    currentIdentity?.htmlSignature || currentIdentity?.textSignature
+      ? currentIdentity
+      : primaryIdentity;
+
+  const merged = resolveEffectiveSignature(
+    {
+      htmlSignature: userSource?.htmlSignature,
+      textSignature: userSource?.textSignature,
+    },
+    { name: contextIdentity.name, email: contextIdentity.email },
+    orgPolicy,
+    domainBrandNames,
+  );
+
+  if (!merged.htmlSignature && !merged.textSignature) return null;
+  return {
+    id: contextIdentity.id,
+    htmlSignature: merged.htmlSignature ?? undefined,
+    textSignature: merged.textSignature ?? undefined,
+  };
+}

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "توقيع HTML",
       "signature_byte_counter": "{bytes} / {max} بايت",
       "signature_byte_limit_reached": "تم بلوغ حد الخادم",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "حفظ الهوية",
       "cancel": "إلغاء",
       "creating": "جارٍ الإنشاء...",

--- a/locales/ca/common.json
+++ b/locales/ca/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "Signatura HTML",
       "signature_byte_counter": "{bytes} / {max} bytes",
       "signature_byte_limit_reached": "S'ha arribat al límit del servidor",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Desa la identitat",
       "cancel": "Cancel·la",
       "creating": "Creant...",

--- a/locales/cs/common.json
+++ b/locales/cs/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "HTML podpis",
       "signature_byte_counter": "{bytes} / {max} bajtů",
       "signature_byte_limit_reached": "Dosažen limit serveru",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Uložit identitu",
       "cancel": "Zrušit",
       "creating": "Vytváření...",

--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "HTML-signatur",
       "signature_byte_counter": "{bytes} / {max} bytes",
       "signature_byte_limit_reached": "Servergrænse nået",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Gem identitet",
       "cancel": "Annuller",
       "creating": "Opretter...",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "HTML-Signatur",
       "signature_byte_counter": "{bytes} / {max} Bytes",
       "signature_byte_limit_reached": "Serverlimit erreicht",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Identität speichern",
       "cancel": "Abbrechen",
       "creating": "Wird erstellt...",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -2271,6 +2271,7 @@
       "html_signature_label": "HTML Signature",
       "signature_byte_counter": "{bytes} / {max} bytes",
       "signature_byte_limit_reached": "Server limit reached",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Save Identity",
       "cancel": "Cancel",
       "creating": "Creating...",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "Firma HTML",
       "signature_byte_counter": "{bytes} / {max} bytes",
       "signature_byte_limit_reached": "Límite del servidor alcanzado",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Guardar Identidad",
       "cancel": "Cancelar",
       "creating": "Creando...",

--- a/locales/fa/common.json
+++ b/locales/fa/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "امضای HTML",
       "signature_byte_counter": "{bytes} / {max} بایت",
       "signature_byte_limit_reached": "حد سرور",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "ذخیره هویت",
       "cancel": "انصراف",
       "creating": "در حال ایجاد...",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "Signature HTML",
       "signature_byte_counter": "{bytes} / {max} octets",
       "signature_byte_limit_reached": "Limite du serveur atteinte",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Enregistrer l'identité",
       "cancel": "Annuler",
       "creating": "Création...",

--- a/locales/he/common.json
+++ b/locales/he/common.json
@@ -2186,7 +2186,8 @@
       "creating": "יוצר...",
       "updating": "מעדכן...",
       "signature_byte_counter": "{bytes} / {max} בתים",
-      "signature_byte_limit_reached": "הגבול של השרת הושג"
+      "signature_byte_limit_reached": "הגבול של השרת הושג",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here."
     },
     "sub_address": {
       "button_tooltip": "השתמש בכתובת משנה",

--- a/locales/hu/common.json
+++ b/locales/hu/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "HTML aláírás",
       "signature_byte_counter": "{bytes} / {max} bájt",
       "signature_byte_limit_reached": "Szerverkorlát elérve",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Azonosság mentése",
       "cancel": "Mégse",
       "creating": "Létrehozás...",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "Firma HTML",
       "signature_byte_counter": "{bytes} / {max} byte",
       "signature_byte_limit_reached": "Limite del server raggiunto",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Salva identità",
       "cancel": "Annulla",
       "creating": "Creazione...",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "HTML署名",
       "signature_byte_counter": "{bytes} / {max} バイト",
       "signature_byte_limit_reached": "サーバーの上限に達しました",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "送信者情報を保存",
       "cancel": "キャンセル",
       "creating": "作成中...",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "HTML 서명",
       "signature_byte_counter": "{bytes} / {max} 바이트",
       "signature_byte_limit_reached": "서버 한도 도달",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "저장",
       "cancel": "취소",
       "creating": "만드는 중...",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "HTML paraksts",
       "signature_byte_counter": "{bytes} / {max} baiti",
       "signature_byte_limit_reached": "Sasniegts servera ierobežojums",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Saglabāt identitāti",
       "cancel": "Atcelt",
       "creating": "Izveido...",

--- a/locales/mn/common.json
+++ b/locales/mn/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "HTML гарын үсэг",
       "signature_byte_counter": "{bytes} / {max} байт",
       "signature_byte_limit_reached": "Серверийн хязгаарт хүрсэн",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Таниулбарыг хадгалах",
       "cancel": "Цуцлах",
       "creating": "Бүтээж байна...",

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "HTML-handtekening",
       "signature_byte_counter": "{bytes} / {max} bytes",
       "signature_byte_limit_reached": "Serverlimiet bereikt",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Identiteit opslaan",
       "cancel": "Annuleren",
       "creating": "Aanmaken...",

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "Podpis HTML",
       "signature_byte_counter": "{bytes} / {max} bajtów",
       "signature_byte_limit_reached": "Osiągnięto limit serwera",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Zapisz tożsamość",
       "cancel": "Anuluj",
       "creating": "Tworzenie...",

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "Assinatura HTML",
       "signature_byte_counter": "{bytes} / {max} bytes",
       "signature_byte_limit_reached": "Limite do servidor atingido",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Salvar Identidade",
       "cancel": "Cancelar",
       "creating": "Criando...",

--- a/locales/ro/common.json
+++ b/locales/ro/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "HTML Semnătură",
       "signature_byte_counter": "{bytes} / {max} bytes",
       "signature_byte_limit_reached": "Limita serverului a fost atinsă",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Salvați identitatea",
       "cancel": "Anulează",
       "creating": "Se creează...",

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "HTML-подпись",
       "signature_byte_counter": "{bytes} / {max} байт",
       "signature_byte_limit_reached": "Достигнут лимит сервера",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Сохранить идентификацию",
       "cancel": "Отмена",
       "creating": "Создание...",

--- a/locales/sk/common.json
+++ b/locales/sk/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "HTML podpis",
       "signature_byte_counter": "{bytes} / {max} bajtov",
       "signature_byte_limit_reached": "Dosiahnutý limit servera",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Uložiť identitu",
       "cancel": "Zrušiť",
       "creating": "Vytváranie...",

--- a/locales/tr/common.json
+++ b/locales/tr/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "HTML İmzası",
       "signature_byte_counter": "{bytes} / {max} bayt",
       "signature_byte_limit_reached": "Sunucu sınırına ulaşıldı",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Kimliği Kaydet",
       "cancel": "İptal",
       "creating": "Oluşturuluyor...",

--- a/locales/uk/common.json
+++ b/locales/uk/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "Підпис HTML",
       "signature_byte_counter": "{bytes} / {max} байтів",
       "signature_byte_limit_reached": "Досягнуто обмеження сервера",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "Зберегти ідентифікатор",
       "cancel": "Скасувати",
       "creating": "Створення...",

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -2255,6 +2255,7 @@
       "html_signature_label": "HTML 签名",
       "signature_byte_counter": "{bytes} / {max} 字节",
       "signature_byte_limit_reached": "已达服务器限制",
+      "org_signature_locked": "Your administrator manages signatures for this account. Personal HTML and plain-text signatures cannot be edited here.",
       "save": "保存身份",
       "cancel": "取消",
       "creating": "创建中...",

--- a/stores/admin-tab-store.ts
+++ b/stores/admin-tab-store.ts
@@ -7,6 +7,7 @@ export const ADMIN_TABS = [
   'branding',
   'auth',
   'policy',
+  'signatures',
   'plugins',
   'themes',
   'marketplace',

--- a/stores/policy-store.ts
+++ b/stores/policy-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { SettingsPolicy, FeatureGates, SettingRestriction, ThemePolicy } from '@/lib/admin/types';
+import type { SettingsPolicy, FeatureGates, SettingRestriction, ThemePolicy, OrgSignaturePolicy } from '@/lib/admin/types';
 import { DEFAULT_POLICY, DEFAULT_THEME_POLICY } from '@/lib/admin/types';
 import { apiFetch } from '@/lib/browser-navigation';
 
@@ -18,6 +18,8 @@ interface PolicyState {
   isPluginForceEnabled: (pluginId: string) => boolean;
   isPluginApproved: (pluginId: string) => boolean;
   isThemeForceEnabled: (themeId: string) => boolean;
+  getOrgSignaturePolicy: () => OrgSignaturePolicy | undefined;
+  getDomainBrandNames: () => Record<string, string>;
 }
 
 export const usePolicyStore = create<PolicyState>()((set, get) => ({
@@ -92,5 +94,13 @@ export const usePolicyStore = create<PolicyState>()((set, get) => ({
 
   isThemeForceEnabled: (themeId) => {
     return (get().policy.forceEnabledThemes || []).includes(themeId);
+  },
+
+  getOrgSignaturePolicy: () => {
+    return get().policy.orgSignature;
+  },
+
+  getDomainBrandNames: () => {
+    return get().policy.domainBrandNames ?? {};
   },
 }));


### PR DESCRIPTION
## Summary

Adds admin-enforced email signatures that can be applied **instance-wide** or **per sender email domain**, without stuffing large HTML into JMAP `Identity.htmlSignature` (which many servers, including Stalwart, limit to ~2047 bytes).

Templates are stored in admin policy, resolved at compose time from the selected identity’s address, and injected through Bulwark’s existing signature embed / send path.

### Policy model

New fields on `SettingsPolicy`:

- **`orgSignature`**
  - `enabled`
  - `scope`: `instance` | `per_domain`
  - `mergeMode`:
    - `replace` — org/domain signature only (ignore user signature)
    - `append` — user signature, then org/domain signature
    - `fallback` — org/domain signature only when the user has none
  - `instance` / `perDomain` HTML + plain-text templates
  - reply signature position + optional lock for users
  - `-- ` separator preference + optional lock for users
- **`domainBrandNames`**: sender email domain → brand display name (for `{{brand.name}}`)

### Template placeholders

Supported in org/domain templates:

- `{{display.name}}` / `{{name}}` / `{{display_name}}`
- `{{email}}`
- `{{brand.name}}` / `{{brand_name}}` (looked up from `domainBrandNames` by **sender email domain**)

### Admin UI (`Admin → Signatures`)

- Enable/disable, scope, and merge mode
- Instance-wide or per-domain template editors
- Brand name map (domain → brand)
- Reply placement + lock; separator + lock
- **Sample identity preview** (display name + email) so admins who are not regular mail users can preview org-only and effective merged output

### User-facing behaviour

- **Composer**: resolves the effective signature from the selected identity + policy; respects admin-locked reply position and separator
- **Identity editor**: hides personal HTML/plain signature fields when merge mode is `replace`
- **Composing settings**: locks signature position / separator controls when the admin locks them

### Implementation notes

- Resolution lives in `lib/org-signatures.ts` (normalized on policy load via `config-manager`)
- Independent of the signature-inline-images work; this PR does not depend on persistent CID signature assets
- Org HTML is injected at compose time (not written into JMAP Identity signature fields)

## Test plan

- [ ] Enable org signatures with **instance** scope + **replace**; compose as a user and confirm only the org template appears
- [ ] Switch merge mode to **append**; confirm user signature then org signature
- [ ] Switch to **fallback**; confirm org sig only when the identity has no personal signature
- [ ] Switch scope to **per_domain**; add templates for two domains and confirm the selected From address picks the matching template
- [ ] Set `domainBrandNames` and confirm `{{brand.name}}` resolves from the sender domain
- [ ] Use Admin → Signatures sample identity preview for org-only and merged output
- [ ] Lock reply signature position; confirm user Composing settings control is locked and composer follows admin position
- [ ] With **replace** mode, open identity editor and confirm signature fields are hidden/locked
- [ ] Confirm existing plain/HTML user signatures still work when org signatures are disabled
- [ ] `npx vitest run lib/__tests__/org-signatures.test.ts` passes


Made with [Cursor](https://cursor.com)