### PR TITLE
fix(sw): focus the client before navigating on notification click

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -218,10 +218,30 @@ async function handleNotificationClick(event) {
     // get annoyed when each notification opens a fresh window.
     if ("focus" in client) {
       try {
-        if ("navigate" in client && targetUrl) {
-          await client.navigate(targetUrl);
+        // FOCUS FIRST, NAVIGATE SECOND, and the order is the entire fix.
+        //
+        // A notification click grants the service worker a TRANSIENT USER ACTIVATION, and
+        // both focus() and openWindow() refuse to run without one. navigate() SPENDS that
+        // activation, and it also replaces the client's document, which invalidates the
+        // WindowClient handle we are about to use. Navigating first therefore breaks the
+        // click two ways over. Instrumented on Android in a real deployment:
+        //
+        //   client 1: navigate ok -> focus() threw NotFoundError      (handle stale after nav)
+        //   client 2: navigate ok -> focus() threw InvalidAccessError (activation spent)
+        //   openWindow()          -> threw InvalidAccessError         (same)
+        //
+        // Every rejection was swallowed by the catch below, so the toast closed and nothing
+        // came to the front. Focusing first uses the activation while it is still live;
+        // navigate() does not need one of its own once the client is focused.
+        const focused = await client.focus();
+        if (focused && "navigate" in focused && targetUrl) {
+          try {
+            await focused.navigate(targetUrl);
+          } catch (_) {
+            // Focused but not navigated still beats nothing opening at all.
+          }
         }
-        return client.focus();
+        return focused;
       } catch (_) {
         // navigate() can reject for cross-origin or detached clients - fall
         // through and open a new window below.


### PR DESCRIPTION
Clicking a push notification on Android closes the notification and does nothing — the app never comes to the front.

## Cause

`handleNotificationClick` navigates an existing client and then focuses it:

```js
if ("navigate" in client && targetUrl) {
  await client.navigate(targetUrl);
}
return client.focus();
```

A notification click grants the service worker a **transient user activation**, and both `focus()` and `openWindow()` refuse to run without one. `navigate()` spends that activation — and it also replaces the client's document, which invalidates the `WindowClient` handle the very next line uses. Navigating first therefore breaks the click two ways over.

Instrumented on a device, against a backgrounded installed PWA:

```
client 1: navigate ok -> focus() threw NotFoundError       (handle stale after navigation)
client 2: navigate ok -> focus() threw InvalidAccessError  (activation already spent)
openWindow()          -> threw InvalidAccessError          (same)
```

Every rejection was swallowed by the surrounding `catch`, so the notification closed and nothing opened, with nothing in any log to say why.

## Fix

Focus first, while the activation is still live, then navigate the focused client. `navigate()` does not need an activation of its own once the client is focused, and it is wrapped so that a failed navigation still leaves the app raised rather than falling through to opening a second window.

## Testing

- Verified on a physical Android device against an installed PWA: a notification click now raises the app and opens the message. Running in production since 2026-08-24.
- `node --check public/sw.js` passes.
- Confined to `public/sw.js`; no build, dependency or configuration surface touched.

## Not in this PR

There is a second, unrelated defect in the same file: `badge` points at `/api/pwa-icon/192`, and Android builds the status-bar badge from the alpha channel alone, so an opaque app icon masks to a featureless blob. I have kept it out of this PR because the fix involves choosing which of your own brand assets to use, which is your call rather than mine. I will open it as a separate issue with the measurements.
