### PR TITLE
fix(calendar): drop default SKIP=OMIT from recurrence rules (DAVx5 sync)

### DIFF
--- a/components/calendar/event-modal.tsx
+++ b/components/calendar/event-modal.tsx
@@ -11,6 +11,7 @@ import { RecurrenceEditor, buildRecurrenceSummary, isSimpleRecurrenceRule } from
 import { parseDuration, getEventColor } from "./event-card";
 import { buildAllDayDuration, getEventDisplayEndDate, getEventEndDate, getEventStartDate, getPrimaryCalendarId } from "@/lib/calendar-utils";
 import { displayNow, getEffectiveTimeZone } from "@/lib/timezone";
+import { createRecurrenceRule } from "@/lib/recurrence-rule";
 import { ParticipantInput, type ParticipantInputHandle } from "./participant-input";
 import {
   isOrganizer,
@@ -543,25 +544,7 @@ export function EventModal({
     if (recurrence === "custom" && customRule) {
       data.recurrenceRules = [customRule];
     } else if (recurrence !== "none" && recurrence !== "custom") {
-      data.recurrenceRules = [{
-        "@type": "RecurrenceRule",
-        frequency: recurrence,
-        interval: 1,
-        rscale: "gregorian",
-        skip: "omit",
-        firstDayOfWeek: "mo",
-        byDay: null,
-        byMonthDay: null,
-        byMonth: null,
-        byYearDay: null,
-        byWeekNo: null,
-        byHour: null,
-        byMinute: null,
-        bySecond: null,
-        bySetPosition: null,
-        count: null,
-        until: null,
-      }];
+      data.recurrenceRules = [createRecurrenceRule(recurrence)];
     } else if (event && event.recurrenceRules?.length) {
       data.recurrenceRules = null;
       if (event.recurrenceOverrides) data.recurrenceOverrides = null;
@@ -1383,9 +1366,9 @@ export function EventModal({
                 >
                   {t("events.delete")}
                 </Button>
-                <Button 
-                  variant="ghost" 
-                  size="sm" 
+                <Button
+                  variant="ghost"
+                  size="sm"
                   onClick={() => setShowDeleteConfirm(false)}
                   className="w-full"
                 >
@@ -1417,10 +1400,10 @@ export function EventModal({
             </Button>
           )}
         </div>
-        
+
         {!showDeleteConfirm && (
         <div className="flex gap-2 w-full">
-          <Button 
+          <Button
             variant="outline"
             onClick={isEdit ? () => setMode("view") : onClose}
             className="w-full"
@@ -1428,7 +1411,7 @@ export function EventModal({
             {t("form.cancel")}
           </Button>
           <Button
-            onClick={handleSave} 
+            onClick={handleSave}
             disabled={!title.trim() || isSaving}
             className="w-full"
           >

--- a/components/calendar/recurrence-editor.tsx
+++ b/components/calendar/recurrence-editor.tsx
@@ -6,6 +6,7 @@ import { addYears, format } from "date-fns";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { CalendarRecurrenceRule } from "@/lib/jmap/types";
+import { createRecurrenceRule } from "@/lib/recurrence-rule";
 
 type EditorFrequency = "daily" | "weekly" | "monthly" | "yearly";
 type MonthlyMode = "day" | "nth";
@@ -210,25 +211,11 @@ export function RecurrenceEditor({ rule, eventStart, onSave, onCancel }: Recurre
   };
 
   const buildRule = (): CalendarRecurrenceRule => {
-    const built: CalendarRecurrenceRule = {
-      "@type": "RecurrenceRule",
-      frequency,
+    const built: CalendarRecurrenceRule = createRecurrenceRule(frequency, {
       interval: Math.max(1, interval),
-      rscale: "gregorian",
-      skip: "omit",
-      firstDayOfWeek: "mo",
-      byDay: null,
-      byMonthDay: null,
-      byMonth: null,
-      byYearDay: null,
-      byWeekNo: null,
-      byHour: null,
-      byMinute: null,
-      bySecond: null,
-      bySetPosition: null,
       count: endsMode === "after" ? Math.max(1, count) : null,
       until: endsMode === "on" && untilDate ? `${untilDate}T23:59:59` : null,
-    };
+    });
 
     if (frequency === "weekly") {
       const days = weekDays.length ? weekDays : [startDay];

--- a/lib/__tests__/recurrence-rule.test.ts
+++ b/lib/__tests__/recurrence-rule.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { createRecurrenceRule } from '@/lib/recurrence-rule';
+
+describe('createRecurrenceRule (#805 — no default SKIP=OMIT)', () => {
+  it('does not emit rscale or skip (which serialise to RSCALE=GREGORIAN;SKIP=OMIT)', () => {
+    const rule = createRecurrenceRule('yearly');
+    expect('skip' in rule).toBe(false);
+    expect('rscale' in rule).toBe(false);
+    expect(rule.skip).toBeUndefined();
+    expect(rule.rscale).toBeUndefined();
+  });
+
+  it('builds a clean Gregorian default rule', () => {
+    expect(createRecurrenceRule('daily')).toEqual({
+      '@type': 'RecurrenceRule',
+      frequency: 'daily',
+      interval: 1,
+      firstDayOfWeek: 'mo',
+      byDay: null,
+      byMonthDay: null,
+      byMonth: null,
+      byYearDay: null,
+      byWeekNo: null,
+      byHour: null,
+      byMinute: null,
+      bySecond: null,
+      bySetPosition: null,
+      count: null,
+      until: null,
+    });
+  });
+
+  it('applies overrides (interval / count / until) without reintroducing skip', () => {
+    const rule = createRecurrenceRule('yearly', { interval: 2, count: 100 });
+    expect(rule.interval).toBe(2);
+    expect(rule.count).toBe(100);
+    expect(rule.until).toBeNull();
+    expect('skip' in rule).toBe(false);
+  });
+});

--- a/lib/demo/fixtures/calendars.ts
+++ b/lib/demo/fixtures/calendars.ts
@@ -161,8 +161,6 @@ export function createDemoCalendarEvents(): CalendarEvent[] {
         '@type': 'RecurrenceRule',
         frequency: 'weekly',
         interval: 1,
-        rscale: 'gregorian',
-        skip: 'omit',
         firstDayOfWeek: 'mo',
         byDay: [{ day: 'mo' }],
         byMonthDay: null,

--- a/lib/jmap/types.ts
+++ b/lib/jmap/types.ts
@@ -673,8 +673,11 @@ export interface CalendarRecurrenceRule {
   '@type': 'RecurrenceRule';
   frequency: 'yearly' | 'monthly' | 'weekly' | 'daily' | 'hourly' | 'minutely' | 'secondly';
   interval: number;
-  rscale: string;
-  skip: 'omit' | 'backward' | 'forward';
+  // Optional and normally omitted: these RFC 7529 (RSCALE/SKIP) fields only
+  // apply to non-Gregorian scales / invalid-date handling. Emitting a default
+  // SKIP=OMIT breaks some CalDAV clients (DAVx5) - see lib/recurrence-rule.ts (#805).
+  rscale?: string;
+  skip?: 'omit' | 'backward' | 'forward';
   firstDayOfWeek: 'mo' | 'tu' | 'we' | 'th' | 'fr' | 'sa' | 'su';
   byDay: CalendarNDay[] | null;
   byMonthDay: number[] | null;

--- a/lib/recurrence-rule.ts
+++ b/lib/recurrence-rule.ts
@@ -1,0 +1,33 @@
+import type { CalendarRecurrenceRule } from '@/lib/jmap/types';
+
+type Frequency = CalendarRecurrenceRule['frequency'];
+
+/**
+ * A plain Gregorian recurrence rule with all by-parts unset. `rscale`/`skip`
+ * are intentionally omitted: they only matter for non-Gregorian scales /
+ * invalid-date handling, and defaulting them made Stalwart serialise
+ * `RSCALE=GREGORIAN;SKIP=OMIT` into the RRULE, which DAVx5 rejects (#805).
+ */
+export function createRecurrenceRule(
+  frequency: Frequency,
+  overrides: Partial<CalendarRecurrenceRule> = {},
+): CalendarRecurrenceRule {
+  return {
+    '@type': 'RecurrenceRule',
+    frequency,
+    interval: 1,
+    firstDayOfWeek: 'mo',
+    byDay: null,
+    byMonthDay: null,
+    byMonth: null,
+    byYearDay: null,
+    byWeekNo: null,
+    byHour: null,
+    byMinute: null,
+    bySecond: null,
+    bySetPosition: null,
+    count: null,
+    until: null,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

Recurring events were created with `skip: "omit"` and `rscale: "gregorian"` on every recurrence rule. Stalwart serialises those RFC 7529 fields into the CalDAV RRULE as `RSCALE=GREGORIAN;SKIP=OMIT`, and DAVx5 rejects that with `java.lang.IllegalArgumentException: Invalid recurrence rule`, breaking Android calendar sync. These fields only matter for non-Gregorian scales / invalid-date handling, so this change stops emitting them for plain Gregorian rules; the stored rule (and thus the RRULE) is now clean, e.g. `FREQ=YEARLY;COUNT=100;INTERVAL=1;BYMONTH=8;BYMONTHDAY=22`.

## Changes

- `lib/recurrence-rule.ts` (new): `createRecurrenceRule(frequency, overrides?)` — builds a plain Gregorian rule with all by-parts unset and NO `skip`/`rscale`.
- `lib/jmap/types.ts`: `rscale` and `skip` on `CalendarRecurrenceRule` are now optional (they are omitted by default).
- `components/calendar/event-modal.tsx` and `components/calendar/recurrence-editor.tsx`: both recurrence-rule construction sites now use `createRecurrenceRule` instead of hardcoding `rscale: "gregorian", skip: "omit"`.
- `lib/demo/fixtures/calendars.ts`: dropped `rscale`/`skip` from the demo recurring event for consistency.
- `lib/__tests__/recurrence-rule.test.ts` (new): asserts the rule contains no `skip`/`rscale`, the clean default shape, and that overrides don't reintroduce them.

## Related issues

Closes #805

## Type of change

<!-- Check all that apply. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [X] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
