### PR TITLE
fix: event toolbar overflow in edit mode

### DIFF
--- a/components/calendar/event-modal.tsx
+++ b/components/calendar/event-modal.tsx
@@ -1357,11 +1357,11 @@ export function EventModal({
         </div>
       </div>
 
-      <div className="flex items-center justify-between px-6 py-4 border-t border-border flex-shrink-0">
-        <div className="flex items-center gap-1">
+      <div className="flex items-center justify-between px-6 py-4 border-t border-border flex-shrink-0 flex-wrap gap-y-2">
+        <div className="flex items-center gap-1 w-full">
           {isEdit && onDelete && (
             showDeleteConfirm ? (
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 flex-wrap">
                 <div>
                   <span className="text-sm text-red-600 dark:text-red-400">
                     {t("form.delete_confirm")}
@@ -1376,11 +1376,16 @@ export function EventModal({
                   variant="outline"
                   size="sm"
                   onClick={() => { onDelete(event!.id, hasParticipants || undefined); onClose(); }}
-                  className="text-red-600 dark:text-red-400 border-red-300 dark:border-red-700"
+                  className="text-red-600 dark:text-red-400 border-red-300 dark:border-red-700 w-full"
                 >
                   {t("events.delete")}
                 </Button>
-                <Button variant="ghost" size="sm" onClick={() => setShowDeleteConfirm(false)}>
+                <Button 
+                  variant="ghost" 
+                  size="sm" 
+                  onClick={() => setShowDeleteConfirm(false)}
+                  className="w-full"
+                >
                   {t("form.cancel")}
                 </Button>
               </div>
@@ -1389,7 +1394,7 @@ export function EventModal({
                 variant="ghost"
                 size="sm"
                 onClick={() => setShowDeleteConfirm(true)}
-                className="text-red-600 dark:text-red-400"
+                className="text-red-600 dark:text-red-400 w-full"
               >
                 <Trash2 className="w-4 h-4 me-1" />
                 {t("events.delete")}
@@ -1402,21 +1407,32 @@ export function EventModal({
               size="sm"
               onClick={handleDuplicate}
               aria-label={t("events.duplicate")}
+              className="w-full"
             >
               <Copy className="w-4 h-4 me-1" />
               {t("events.duplicate")}
             </Button>
           )}
         </div>
-
-        <div className="flex gap-2">
-          <Button variant="outline" onClick={isEdit ? () => setMode("view") : onClose}>
+        
+        {isEdit && !showDeleteConfirm && (
+        <div className="flex gap-2 w-full">
+          <Button 
+            variant="outline"
+            onClick={isEdit ? () => setMode("view") : onClose}
+            className="w-full"
+          >
             {t("form.cancel")}
           </Button>
-          <Button onClick={handleSave} disabled={!title.trim() || isSaving}>
+          <Button
+            onClick={handleSave} 
+            disabled={!title.trim() || isSaving}
+            className="w-full"
+          >
             {t("form.save")}
           </Button>
         </div>
+        )}
       </div>
     </div>
   );

--- a/components/calendar/event-modal.tsx
+++ b/components/calendar/event-modal.tsx
@@ -1415,7 +1415,7 @@ export function EventModal({
           )}
         </div>
         
-        {isEdit && !showDeleteConfirm && (
+        {!showDeleteConfirm && (
         <div className="flex gap-2 w-full">
           <Button 
             variant="outline"


### PR DESCRIPTION
## Summary

This PR addresses the issue of the calendar event modal's edit toolbar overflowing when dealing with less concise locales (e.g., French). The solution spans the edit toolbar over two lines instead of one, allowing each button to take up more space while improving readability.

## Changes

In the calendar event modal :
- Returned to next line cancel and save buttons
- Hid cancel and save buttons when confirming deletion
- Revised deletion confirm layout

## Related issues

Fixes #881

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

### Previous base layout (english/french)
<img width="2363" height="1298" alt="base_edit_en_layout" src="https://github.com/user-attachments/assets/eb00dde5-e13e-40a4-b61a-11b57d1da57e" />
<img width="2363" height="1298" alt="base_edit_fr_layout" src="https://github.com/user-attachments/assets/b8ea039f-ecf6-422c-aee3-2a1d9b06d1ba" />

### Revised base layout (english/french)
<img width="2363" height="1298" alt="base_edit_en_layout_revised" src="https://github.com/user-attachments/assets/daee4ecb-8b3f-479f-83a2-e1899242df1a" />
<img width="2363" height="1298" alt="base_edit_fr_layout_revised" src="https://github.com/user-attachments/assets/7c27ebd1-bc76-435a-b44e-a0a75ed7b344" />

### Previous deletion confirm (english/french)
<img width="2363" height="1298" alt="delete_confirm_edit_en_layout" src="https://github.com/user-attachments/assets/72d64713-b24f-4606-bae4-59251ad6aba7" />
<img width="2363" height="1298" alt="delete_confirm_edit_fr_layout" src="https://github.com/user-attachments/assets/ca98a178-3328-4f17-a05c-a6c40bb09dfa" />

### Revised deletion confirm (english/french)
<img width="2363" height="1298" alt="delete_confirm_edit_en_layout_revised" src="https://github.com/user-attachments/assets/97abfe9f-bf1a-4d0e-9572-3a11787a1e9f" />
<img width="2363" height="1298" alt="delete_confirm_edit_fr_layout_revised" src="https://github.com/user-attachments/assets/205ceeda-a4ab-46d8-935e-7eb25629f9d4" />

## Notes for reviewers

I figured out it was mostly CSS changes which seemed to be within my capability. I did also change the cancel and save buttons behaviour to hide them when confirming deletion. Let me know if there is anything wrong, while I do code on own project, it's my first *proper* contribution.