### PR TITLE
add file-based env variables for LibreTranslate and Stalwart Impersonation & handle file-based vars from JSON configs in ConfigManager

### DIFF
--- a/app/api/translate/route.ts
+++ b/app/api/translate/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { readFileEnv } from "@/lib/read-file-env";
 import { getStalwartCredentials } from '@/lib/stalwart/credentials';
 
 // Host-side proxy backing the "Translate" plugin (manifest apiPostPaths:
@@ -11,7 +12,7 @@ import { getStalwartCredentials } from '@/lib/stalwart/credentials';
 //                       langpair needs an explicit source language, so when the
 //                       plugin asks for "auto" we detect it locally first.
 //   - "libretranslate" — only available when the host sets LIBRETRANSLATE_URL
-//                       (and optionally LIBRETRANSLATE_API_KEY). Supports native
+//                       (and optionally LIBRETRANSLATE_API_KEY or LIBRETRANSLATE_API_KEY_FILE). Supports native
 //                       source auto-detection.
 
 export const runtime = 'nodejs';
@@ -225,7 +226,9 @@ async function translateLibre(
   if (!endpoint) {
     throw new Error('LibreTranslate is not configured on this server');
   }
-  const apiKey = process.env.LIBRETRANSLATE_API_KEY;
+  const apiKey =
+    process.env.LIBRETRANSLATE_API_KEY ||
+    readFileEnv(process.env.LIBRETRANSLATE_API_KEY_FILE);
   const url = endpoint.replace(/\/+$/, '') + '/translate';
   const res = await fetch(url, {
     method: 'POST',

--- a/lib/admin/config-manager.ts
+++ b/lib/admin/config-manager.ts
@@ -58,12 +58,17 @@ class ConfigManager {
    */
   get<T>(key: string, defaultValue?: T): T {
     // Admin override (highest priority)
+    const mapping = CONFIG_ENV_MAP[key];
     if (key in this.adminConfig) {
       return this.adminConfig[key] as T;
+    } else if (mapping && mapping.fileKey && mapping.fileKey in this.adminConfig) {
+      const fileVal = readFileEnv(<string | undefined>this.adminConfig[mapping.fileKey]);
+      if (fileVal !== null) {
+        return parseEnvValue(fileVal, mapping.type) as T;
+      }
     }
 
     // Environment variable
-    const mapping = CONFIG_ENV_MAP[key];
     if (mapping) {
       const envVal = process.env[mapping.envVar];
       if (envVal !== undefined) {
@@ -101,6 +106,14 @@ class ConfigManager {
     for (const [key, mapping] of Object.entries(CONFIG_ENV_MAP)) {
       if (key in this.adminConfig) {
         result[key] = { value: this.adminConfig[key], source: 'admin' };
+      } else if (mapping.fileKey && mapping.fileKey in this.adminConfig) {
+        const fileVal = readFileEnv(<string | undefined>this.adminConfig[mapping.fileKey]);
+        if (fileVal !== null) {
+          result[key] = { value: parseEnvValue(fileVal, mapping.type), source: 'admin' };
+          continue;
+        }
+
+        result[key] = { value: mapping.defaultValue, source: 'default' };
       } else {
         const envVal = process.env[mapping.envVar];
         if (envVal !== undefined) {

--- a/lib/admin/types.ts
+++ b/lib/admin/types.ts
@@ -185,7 +185,7 @@ export interface AuditEntry {
 }
 
 /** Config keys that map to environment variables */
-export const CONFIG_ENV_MAP: Record<string, { envVar: string; fileEnvVar?: string; type: 'string' | 'boolean' | 'url' | 'enum' | 'json'; defaultValue: unknown; enumValues?: string[] }> = {
+export const CONFIG_ENV_MAP: Record<string, { envVar: string; fileEnvVar?: string; fileKey?: string; type: 'string' | 'boolean' | 'url' | 'enum' | 'json'; defaultValue: unknown; enumValues?: string[] }> = {
   appName: { envVar: 'APP_NAME', type: 'string', defaultValue: 'Webmail' },
   appShortName: { envVar: 'APP_SHORT_NAME', type: 'string', defaultValue: '' },
   appDescription: { envVar: 'APP_DESCRIPTION', type: 'string', defaultValue: '' },
@@ -232,7 +232,7 @@ export const CONFIG_ENV_MAP: Record<string, { envVar: string; fileEnvVar?: strin
   oauthEnabled: { envVar: 'OAUTH_ENABLED', type: 'boolean', defaultValue: false },
   oauthOnly: { envVar: 'OAUTH_ONLY', type: 'boolean', defaultValue: false },
   oauthClientId: { envVar: 'OAUTH_CLIENT_ID', type: 'string', defaultValue: '' },
-  oauthClientSecret: { envVar: 'OAUTH_CLIENT_SECRET', fileEnvVar: 'OAUTH_CLIENT_SECRET_FILE', type: 'string', defaultValue: '' },
+  oauthClientSecret: { envVar: 'OAUTH_CLIENT_SECRET', fileEnvVar: 'OAUTH_CLIENT_SECRET_FILE', fileKey: "oauthClientSecretFile", type: 'string', defaultValue: '' },
   oauthIssuerUrl: { envVar: 'OAUTH_ISSUER_URL', type: 'url', defaultValue: '' },
   // Overrides only the user-facing authorize endpoint. Discovery, token exchange
   // and refresh continue to use the canonical OAUTH_ISSUER_URL. Lets a per-brand
@@ -263,7 +263,7 @@ export const CONFIG_ENV_MAP: Record<string, { envVar: string; fileEnvVar?: strin
   settingsSyncEnabled: { envVar: 'SETTINGS_SYNC_ENABLED', type: 'boolean', defaultValue: false },
   logFormat: { envVar: 'LOG_FORMAT', type: 'enum', defaultValue: 'text', enumValues: ['text', 'json'] },
   logLevel: { envVar: 'LOG_LEVEL', type: 'enum', defaultValue: 'info', enumValues: ['error', 'warn', 'info', 'debug'] },
-  sessionSecret: { envVar: 'SESSION_SECRET', fileEnvVar: 'SESSION_SECRET_FILE', type: 'string', defaultValue: '' },
+  sessionSecret: { envVar: 'SESSION_SECRET', fileEnvVar: 'SESSION_SECRET_FILE', fileKey: "sessionSecretFile", type: 'string', defaultValue: '' },
   extensionDirectoryUrl: { envVar: 'EXTENSION_DIRECTORY_URL', type: 'url', defaultValue: 'https://extensions.bulwarkmail.org' },
   // WOPI document editing (#425). `wopiClientUrl` is the editor's base URL
   // (Collabora Online / OnlyOffice / EuroOffice, ...); discovery is fetched

--- a/lib/impersonation/master-config.ts
+++ b/lib/impersonation/master-config.ts
@@ -1,4 +1,5 @@
 import { configManager } from '@/lib/admin/config-manager';
+import { readFileEnv } from "@/lib/read-file-env";
 
 export interface ImpersonationConfig {
   jwtSecret: string;
@@ -16,13 +17,27 @@ export interface ImpersonationConfig {
  *   BULWARK_STALWART_MASTER_USER   master account address (e.g. master@example.com)
  *   BULWARK_STALWART_MASTER_PASSWORD
  *
+ * Alternatively the file-based env:
+ *   BULWARK_JWT_AUTH_SECRET_FILE
+ *   BULWARK_STALWART_MASTER_USER_FILE
+ *   BULWARK_STALWART_MASTER_PASSWORD_FILE
+ *
  * Optional env:
  *   BULWARK_JWT_AUTH_ISSUER        (default: "platform-api/webmail")
  */
 export function readImpersonationConfig(): ImpersonationConfig | null {
-  const jwtSecret = process.env.BULWARK_JWT_AUTH_SECRET ?? '';
-  const masterUser = process.env.BULWARK_STALWART_MASTER_USER ?? '';
-  const masterPassword = process.env.BULWARK_STALWART_MASTER_PASSWORD ?? '';
+  const jwtSecret =
+    process.env.BULWARK_JWT_AUTH_SECRET ??
+    readFileEnv(process.env.BULWARK_JWT_AUTH_SECRET_FILE) ??
+    "";
+  const masterUser =
+    process.env.BULWARK_STALWART_MASTER_USER ??
+    readFileEnv(process.env.BULWARK_STALWART_MASTER_USER_FILE) ??
+    "";
+  const masterPassword =
+    process.env.BULWARK_STALWART_MASTER_PASSWORD ??
+    readFileEnv(process.env.BULWARK_STALWART_MASTER_PASSWORD_FILE) ??
+    "";
   if (!jwtSecret || !masterUser || !masterPassword) return null;
   return {
     jwtSecret,


### PR DESCRIPTION
## Summary

I think the missing file-based env vars are clear.
For ConfigManager however I noticed that Bulwark complains about `SESSION_SECRET` not being set when logging in as admin when using `sessionSecretFile` in `config.json`. The thing is, it doesn’t recognize this as variant of `sessionSecret` which this PR fixes.

I didn’t test LibreTranslate and Stalwart Impersonation.

## Changes

<!-- A bulleted list of the key changes made. -->

- read file-based env vars for LibreTranslate and Stalwart Impersonation secrets
- add a `fileKey` field on `CONFIG_ENV_MAP`
- ConfigManager’s `get` and `getAllWithSources` now also try using `fileKey`

## Related issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [ ] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
