### PR TITLE
fix: paginate mailbox retrieval beyond maxObjectsInGet

### DIFF
--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -70,6 +70,7 @@ import { AccountSwitcher } from "./account-switcher";
 import { useIsEmbedded } from "@/hooks/use-is-embedded";
 import { buildSettingsPath, SCHEDULED_MAILBOX_ID, scopedScheduledMailboxId } from "@/lib/deep-links";
 import { useTour } from "@/components/tour/tour-provider";
+import { flattenVisibleTree } from "@/lib/folder-tree-dnd";
 
 interface SidebarProps {
   mailboxes: Mailbox[];
@@ -127,6 +128,9 @@ interface SidebarProps {
 const ROW_PX_BASE = 8;
 const CHEVRON_SLOT = 20;
 const INDENT_STEP = 12;
+const MAX_AUTO_EXPANDED_MAILBOXES = 1000;
+const MAILBOX_ROW_BATCH = 250;
+const NO_EXPANDED_MAILBOXES = new Set<string>();
 
 const getIconForMailbox = (role?: string, name?: string, hasChildren?: boolean, isExpanded?: boolean, _isShared?: boolean, id?: string) => {
   const lowerName = name?.toLowerCase() || "";
@@ -281,6 +285,7 @@ interface SidebarRowProps {
   testRole?: string | null;
   testName?: string;
   testMailboxId?: string;
+  testParentId?: string | null;
   testShared?: boolean;
 }
 
@@ -306,6 +311,7 @@ function SidebarRow({
   testRole,
   testName,
   testMailboxId,
+  testParentId,
   testShared,
 }: SidebarRowProps) {
   const t = useTranslations('sidebar');
@@ -320,6 +326,7 @@ function SidebarRow({
       data-folder-role={testRole ?? undefined}
       data-folder-name={testName ?? undefined}
       data-mailbox-id={testMailboxId ?? undefined}
+      data-parent-id={testParentId ?? undefined}
       data-shared={testShared ? 'true' : undefined}
       data-selected={isSelected ? 'true' : undefined}
       style={{ paddingBlock: 'var(--density-sidebar-py)' }}
@@ -474,6 +481,20 @@ function SidebarSectionHeader({
   );
 }
 
+interface MailboxTreeItemProps {
+  node: MailboxNode;
+  selectedMailbox: string;
+  expandedFolders: Set<string>;
+  onMailboxSelect?: (id: string) => void;
+  onToggleExpand: (id: string) => void;
+  isCollapsed: boolean;
+  onUnreadFilterClick?: (mailboxId: string) => void;
+  colorful: boolean;
+  onContextMenu?: (e: React.MouseEvent, node: MailboxNode) => void;
+  /** The account id is part of the drag payload so the drop target uses the right client. */
+  dragAccountId?: string | null;
+}
+
 function MailboxTreeItem({
   node,
   selectedMailbox,
@@ -485,21 +506,7 @@ function MailboxTreeItem({
   colorful,
   onContextMenu,
   dragAccountId = null,
-}: {
-  node: MailboxNode;
-  selectedMailbox: string;
-  expandedFolders: Set<string>;
-  onMailboxSelect?: (id: string) => void;
-  onToggleExpand: (id: string) => void;
-  isCollapsed: boolean;
-  onUnreadFilterClick?: (mailboxId: string) => void;
-  colorful: boolean;
-  onContextMenu?: (e: React.MouseEvent, node: MailboxNode) => void;
-  /** Connected-account id this folder is listed under; null = active account.
-   *  Travels in the folder-drag payload so a folder tab fetches through the
-   *  right client. */
-  dragAccountId?: string | null;
-}) {
+}: MailboxTreeItemProps) {
   const tNotifications = useTranslations('notifications');
   const tSidebar = useTranslations('sidebar');
   const hasChildren = node.children.length > 0;
@@ -550,13 +557,13 @@ function MailboxTreeItem({
   });
 
   return (
-    <>
-      <SidebarRow
+    <SidebarRow
         icon={<Icon className={getIconClass(isSelected, isVirtualNode, colorful, roleKey)} />}
         label={label}
         testRole={node.role}
         testName={node.name}
         testMailboxId={node.id}
+        testParentId={node.parentId}
         testShared={node.isShared}
         depth={node.depth}
         isSelected={isSelected}
@@ -581,23 +588,43 @@ function MailboxTreeItem({
         isInvalidDropTarget={isInvalidDropTarget}
         onContextMenu={onContextMenu && !isVirtualNode ? (e) => onContextMenu(e, node) : undefined}
       />
+  );
+}
 
-      {hasChildren && isExpanded && !isCollapsed && node.children.map((child) => (
-        <MailboxTreeItem
-          key={child.id}
-          node={child}
-          selectedMailbox={selectedMailbox}
-          expandedFolders={expandedFolders}
-          onMailboxSelect={onMailboxSelect}
-          onToggleExpand={onToggleExpand}
-          isCollapsed={isCollapsed}
-          onUnreadFilterClick={onUnreadFilterClick}
-          colorful={colorful}
-          onContextMenu={onContextMenu}
-          dragAccountId={dragAccountId}
-        />
+type MailboxTreeRowsProps = Omit<MailboxTreeItemProps, 'node'> & {
+  nodes: MailboxNode[];
+  renderAfterNode?: (node: MailboxNode) => ReactNode;
+};
+
+function MailboxTreeRows({ nodes, renderAfterNode, ...itemProps }: MailboxTreeRowsProps) {
+  const rows = useMemo(
+    () => flattenVisibleTree(nodes, itemProps.isCollapsed ? NO_EXPANDED_MAILBOXES : itemProps.expandedFolders),
+    [nodes, itemProps.expandedFolders, itemProps.isCollapsed],
+  );
+  const [limit, setLimit] = useState(MAILBOX_ROW_BATCH);
+  useEffect(() => setLimit(MAILBOX_ROW_BATCH), [rows.length]);
+
+  return (
+    <div data-testid="mailbox-tree-rows" data-total-rows={rows.length}>
+      {rows.slice(0, limit).map(({ node }) => (
+        <Fragment key={node.id}>
+          <MailboxTreeItem node={node} {...itemProps} />
+          {renderAfterNode?.(node)}
+        </Fragment>
       ))}
-    </>
+      {limit < rows.length && (
+        <button
+          type="button"
+          data-testid="show-more-mailboxes"
+          className="flex w-full items-center justify-center gap-2 py-2 text-xs text-muted-foreground hover:text-foreground"
+          onClick={() => setLimit((current) => current + MAILBOX_ROW_BATCH)}
+          aria-label="Show more folders"
+        >
+          <MoreHorizontal className="h-4 w-4" />
+          {(rows.length - limit).toLocaleString()}
+        </button>
+      )}
+    </div>
   );
 }
 
@@ -907,6 +934,7 @@ export function Sidebar({
     (connectedAccounts.length > 1 || (includeGroupInUnified && hasGroupInboxes));
   const { unifiedCounts } = useEmailStore();
   const t = useTranslations('sidebar');
+  const mailboxTree = useMemo(() => buildMailboxTree(mailboxes), [mailboxes]);
 
   useEffect(() => {
     const stored = localStorage.getItem('expandedMailboxes');
@@ -918,7 +946,6 @@ export function Sidebar({
         debug.error('Failed to parse expanded mailboxes:', e);
       }
     } else {
-      const tree = buildMailboxTree(mailboxes);
       const collectExpandable = (nodes: MailboxNode[]): string[] => {
         const ids: string[] = [];
         for (const node of nodes) {
@@ -929,9 +956,13 @@ export function Sidebar({
         }
         return ids;
       };
-      setExpandedFolders(new Set(collectExpandable(tree)));
+      setExpandedFolders(new Set(
+        mailboxes.length <= MAX_AUTO_EXPANDED_MAILBOXES
+          ? collectExpandable(mailboxTree)
+          : [],
+      ));
     }
-  }, [mailboxes]);
+  }, [mailboxes.length, mailboxTree]);
 
   const handleToggleExpand = (mailboxId: string) => {
     setExpandedFolders((prev) => {
@@ -985,7 +1016,6 @@ export function Sidebar({
   // so it does not appear twice. (#495)
   const isServerScheduledNode = (n: MailboxNode) => showScheduledMailbox && n.role === 'scheduled';
 
-  const mailboxTree = buildMailboxTree(mailboxes);
   const ownTree = mailboxTree.filter(n => !n.id.startsWith('shared-account-') && !isServerScheduledNode(n));
   const sharedAccounts = mailboxTree.filter(n => n.id.startsWith('shared-account-'));
 
@@ -1321,25 +1351,23 @@ export function Sidebar({
                       </div>
                     ) : (
                       <>
-                        {tree.map((node) => (
-                          <Fragment key={node.id}>
-                            <MailboxTreeItem
-                              node={node}
-                              selectedMailbox={selectedKeyword || !isViewing ? "" : selectedMailbox}
-                              expandedFolders={expandedFolders}
-                              onMailboxSelect={(mailboxId) =>
-                                onAccountMailboxSelect?.(isActive ? null : account.id, mailboxId)
-                              }
-                              onToggleExpand={handleToggleExpand}
-                              isCollapsed={isCollapsed}
-                              onUnreadFilterClick={isActive ? onUnreadFilterClick : undefined}
-                              colorful={colorfulSidebarIcons}
-                              onContextMenu={isActive ? handleMailboxContextMenu : undefined}
-                              dragAccountId={isActive ? null : account.id}
-                            />
-                            {isActive && node.role === 'drafts' && renderScheduledRow(`scheduled-${account.id}`)}
-                          </Fragment>
-                        ))}
+                        <MailboxTreeRows
+                          nodes={tree}
+                          selectedMailbox={selectedKeyword || !isViewing ? "" : selectedMailbox}
+                          expandedFolders={expandedFolders}
+                          onMailboxSelect={(mailboxId) =>
+                            onAccountMailboxSelect?.(isActive ? null : account.id, mailboxId)
+                          }
+                          onToggleExpand={handleToggleExpand}
+                          isCollapsed={isCollapsed}
+                          onUnreadFilterClick={isActive ? onUnreadFilterClick : undefined}
+                          colorful={colorfulSidebarIcons}
+                          onContextMenu={isActive ? handleMailboxContextMenu : undefined}
+                          dragAccountId={isActive ? null : account.id}
+                          renderAfterNode={isActive
+                            ? (node) => node.role === 'drafts' && renderScheduledRow(`scheduled-${account.id}`)
+                            : undefined}
+                        />
                         {isActive && !tree.some((node) => node.role === 'drafts') && renderScheduledRow(`scheduled-${account.id}`)}
                       </>
                     )}
@@ -1367,22 +1395,18 @@ export function Sidebar({
                   </div>
                 ) : (
                   <>
-                    {ownTree.map((node) => (
-                      <Fragment key={node.id}>
-                        <MailboxTreeItem
-                          node={node}
-                          selectedMailbox={selectedKeyword ? "" : selectedMailbox}
-                          expandedFolders={expandedFolders}
-                          onMailboxSelect={onMailboxSelect}
-                          onToggleExpand={handleToggleExpand}
-                          isCollapsed={isCollapsed}
-                          onUnreadFilterClick={onUnreadFilterClick}
-                          colorful={colorfulSidebarIcons}
-                          onContextMenu={handleMailboxContextMenu}
-                        />
-                        {node.role === 'drafts' && renderScheduledRow('scheduled')}
-                      </Fragment>
-                    ))}
+                    <MailboxTreeRows
+                      nodes={ownTree}
+                      selectedMailbox={selectedKeyword ? "" : selectedMailbox}
+                      expandedFolders={expandedFolders}
+                      onMailboxSelect={onMailboxSelect}
+                      onToggleExpand={handleToggleExpand}
+                      isCollapsed={isCollapsed}
+                      onUnreadFilterClick={onUnreadFilterClick}
+                      colorful={colorfulSidebarIcons}
+                      onContextMenu={handleMailboxContextMenu}
+                      renderAfterNode={(node) => node.role === 'drafts' && renderScheduledRow('scheduled')}
+                    />
                     {!ownTree.some((node) => node.role === 'drafts') && renderScheduledRow('scheduled')}
                   </>
                 )}
@@ -1421,23 +1445,19 @@ export function Sidebar({
                       />
                       {accountExpanded && !isCollapsed && (
                         <>
-                          {account.children.map((child) => (
-                            <Fragment key={child.id}>
-                              <MailboxTreeItem
-                                node={child}
-                                selectedMailbox={selectedKeyword ? "" : selectedMailbox}
-                                expandedFolders={expandedFolders}
-                                onMailboxSelect={onMailboxSelect}
-                                onToggleExpand={handleToggleExpand}
-                                isCollapsed={isCollapsed}
-                                onUnreadFilterClick={onUnreadFilterClick}
-                                colorful={colorfulSidebarIcons}
-                                onContextMenu={handleMailboxContextMenu}
-                              />
-                              {child.role === 'drafts' && menuAccountId
-                                && renderScheduledRow(`${account.id}-scheduled`, { accountId: menuAccountId })}
-                            </Fragment>
-                          ))}
+                          <MailboxTreeRows
+                            nodes={account.children}
+                            selectedMailbox={selectedKeyword ? "" : selectedMailbox}
+                            expandedFolders={expandedFolders}
+                            onMailboxSelect={onMailboxSelect}
+                            onToggleExpand={handleToggleExpand}
+                            isCollapsed={isCollapsed}
+                            onUnreadFilterClick={onUnreadFilterClick}
+                            colorful={colorfulSidebarIcons}
+                            onContextMenu={handleMailboxContextMenu}
+                            renderAfterNode={(child) => child.role === 'drafts' && menuAccountId
+                              && renderScheduledRow(`${account.id}-scheduled`, { accountId: menuAccountId })}
+                          />
                           {menuAccountId && !account.children.some((child) => child.role === 'drafts')
                             && renderScheduledRow(`${account.id}-scheduled`, { accountId: menuAccountId })}
                         </>

--- a/integration/stalwart/plan-accounts.ndjson.tpl
+++ b/integration/stalwart/plan-accounts.ndjson.tpl
@@ -1,4 +1,4 @@
-{"@type":"create","object":"Account","value":{"alice":{"@type":"User","name":"alice","domainId":"${DOMAIN_ID}","description":"Integration test mailbox alice","credentials":{"0":{"@type":"Password","secret":"${TEST_ACCOUNT_PASSWORD}"}}}}}
+{"@type":"create","object":"Account","value":{"alice":{"@type":"User","name":"alice","domainId":"${DOMAIN_ID}","description":"Integration test mailbox alice","quotas":{"maxMailboxes":2000},"credentials":{"0":{"@type":"Password","secret":"${TEST_ACCOUNT_PASSWORD}"}}}}}
 {"@type":"create","object":"Account","value":{"bob":{"@type":"User","name":"bob","domainId":"${DOMAIN_ID}","description":"Integration test mailbox bob","credentials":{"0":{"@type":"Password","secret":"${TEST_ACCOUNT_PASSWORD}"}}}}}
 {"@type":"create","object":"Account","value":{"carol":{"@type":"User","name":"carol","domainId":"${DOMAIN_ID}","description":"Integration test mailbox carol","credentials":{"0":{"@type":"Password","secret":"${TEST_ACCOUNT_PASSWORD}"}}}}}
 {"@type":"create","object":"Account","value":{"team":{"@type":"Group","name":"team","domainId":"${DOMAIN_ID}","description":"Team shared mailbox"}}}

--- a/integration/tests/14-mailbox-pagination.spec.ts
+++ b/integration/tests/14-mailbox-pagination.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+import { ACCOUNTS } from "./helpers/config";
+import { folderRow, login } from "./helpers/app";
+import { JmapClient } from "./helpers/jmap";
+
+const PREFIX = "IT-Pagination-";
+const CHILD_COUNT = 520;
+const BATCH_SIZE = 400;
+
+async function setMailboxes(
+  client: JmapClient,
+  property: "create" | "update",
+  values: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const response = await client.request([
+    ["Mailbox/set", { accountId: client.accountId, [property]: values }, "set"],
+  ]);
+  const result = response.methodResponses[0][1];
+  expect(result[property === "create" ? "notCreated" : "notUpdated"] ?? {}).toEqual({});
+  return result;
+}
+
+test.describe("Mailbox pagination with real Stalwart data", () => {
+  test.setTimeout(180_000);
+  let client: JmapClient;
+
+  test.beforeAll(async () => {
+    client = await JmapClient.connect(ACCOUNTS.alice.email, ACCOUNTS.alice.password);
+    await client.reset();
+  });
+  test.afterAll(async () => client.reset());
+
+  test("loads and nests all 520 children beneath their parent", async ({ page }) => {
+    const childIds: string[] = [];
+    for (let offset = 0; offset < CHILD_COUNT; offset += BATCH_SIZE) {
+      const names = Array.from(
+        { length: Math.min(BATCH_SIZE, CHILD_COUNT - offset) },
+        (_, index) => `${PREFIX}Child-${(offset + index).toString().padStart(3, "0")}`,
+      );
+      const create = Object.fromEntries(names.map((name, index) => [`item-${index}`, { name }]));
+      const created = (await setMailboxes(client, "create", create)).created as Record<string, { id: string }>;
+      childIds.push(...Object.keys(create).map((key) => created[key].id));
+    }
+
+    // Creating the parent last puts it beyond a legacy capped Mailbox/get.
+    const parentId = await client.createMailbox(`${PREFIX}Parent`);
+    for (let offset = 0; offset < CHILD_COUNT; offset += BATCH_SIZE) {
+      await setMailboxes(client, "update", Object.fromEntries(
+        childIds.slice(offset, offset + BATCH_SIZE).map((id) => [id, { parentId }]),
+      ));
+    }
+
+    const fixture = (await client.mailboxes()).filter(({ name }) => name.startsWith(PREFIX));
+    expect(fixture).toHaveLength(CHILD_COUNT + 1);
+    expect(fixture.filter((mailbox) => mailbox.parentId === parentId)).toHaveLength(CHILD_COUNT);
+
+    await page.addInitScript(() => localStorage.setItem("expandedMailboxes", "[]"));
+    await login(page, ACCOUNTS.alice);
+    const fixtureRows = page.locator(`[data-testid="folder-row"][data-folder-name^="${PREFIX}"]`);
+    await expect(fixtureRows).toHaveCount(1, { timeout: 60_000 });
+
+    const parentRow = folderRow(page, { mailboxId: parentId }).first();
+    await parentRow.locator('[data-testid="folder-expand-toggle"]').click();
+    const tree = page.getByTestId("mailbox-tree-rows").first();
+    await expect(tree).toHaveAttribute("data-total-rows", /\d+/, { timeout: 60_000 });
+    expect(Number(await tree.getAttribute("data-total-rows"))).toBeGreaterThanOrEqual(CHILD_COUNT + 1);
+    expect(await fixtureRows.count()).toBeLessThanOrEqual(250);
+    expect(await fixtureRows.evaluateAll((rows) => {
+      const ids = new Set(rows.map((row) => row.getAttribute("data-mailbox-id")));
+      return rows.every((row) => !row.dataset.parentId || ids.has(row.dataset.parentId));
+    })).toBe(true);
+
+    const childRow = folderRow(page, { mailboxId: childIds[0] }).first();
+    await expect(childRow).toHaveAttribute("data-parent-id", parentId);
+    const indent = (row: typeof childRow) => row.evaluate((element) =>
+      Number.parseFloat(getComputedStyle(element.firstElementChild!).paddingLeft));
+    expect(await indent(childRow)).toBeGreaterThan(await indent(parentRow));
+  });
+});

--- a/integration/tests/helpers/jmap.ts
+++ b/integration/tests/helpers/jmap.ts
@@ -189,8 +189,20 @@ export class JmapClient {
   }
 
   async mailboxes(accountId: string = this.accountId): Promise<JmapMailbox[]> {
-    const r = await this.request([['Mailbox/get', { accountId }, '0']]);
-    return r.methodResponses[0][1].list as JmapMailbox[];
+    const mailboxes: JmapMailbox[] = [];
+    for (let position = 0;;) {
+      const r = await this.request([
+        ['Mailbox/query', { accountId, position, limit: 500 }, 'q'],
+        ['Mailbox/get', {
+          accountId,
+          '#ids': { resultOf: 'q', name: 'Mailbox/query', path: '/ids' },
+        }, 'g'],
+      ]);
+      const ids = r.methodResponses[0][1].ids as string[];
+      mailboxes.push(...r.methodResponses[1][1].list as JmapMailbox[]);
+      if (ids.length === 0 || position + ids.length >= r.methodResponses[0][1].total) return mailboxes;
+      position += ids.length;
+    }
   }
 
   async mailboxByRole(role: string, accountId: string = this.accountId): Promise<JmapMailbox | undefined> {

--- a/lib/__tests__/jmap-draft-lifecycle.test.ts
+++ b/lib/__tests__/jmap-draft-lifecycle.test.ts
@@ -24,7 +24,7 @@ interface JMAPMethodCall { 0: string; 1: Record<string, unknown>; 2: string }
 interface CapturedRequest { methodCalls: JMAPMethodCall[] }
 
 /**
- * Capture every request; answer Mailbox/get, Identity/get, Email/set
+ * Capture every request; answer Mailbox/query+get, Identity/get, Email/set
  * (create and/or destroy) and EmailSubmission/set. `failCreate` makes the
  * Email/set create come back as notCreated; `failSubmission` does the same
  * for EmailSubmission/set.
@@ -37,12 +37,20 @@ function mockFlow({ failCreate = false, failSubmission = false } = {}) {
 
     const methodResponses: unknown[] = [];
     for (const [method, args, callId] of body.methodCalls as unknown as Array<[string, Record<string, unknown>, string]>) {
-      if (method === 'Mailbox/get') {
+      if (method === 'Mailbox/query') {
+        const ids = args.position === 0 ? ['mb-drafts', 'mb-sent'] : [];
+        methodResponses.push(['Mailbox/query', {
+          position: args.position,
+          ids,
+          queryState: 'state-1',
+          total: 2,
+        }, callId]);
+      } else if (method === 'Mailbox/get') {
         methodResponses.push(['Mailbox/get', {
-          list: [
+          list: body.methodCalls[0][0] !== 'Mailbox/query' || body.methodCalls[0][1].position === 0 ? [
             { id: 'mb-drafts', name: 'Drafts', role: 'drafts' },
             { id: 'mb-sent', name: 'Sent', role: 'sent' },
-          ],
+          ] : [],
         }, callId]);
       } else if (method === 'Identity/get') {
         methodResponses.push(['Identity/get', { list: [{ id: 'identity-1', email: 'user@example.com' }] }, callId]);

--- a/lib/__tests__/jmap-first-touch-ordering.test.ts
+++ b/lib/__tests__/jmap-first-touch-ordering.test.ts
@@ -8,7 +8,7 @@ import { JMAPClient } from '../jmap/client';
  * server, each node can create its own default - duplicating the "Personal"
  * calendar. The client must therefore not put a second calendar (or contacts)
  * request on the wire until the first one for that account has settled, while
- * leaving unrelated requests (Mailbox/get) unaffected.
+ * leaving unrelated mailbox requests unaffected.
  */
 
 function makeSession() {
@@ -84,7 +84,9 @@ describe('JMAPClient first-touch ordering (#907)', () => {
     return client;
   }
 
-  const emptyResponse = (method: string) => ({ methodResponses: [[method, { list: [], ids: [] }, '0']] });
+  const emptyResponse = (method: string) => method === 'Mailbox/query'
+    ? { methodResponses: [['Mailbox/query', { ids: [], queryState: 's', total: 0 }, 'query'], ['Mailbox/get', { list: [] }, 'get']] }
+    : { methodResponses: [[method, { list: [], ids: [] }, '0']] };
 
   it('holds CalendarEvent/query until the first Calendar/get for the account has settled', async () => {
     const client = await connectedClient();
@@ -112,7 +114,7 @@ describe('JMAPClient first-touch ordering (#907)', () => {
     const books = client.getAddressBooks();
     await flush();
 
-    expect(onWire.map((p) => p.methods[0]).sort()).toEqual(['AddressBook/get', 'Calendar/get', 'Mailbox/get']);
+    expect(onWire.map((p) => p.methods[0]).sort()).toEqual(['AddressBook/get', 'Calendar/get', 'Mailbox/query']);
 
     for (const p of onWire) p.resolve(emptyResponse(p.methods[0]));
     await Promise.all([calendars, mailboxes, books]);

--- a/lib/__tests__/jmap-mailbox-pagination.test.ts
+++ b/lib/__tests__/jmap-mailbox-pagination.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JMAPClient } from '../jmap/client';
+
+type RawMailbox = { id: string; name: string; parentId?: string };
+type MethodCall = [string, Record<string, unknown>, string];
+type RequestTarget = { request(calls: MethodCall[]): Promise<unknown> };
+
+function createClient(
+  maxObjectsInGet = 2,
+  accounts: Record<string, { name: string }> = { primary: { name: 'user@example.com' } },
+): JMAPClient {
+  const client = new JMAPClient('https://jmap.example.com', 'user@example.com', 'pass');
+  Object.assign(client, {
+    apiUrl: 'https://jmap.example.com/api',
+    accountId: 'primary',
+    username: 'user@example.com',
+    accounts,
+    capabilities: { 'urn:ietf:params:jmap:core': { maxObjectsInGet } },
+  });
+  return client;
+}
+
+function serve(client: JMAPClient, mailboxes: Record<string, RawMailbox[]>, clamp = Infinity): MethodCall[][] {
+  const requests: MethodCall[][] = [];
+  vi.spyOn(client as unknown as RequestTarget, 'request').mockImplementation(async (calls) => {
+    requests.push(calls);
+    const accountId = calls[0][1].accountId as string;
+    const position = calls[0][1].position as number;
+    const limit = calls[0][1].limit as number;
+    const all = mailboxes[accountId] ?? [];
+    const page = all.slice(position, position + Math.min(limit, clamp));
+    return { methodResponses: [
+      ['Mailbox/query', { ids: page.map(({ id }) => id), queryState: 's', total: all.length }, 'query'],
+      ['Mailbox/get', { list: page, notFound: [] }, 'get'],
+    ] };
+  });
+  return requests;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('JMAP mailbox pagination', () => {
+  it('loads a complete hierarchy across server-clamped pages', async () => {
+    const client = createClient(3);
+    const requests = serve(client, { primary: [
+      { id: 'grandchild', name: 'Grandchild', parentId: 'child' },
+      { id: 'other', name: 'Other' },
+      { id: 'child', name: 'Child', parentId: 'root' },
+      { id: 'root', name: 'Root' },
+    ] }, 1);
+
+    const mailboxes = await client.getMailboxes();
+
+    expect(mailboxes.map(({ id, parentId }) => [id, parentId])).toEqual([
+      ['grandchild', 'child'], ['other', undefined], ['child', 'root'], ['root', undefined],
+    ]);
+    expect(requests.map(([query]) => query[1].position)).toEqual([0, 1, 2, 3]);
+    expect(requests.map(([query]) => query[1].calculateTotal)).toEqual([true, false, false, false]);
+    expect(requests.every((calls) => calls.length === 2 && calls[1][1]['#ids'] && !calls[1][1].ids)).toBe(true);
+  });
+
+  it.each([
+    ['missing ids', undefined, 's', []],
+    ['mixed ids', ['third', 4], 's', []],
+    ['duplicate ids', ['parent'], 's', [{ id: 'parent', name: 'Parent' }]],
+    ['changed state', ['third'], 's2', [{ id: 'third', name: 'Third' }]],
+  ])('rejects %s instead of publishing a partial hierarchy', async (_label, ids, queryState, list) => {
+    const client = createClient();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(client as unknown as RequestTarget, 'request')
+      .mockResolvedValueOnce({ methodResponses: [
+        ['Mailbox/query', { ids: ['child', 'parent'], queryState: 's', total: 3 }, 'query'],
+        ['Mailbox/get', { list: [{ id: 'child', name: 'Child' }, { id: 'parent', name: 'Parent' }] }, 'get'],
+      ] })
+      .mockResolvedValueOnce({ methodResponses: [
+        ['Mailbox/query', { ids, queryState }, 'query'],
+        ['Mailbox/get', { list }, 'get'],
+      ] });
+
+    await expect(client.getMailboxes()).rejects.toThrow();
+  });
+
+  it('prefixes shared mailbox and parent ids', async () => {
+    const client = createClient(1, { primary: { name: 'user@example.com' }, shared: { name: 'team@example.com' } });
+    serve(client, {
+      primary: [{ id: 'inbox', name: 'Inbox' }],
+      shared: [{ id: 'child', name: 'Child', parentId: 'parent' }, { id: 'parent', name: 'Parent' }],
+    });
+
+    expect((await client.getAllMailboxes()).find(({ name }) => name === 'Child')).toMatchObject({
+      id: 'shared:child', originalId: 'child', parentId: 'shared:parent', accountId: 'shared', isShared: true,
+    });
+  });
+});

--- a/lib/__tests__/jmap-recipient-mailboxes.test.ts
+++ b/lib/__tests__/jmap-recipient-mailboxes.test.ts
@@ -22,7 +22,7 @@ function createClient(): JMAPClient {
 interface JMAPMethodCall { 0: string; 1: Record<string, unknown>; 2: string }
 interface CapturedRequest { using?: string[]; methodCalls: JMAPMethodCall[] }
 
-/** Mailbox/get → Identity/get → Email/set (+ EmailSubmission/set). */
+/** Mailbox/get (or query+get) → Identity/get → Email/set (+ EmailSubmission/set). */
 function mockFlow() {
   const captured: CapturedRequest[] = [];
   vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
@@ -38,6 +38,18 @@ function mockFlow() {
           { list: [{ id: 'mb-drafts', name: 'Drafts', role: 'drafts' }, { id: 'mb-sent', name: 'Sent', role: 'sent' }] },
           '0',
         ]],
+      };
+    } else if (method === 'Mailbox/query') {
+      const firstPage = body.methodCalls[0][1].position === 0;
+      payload = {
+        methodResponses: [
+          ['Mailbox/query', { position: body.methodCalls[0][1].position, ids: firstPage ? ['mb-drafts', 'mb-sent'] : [], queryState: 'state-1', total: 2 }, 'query'],
+          [
+            'Mailbox/get',
+            { list: firstPage ? [{ id: 'mb-drafts', name: 'Drafts', role: 'drafts' }, { id: 'mb-sent', name: 'Sent', role: 'sent' }] : [], notFound: [] },
+            'get',
+          ],
+        ],
       };
     } else if (method === 'Identity/get') {
       payload = {

--- a/lib/__tests__/jmap-request-limits.test.ts
+++ b/lib/__tests__/jmap-request-limits.test.ts
@@ -233,11 +233,14 @@ describe('JMAPClient request limits', () => {
   // (maxConcurrentRequests, default 4) and refuses the surplus with the same
   // 400 jmap:error:limit shape - BEFORE running any method. A push event fans
   // out several refreshes at once, so the ceiling is reached in ordinary use;
-  // a refused Mailbox/get used to be answered with a fake lone "Inbox" that
+  // a refused mailbox refresh used to be answered with a fake lone "Inbox" that
   // then replaced the real folder tree in the sidebar (#780).
   describe('maxConcurrentRequests', () => {
     const inboxList = {
-      methodResponses: [['Mailbox/get', { list: [{ id: 'mb-inbox', name: 'Inbox', role: 'inbox' }] }, '0']],
+      methodResponses: [
+        ['Mailbox/query', { ids: ['mb-inbox'], queryState: 's', total: 1 }, 'query'],
+        ['Mailbox/get', { list: [{ id: 'mb-inbox', name: 'Inbox', role: 'inbox' }] }, 'get'],
+      ],
     };
 
     it('backs off and replays a refused request instead of failing it', async () => {

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -1195,36 +1195,82 @@ export class JMAPClient implements IJMAPClient {
     }
   }
 
+  /**
+   * Mailbox/get without ids can silently stop at maxObjectsInGet, leaving
+   * children without their parents. Querying all ids keeps the tree complete.
+   */
+  private async fetchMailboxTree(accountId: string): Promise<JMAPResponse> {
+    const mailboxes: JMAPMailbox[] = [];
+    const seenIds = new Set<string>();
+    let position = 0;
+    let total: number | undefined;
+    let queryState: string | undefined;
+
+    let hasMorePages = true;
+    while (hasMorePages) {
+      const response = await this.request([
+        ["Mailbox/query", {
+          accountId,
+          position,
+          limit: this.getMaxObjectsInGet(),
+          calculateTotal: position === 0,
+          sortAsTree: true,
+        }, "query"],
+        ["Mailbox/get", {
+          accountId,
+          "#ids": { resultOf: "query", name: "Mailbox/query", path: "/ids" },
+        }, "get"],
+      ]);
+
+      const queryResponse = response.methodResponses?.[0];
+      const getResponse = response.methodResponses?.[1];
+      const ids = queryResponse?.[1]?.ids;
+      const pageQueryState = queryResponse?.[1]?.queryState;
+      const page = getResponse?.[1]?.list;
+
+      if (
+        queryResponse?.[0] !== "Mailbox/query" ||
+        !Array.isArray(ids) ||
+        !ids.every((id: unknown) => typeof id === "string") ||
+        typeof pageQueryState !== "string" ||
+        getResponse?.[0] !== "Mailbox/get" ||
+        !Array.isArray(page) ||
+        getResponse[1].notFound?.length ||
+        page.length !== ids.length
+      ) {
+        throw new Error("Failed to load the complete mailbox list");
+      }
+
+      if (queryState !== undefined && pageQueryState !== queryState) {
+        throw new Error("Mailbox list changed while it was being loaded");
+      }
+      queryState = pageQueryState;
+      for (const id of ids) {
+        if (seenIds.has(id)) throw new Error("Mailbox/query returned duplicate ids");
+        seenIds.add(id);
+      }
+      mailboxes.push(...page);
+      if (typeof queryResponse[1].total === "number") total = queryResponse[1].total;
+      position += ids.length;
+      hasMorePages = ids.length > 0 && (total === undefined || position < total);
+    }
+
+    if (total !== undefined && seenIds.size !== total) {
+      throw new Error(`Mailbox/query returned ${seenIds.size} of ${total} mailboxes`);
+    }
+
+    return { methodResponses: [["Mailbox/get", { list: mailboxes }, "0"]] };
+  }
+
   async getMailboxes(accountId?: string): Promise<Mailbox[]> {
     const acctId = accountId || this.accountId;
     try {
-      const response = await this.request([
-        ["Mailbox/get", { accountId: acctId }, "0"]
-      ]);
+      const response = await this.fetchMailboxTree(acctId);
 
       if (response.methodResponses?.[0]?.[0] === "Mailbox/get") {
         const rawMailboxes = (response.methodResponses[0][1].list || []) as JMAPMailbox[];
 
         debug.log('jmap', `[JMAP Mailbox] getMailboxes returned ${rawMailboxes.length} mailboxes for account ${acctId}`);
-
-        // Warn if response might be truncated
-        const maxObjects = this.getMaxObjectsInGet();
-        if (rawMailboxes.length >= maxObjects) {
-          debug.warn('jmap', 
-            `[JMAP Mailbox] Response contains ${rawMailboxes.length} mailboxes which equals maxObjectsInGet (${maxObjects}). ` +
-            `Some mailboxes may be missing - nested folders could appear orphaned at root level.`
-          );
-        }
-
-        // Log parentId references to detect potential orphans
-        const returnedIds = new Set(rawMailboxes.map(mb => mb.id));
-        const missingParents = rawMailboxes.filter(mb => mb.parentId && !returnedIds.has(mb.parentId));
-        if (missingParents.length > 0) {
-          debug.warn('jmap', 
-            `[JMAP Mailbox] ${missingParents.length} mailbox(es) reference parentId not in response (will be orphaned):`,
-            missingParents.map(mb => ({ id: mb.id, name: mb.name, parentId: mb.parentId }))
-          );
-        }
 
         return rawMailboxes.map((mb) => ({
           id: mb.id,
@@ -1274,25 +1320,12 @@ export class JMAPClient implements IJMAPClient {
         const isPrimary = accountId === this.accountId;
 
         try {
-          const response = await this.request([
-            ["Mailbox/get", {
-              accountId: accountId,
-            }, "0"]
-          ]);
+          const response = await this.fetchMailboxTree(accountId);
 
           if (response.methodResponses?.[0]?.[0] === "Mailbox/get") {
             const rawMailboxes = (response.methodResponses[0][1].list || []) as JMAPMailbox[];
 
             debug.log('jmap', `[JMAP Mailbox] getAllMailboxes: account ${accountId} returned ${rawMailboxes.length} mailboxes (isPrimary: ${isPrimary})`);
-
-            // Warn if response might be truncated
-            const maxObjects = this.getMaxObjectsInGet();
-            if (rawMailboxes.length >= maxObjects) {
-              debug.warn('jmap', 
-                `[JMAP Mailbox] Account ${accountId}: response contains ${rawMailboxes.length} mailboxes which equals maxObjectsInGet (${maxObjects}). ` +
-                `Some mailboxes may be missing.`
-              );
-            }
 
             const mailboxes = rawMailboxes.map((mb) => ({
               id: isPrimary ? mb.id : `${accountId}:${mb.id}`,


### PR DESCRIPTION
## Design

Paginate folder retrieval and ensure parent folders are sent to frontend before nested child folders.

- `Mailbox/query` returns parent-first ID pages with `sortAsTree`, bounded by the server-advertised `maxObjectsInGet`.
- Each ID page feeds `Mailbox/get` through a result reference in the same JMAP request. Request count scales by page, never by folder.
- The first page records the total and query state. Every page must preserve that state, contain only unique string IDs, and return the requested object count; otherwise the snapshot is rejected.
- Primary, delegated, and shared accounts use the same complete loader before mailbox mapping and tree construction.
- The sidebar builds the complete tree once, flattens expanded nodes parent-first, and mounts 250 rows at a time. Each rendered child therefore has its parent earlier in the rendered prefix.
- The complete mailbox model remains available while additional 250-row batches are revealed on demand. Fresh profiles with more than 1,000 mailboxes begin collapsed.


### Capped object slice

![A capped response showing arbitrary generated child mailboxes at the top level](https://raw.githubusercontent.com/pirate/webmail/3738085/mailbox-pagination-before.png)

### Complete parent-first hierarchy

![The complete hierarchy showing generated child mailboxes nested beneath their parent](https://raw.githubusercontent.com/pirate/webmail/3738085/mailbox-pagination-after.png)

## Validation

- Stalwart + Playwright integration tests: one parent and 520 children load with correct parent IDs and indentation
- Vitest suites: 40 tests pass, including split hierarchies, server-clamped pages, missing or malformed IDs, and delegated-account namespacing.
- A disposable 20,000-folder model check built and flattened the hierarchy and selected its first 250 rows in 53 ms

