### PR TITLE
fix: send from the address a message was delivered to (shared/aliased mailboxes)

### DIFF
--- a/components/email/__tests__/reply-addressing.test.tsx
+++ b/components/email/__tests__/reply-addressing.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
 import { EmailComposer } from '../email-composer';
+import { useSettingsStore } from '@/stores/settings-store';
 
 // ─── Heavy component mocks (mirrors recipient-paste.test.tsx) ─────────────────
 
@@ -86,7 +87,7 @@ vi.mock('@/stores/settings-store', () => {
     timeFormat: '24h',
     plainTextMode: false,
     subAddressDelimiter: '+',
-    autoSelectReplyIdentity: true,
+    autoSelectReplyIdentity: false,
     attachmentReminderEnabled: false,
     attachmentReminderKeywords: [],
     sendDelaySeconds: 0,
@@ -183,6 +184,21 @@ const SELF_SENT = {
   subject: 'Re: Hello',
 };
 
+/** Delivered to an aliased/shared mailbox the user DOES hold an identity for. */
+const RECEIVED_SHARED = {
+  from: [{ email: 'bob@other.com', name: 'Bob' }],
+  to: [{ email: 'info@example.com', name: 'Info' }],
+  subject: 'Question for the team inbox',
+};
+
+/** Delivered to a same-domain address that is NOT one of our identities -
+ *  the domain catch-all shape that rewrites the From header. */
+const RECEIVED_CATCH_ALL = {
+  from: [{ email: 'bob@other.com', name: 'Bob' }],
+  to: [{ email: 'colleague@example.com', name: 'A Colleague' }],
+  subject: 'Sent to a colleague on our domain',
+};
+
 /** Chip labels currently shown in a recipient row, in order. Chips are the
  *  draggable spans inside the row; next-intl is mocked to return the key, so
  *  the Cc row is found via its "cc_label" caption. */
@@ -194,8 +210,12 @@ const ccChips = () => chipsIn(screen.getByText('cc_label').parentElement as HTML
 
 const identitySelect = () => screen.getByTestId('composer-from') as HTMLSelectElement;
 
+const setAutoSelect = (on: boolean) =>
+  (useSettingsStore as unknown as { setState: (p: Record<string, unknown>) => void })
+    .setState({ autoSelectReplyIdentity: on });
+
 describe('composer reply addressing', () => {
-  beforeEach(() => { vi.clearAllMocks(); });
+  beforeEach(() => { vi.clearAllMocks(); setAutoSelect(false); });
 
   it('addresses a reply to the sender of a received message', () => {
     render(<EmailComposer mode="reply" replyTo={RECEIVED} />);
@@ -224,5 +244,53 @@ describe('composer reply addressing', () => {
   it('sends the reply to our own message from the identity that sent it', () => {
     render(<EmailComposer mode="reply" replyTo={{ ...SELF_SENT, from: [{ email: 'info@example.com', name: 'Info' }] }} />);
     expect(identitySelect().value).toBe('id-info');
+  });
+
+  // Own-identity matching is unconditional: it only chooses which of the
+  // user's OWN addresses sends, so it carries no impersonation risk. Shipping
+  // it behind an off-by-default setting meant a shared mailbox always replied
+  // as the account owner.
+  it('replies from the address that received the original', () => {
+    render(<EmailComposer mode="reply" replyTo={RECEIVED_SHARED} />);
+    expect(identitySelect().value).toBe('id-info');
+  });
+
+  it('forwards from the address that received the original', () => {
+    render(<EmailComposer mode="forward" replyTo={RECEIVED_SHARED} />);
+    expect(identitySelect().value).toBe('id-info');
+  });
+
+  // The catch-all From REWRITE is a different behaviour and stays opt-in: it
+  // puts an address the user has NOT configured into From, and on a multi-user
+  // domain that address can be a colleague's.
+  it('does not rewrite From to a same-domain non-identity while the setting is off', () => {
+    render(<EmailComposer mode="reply" replyTo={RECEIVED_CATCH_ALL} />);
+    expect(screen.queryByDisplayValue('colleague@example.com')).toBeNull();
+    expect(identitySelect().value).toBe('id-me');
+  });
+
+  // A forward introduces the rewritten From to a recipient the user just
+  // typed, who has no way to tell it is not really from that person - so
+  // forwards never take the rewrite, even when it is enabled.
+  // Control: the opt-in path itself still works on a reply, so the two tests
+  // above are proving the gate, not a broken resolver.
+  it('rewrites From to the catch-all address on a reply when the setting is on', () => {
+    setAutoSelect(true);
+    try {
+      render(<EmailComposer mode="reply" replyTo={RECEIVED_CATCH_ALL} />);
+      expect(screen.getByDisplayValue('colleague@example.com')).toBeTruthy();
+    } finally {
+      setAutoSelect(false);
+    }
+  });
+
+  it('never rewrites From on a forward, even with the setting on', () => {
+    setAutoSelect(true);
+    try {
+      render(<EmailComposer mode="forward" replyTo={RECEIVED_CATCH_ALL} />);
+      expect(screen.queryByDisplayValue('colleague@example.com')).toBeNull();
+    } finally {
+      setAutoSelect(false);
+    }
   });
 });

--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -37,7 +37,7 @@ import { TemplatePicker } from "@/components/templates/template-picker";
 import { TemplateForm } from "@/components/templates/template-form";
 import type { EmailTemplate } from "@/lib/template-types";
 import { appendPlainTextSignature, getPlainTextSignature, plainTextBodyHasSignature, plainTextBodyWithoutSignature } from "@/lib/signature-utils";
-import { findComposeIdentityId, findDraftIdentityId, resolveReplyFrom } from "@/lib/reply-identity";
+import { findComposeIdentityId, findDraftIdentityId, findReplyIdentityId, resolveReplyFrom } from "@/lib/reply-identity";
 import { buildReplyRecipients, isSelfSent } from "@/lib/reply-recipients";
 import { computeReplyThreadingHeaders } from "@/lib/email-threading";
 import { RequestTimeoutError } from "@/lib/jmap/client";
@@ -791,8 +791,26 @@ export function EmailComposer({
     setShowSendMenu(false);
   }, []);
 
+  // Two DIFFERENT behaviours used to sit behind `autoSelectReplyIdentity`:
+  //
+  //   1. pick among the user's OWN configured identities (exact address, then
+  //      `+tag`-stripped). Never rewrites `From:` - it only chooses which of
+  //      your own addresses sends.
+  //   2. the domain catch-all: rewrite `From:` to an address you have NOT
+  //      configured, sending through a same-domain identity.
+  //
+  // (1) is what makes a shared or aliased mailbox reply from its own address,
+  // and it is what users expect; shipping it off meant that on a shared mailbox
+  // every reply, reply-all and new message silently went out as the account
+  // owner. It carries no impersonation risk, so it is now unconditional.
+  //
+  // (2) stays behind the setting. `ownedDomains` in `resolveReplyFrom` treats
+  // ANY address on a domain you hold an identity on as a catch-all candidate -
+  // including a colleague's, and including one that only appeared in `Bcc:` -
+  // so on a multi-user domain it can put someone else's address in your From.
+  // That is a deliberate opt-in for genuine catch-all deployments, which is
+  // exactly what the setting's description promises, and it must stay one.
   useEffect(() => {
-    if (!autoSelectReplyIdentity) return;
     if (selectedIdentityId || initialData?.selectedIdentityId) return;
 
     // New message started from a specific mailbox/account: default the From to
@@ -807,7 +825,12 @@ export function EmailComposer({
       return;
     }
 
-    if (mode !== 'reply' && mode !== 'replyAll') return;
+    // `forward` resolves like a reply: the address the original was delivered
+    // to is the one to send from. It was excluded, so forwarding a message that
+    // arrived at a shared mailbox went out as the account owner - even though
+    // the comment above already promised "Reply/forward fall through", and the
+    // neighbouring inline-image effect groups all three modes together.
+    if (mode !== 'reply' && mode !== 'replyAll' && mode !== 'forward') return;
 
     // Replying to our own message in a thread (#703): keep sending as the
     // identity that sent it. Resolving from the recipients here would pick the
@@ -821,20 +844,35 @@ export function EmailComposer({
       }
     }
 
-    const resolved = resolveReplyFrom(identities, {
+    const recipients = {
       to: replyTo?.to,
       cc: replyTo?.cc,
       bcc: replyTo?.bcc,
-    });
+    };
 
-    if (resolved) {
-      setSelectedIdentityId(resolved.identityId);
-      if (resolved.overrideEmail && !fromOverrideEnabled) {
-        setFromOverrideEnabled(true);
-        setFromOverrideEmail(resolved.overrideEmail);
-        if (resolved.overrideName) setFromOverrideName(resolved.overrideName);
-      }
+    // (1) Own-identity match - unconditional.
+    const ownIdentityId = findReplyIdentityId(identities, recipients);
+    if (ownIdentityId) {
+      setSelectedIdentityId(ownIdentityId);
       return;
+    }
+
+    // (2) Catch-all From rewrite - opt-in, and never on a forward. A reply
+    // continues a thread whose participants already know the addressing; a
+    // forward introduces the rewritten From to a recipient the user just typed,
+    // who has no way to tell it is not really from that person. Forwards
+    // therefore keep the own-identity match above and stop there.
+    if (autoSelectReplyIdentity && mode !== 'forward') {
+      const resolved = resolveReplyFrom(identities, recipients);
+      if (resolved) {
+        setSelectedIdentityId(resolved.identityId);
+        if (resolved.overrideEmail && !fromOverrideEnabled) {
+          setFromOverrideEnabled(true);
+          setFromOverrideEmail(resolved.overrideEmail);
+          if (resolved.overrideName) setFromOverrideName(resolved.overrideName);
+        }
+        return;
+      }
     }
 
     // Fallback: match identity by the account's email when replying from unified view

--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -81,7 +81,7 @@ import { isFilePreviewable } from "@/lib/file-preview";
 import { appendHtmlSignature, appendPlainTextSignature } from "@/lib/signature-utils";
 import { computeReplyThreadingHeaders } from "@/lib/email-threading";
 import { EML_IMPORT_ACCEPT, expandImportableEmails } from "@/lib/eml-import";
-import { findDraftIdentityId, resolveComposeAccountEmail, resolveReplyFrom, type ReplyFromResolution } from "@/lib/reply-identity";
+import { findDraftIdentityId, findReplyIdentityId, resolveComposeAccountEmail, type ReplyFromResolution } from "@/lib/reply-identity";
 import { buildReplyRecipients, isSelfSent } from "@/lib/reply-recipients";
 import { useProMultiAccountIdentities } from "@/hooks/use-pro-multi-account-identities";
 import { Filter, ChevronDown, X, Paperclip, Star, Mail, MailOpen, RotateCcw, PenSquare, PenLine, CheckSquare, Square, AlertTriangle } from "lucide-react";
@@ -2949,25 +2949,31 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
     }
 
     const primaryIdentity = identities[0];
-    const autoSelectReplyIdentity = useSettingsStore.getState().autoSelectReplyIdentity;
 
-    // Decide the sending identity and (for domain-catch-all) an optional
-    // header From override that matches the address the message was sent to.
-    // Our own message keeps the identity it was sent from - the recipients are
-    // the other party, so resolving from them would send as their address.
-    // When the setting is off, fall through to primary-identity behavior.
+    // Send from the address the message was delivered to, so a reply out of a
+    // shared or aliased mailbox does not go out as the account owner. Our own
+    // message keeps the identity it was sent from - the recipients are the
+    // other party, so resolving from them would send as their address.
+    //
+    // Quick reply resolves the user's OWN identities only. It deliberately does
+    // NOT take the domain catch-all `From:` rewrite that the full composer
+    // offers: this surface is a bare text box with no From row, so a rewritten
+    // From would be applied with nothing on screen to show it - or to correct
+    // it. A catch-all delivery quick-replies as the matching own identity, and
+    // the user can open the full composer when they need the rewrite.
     const selfSentIdentityId = isSelfSent(replySource, ownIdentityEmails)
       ? findDraftIdentityId(identities, selectedEmail.from?.[0])
       : null;
-    const resolved: ReplyFromResolution | null = !autoSelectReplyIdentity
-      ? null
-      : selfSentIdentityId
-        ? { identityId: selfSentIdentityId }
-        : resolveReplyFrom(identities, {
+    const resolved: ReplyFromResolution | null = selfSentIdentityId
+      ? { identityId: selfSentIdentityId }
+      : (() => {
+          const ownIdentityId = findReplyIdentityId(identities, {
             to: selectedEmail.to,
             cc: selectedEmail.cc,
             bcc: selectedEmail.bcc,
           });
+          return ownIdentityId ? { identityId: ownIdentityId } : null;
+        })();
     const sendingIdentity = resolved
       ? (identities.find((i) => i.id === resolved.identityId) || primaryIdentity)
       : primaryIdentity;

--- a/components/pro/pro-compose-tab-body.tsx
+++ b/components/pro/pro-compose-tab-body.tsx
@@ -6,6 +6,8 @@ import { EmailComposer, type ComposerDraftData } from "@/components/email/email-
 import { ErrorBoundary, ComposerErrorFallback } from "@/components/error";
 import { useAuthStore } from "@/stores/auth-store";
 import { useEmailStore } from "@/stores/email-store";
+import { useAccountStore } from "@/stores/account-store";
+import { resolveComposeAccountEmail } from "@/lib/reply-identity";
 import { toast } from "@/stores/toast-store";
 import { useProTabStore, registerProTabCloseInterceptor, type ProComposeTabData } from "@/stores/pro-tab-store";
 import { debug } from "@/lib/debug";
@@ -25,6 +27,10 @@ export function ProComposeTabBody({ tabId, data }: ProComposeTabBodyProps) {
   const t = useTranslations();
   const client = useAuthStore((s) => s.client);
   const sendEmail = useEmailStore((s) => s.sendEmail);
+  const mailboxes = useEmailStore((s) => s.mailboxes);
+  const selectedMailbox = useEmailStore((s) => s.selectedMailbox);
+  const viewingAccountId = useEmailStore((s) => s.viewingAccountId);
+  const activeAccountId = useAuthStore((s) => s.activeAccountId);
   const refreshCurrentMailbox = useEmailStore((s) => s.refreshCurrentMailbox);
   const fetchScheduledEmails = useEmailStore((s) => s.fetchScheduledEmails);
   const refreshScheduledMetadata = useEmailStore((s) => s.refreshScheduledMetadata);
@@ -183,6 +189,20 @@ export function ProComposeTabBody({ tabId, data }: ProComposeTabBodyProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Mirrors the standard shell (see the same prop in `components/mail/mail-app.tsx`).
+  // Without it `mode === 'compose'` resolves `findComposeIdentityId(identities,
+  // undefined)` -> null and every new message in the Pro shell defaults to the
+  // account owner, even with a shared folder open. The Pro shell hoists every
+  // "show composer" intent - including `mailto:` links - into a tab, so this
+  // omission covered the whole compose surface there.
+  const composeFromAccountEmail = resolveComposeAccountEmail(
+    mailboxes,
+    selectedMailbox,
+    useAccountStore
+      .getState()
+      .getAccountById(viewingAccountId ?? activeAccountId ?? '')?.email,
+  );
+
   return (
     <div className="flex h-full w-full flex-col bg-background">
       <ErrorBoundary fallback={ComposerErrorFallback}>
@@ -192,6 +212,7 @@ export function ProComposeTabBody({ tabId, data }: ProComposeTabBodyProps) {
           replyTo={data.replyTo}
           initialDraftText={data.initialDraftText}
           initialData={data.initialData}
+          composeFromAccountEmail={composeFromAccountEmail}
           onSend={handleSend}
           onScheduledSendCreated={handleScheduledSendCreated}
           onClose={handleClose}

--- a/stores/__tests__/email-store-shared-folder-push-refresh.test.ts
+++ b/stores/__tests__/email-store-shared-folder-push-refresh.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEmailStore } from '../email-store';
+import type { Mailbox, StateChange } from '@/lib/jmap/types';
+import type { IJMAPClient } from '@/lib/jmap/client-interface';
+
+// Regression coverage for the open list going stale on a shared/group folder.
+//
+// Stalwart's SSE only pushes StateChange for the primary account, never for a
+// delegated/shared owner, so changes to those arrive via the client's secondary
+// poll - reported under the OWNER's accountId. `handleStateChange` keyed the
+// email-list refresh off `change.changed[primaryAccountId]` only, so while a
+// shared folder was open a background Email change refreshed the folder
+// COUNTERS (those already react to any account) but never refetched the rows.
+// A server-side keyword patch - an operator job stamping a colour label, or
+// another member of the shared mailbox acting on it - stayed invisible until a
+// hard reload.
+
+const PRIMARY = 'primary-account';
+const OWNER = 'shared-owner-account';
+
+function makeMailbox(overrides: Partial<Mailbox> = {}): Mailbox {
+  return {
+    id: 'inbox',
+    name: 'Inbox',
+    sortOrder: 0,
+    totalEmails: 0,
+    unreadEmails: 0,
+    totalThreads: 0,
+    unreadThreads: 0,
+    myRights: {
+      mayReadItems: true, mayAddItems: true, mayRemoveItems: true,
+      maySetSeen: true, maySetKeywords: true, mayCreateChild: true,
+      mayRename: true, mayDelete: true, maySubmit: true,
+    },
+    isSubscribed: true,
+    isShared: false,
+    ...overrides,
+  };
+}
+
+const client = { getAccountId: () => PRIMARY } as unknown as IJMAPClient;
+
+const change = (changed: StateChange['changed']): StateChange =>
+  ({ '@type': 'StateChange', changed }) as StateChange;
+
+describe('handleStateChange refreshes the open shared folder', () => {
+  let refreshCurrentMailbox: ReturnType<typeof vi.fn>;
+
+  const seed = (over: Record<string, unknown> = {}) => {
+    refreshCurrentMailbox = vi.fn().mockResolvedValue(undefined);
+    useEmailStore.setState({
+      selectedMailbox: 'shared-inbox',
+      // `isShared` is load-bearing: resolveViewAccountId() only reports an
+      // owner account for a shared folder.
+      mailboxes: [makeMailbox({ id: 'shared-inbox', accountId: OWNER, isShared: true })],
+      accountMailboxes: {},
+      viewingAccountId: undefined,
+      isUnifiedView: false,
+      refreshCurrentMailbox,
+      fetchTagCounts: vi.fn(),
+      fetchMailboxes: vi.fn().mockResolvedValue(undefined),
+      ...over,
+    } as never);
+  };
+
+  beforeEach(() => seed());
+
+  it('refetches the rows when the OWNER account of the viewed folder changed', async () => {
+    await useEmailStore.getState().handleStateChange(change({ [OWNER]: { Email: 'state-2' } }), client);
+    expect(refreshCurrentMailbox).toHaveBeenCalled();
+  });
+
+  it('still refetches on a primary-account change (unchanged behaviour)', async () => {
+    await useEmailStore.getState().handleStateChange(change({ [PRIMARY]: { Email: 'state-2' } }), client);
+    expect(refreshCurrentMailbox).toHaveBeenCalled();
+  });
+
+  it('does not refetch for an unrelated account while a shared folder is open', async () => {
+    await useEmailStore.getState().handleStateChange(change({ 'other-account': { Email: 'state-2' } }), client);
+    expect(refreshCurrentMailbox).not.toHaveBeenCalled();
+  });
+
+  it('does not refetch when only the MAILBOX state moved (counters only)', async () => {
+    await useEmailStore.getState().handleStateChange(change({ [OWNER]: { Mailbox: 'state-2' } }), client);
+    expect(refreshCurrentMailbox).not.toHaveBeenCalled();
+  });
+
+  it('leaves an own-account view untouched by a shared account change', async () => {
+    seed({
+      selectedMailbox: 'inbox',
+      mailboxes: [makeMailbox({ id: 'inbox' })],
+    });
+    await useEmailStore.getState().handleStateChange(change({ [OWNER]: { Email: 'state-2' } }), client);
+    expect(refreshCurrentMailbox).not.toHaveBeenCalled();
+  });
+
+  // The aggregate views contribute shared accounts too, so they take any
+  // contributing account's Email change.
+  it('refetches an aggregate view on any contributing account change', async () => {
+    seed({ isUnifiedView: true });
+    await useEmailStore.getState().handleStateChange(change({ 'other-account': { Email: 'state-2' } }), client);
+    expect(refreshCurrentMailbox).toHaveBeenCalled();
+  });
+});

--- a/stores/email-store.ts
+++ b/stores/email-store.ts
@@ -3256,8 +3256,36 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
       const accountChanges = change.changed[accountId];
       const anyMailboxChanged = Object.values(change.changed).some((c) => c?.Mailbox);
 
-      // Handle Email state changes - refresh current mailbox
-      if (accountChanges?.Email) {
+      // Handle Email state changes - refresh current mailbox.
+      //
+      // The OPEN folder may be a delegated/shared one whose owner is not the
+      // primary account. Stalwart's SSE never pushes StateChange for those, so
+      // they arrive only via the client's secondary poll - reported under the
+      // OWNER's accountId, never the primary's. Keying this refresh off the
+      // primary alone therefore left the visible rows stale until a manual
+      // reload whenever a background change touched a shared folder: the folder
+      // counters moved (they already react to any account, below) while the
+      // list did not. A server-side keyword patch - an operator job stamping a
+      // colour label, or another member of the shared mailbox acting on it -
+      // was invisible until a hard refresh.
+      //
+      // `resolveViewAccountId()` is the existing helper for "which owner
+      // account am I looking at", and resolves through `resolveActionMailboxes`
+      // so it stays correct in the multi-account shell too. It returns
+      // undefined for a normal own-account view, leaving behaviour unchanged.
+      //
+      // The aggregate views contribute shared accounts as well, so they take
+      // any contributing account's Email change. `refreshCurrentMailbox`
+      // already coalesces (see `coalesceRefresh`), which bounds the extra
+      // refetches a busy shared mailbox can trigger.
+      const viewedOwnerAccountId = resolveViewAccountId();
+      const viewedEmailChanged = Boolean(
+        accountChanges?.Email
+        || (viewedOwnerAccountId && change.changed[viewedOwnerAccountId]?.Email)
+        || (get().isUnifiedView && Object.values(change.changed).some((c) => c?.Email)),
+      );
+
+      if (viewedEmailChanged) {
         await get().refreshCurrentMailbox(client);
         get().fetchTagCounts(client);
       }


### PR DESCRIPTION
On a shared, group or aliased mailbox every reply, reply-all and forward goes
out as `identities[0]` — the account owner — whichever mailbox is open. Users
hit this as *"it keeps sending as the wrong address and I have to fix the From
by hand every time"*.

This supersedes #918, rebased onto current `main`. Two things changed since:

- The `handleStateChange` commit is **dropped** — 5805a28e8 ("resolve pushes
  with `Email/changes` and `Mailbox/changes` deltas") solved that
  independently, and better, via `emailListSync.accountId`. It was also the
  only merge conflict, so what is left applies cleanly.
- The Pro compose-tab half is now a separate, self-contained PR so it isn't
  held up by the discussion here.

### Why the setting is being split rather than flipped

The gate is deliberate — ddb636ed7 added it default-off, b0640c9ec fused the
catch-all into the same flag, and b716f95a7 (mine) then rode the same flag. I
am not asking to flip that default. The argument is that one flag is covering
two behaviours with very different risk:

1. **Own-identity match** — pick among the user's *configured* identities
   (exact, then `+tag`-stripped). Never rewrites `From:`; it only chooses which
   of your own addresses sends. This is the Thunderbird/Outlook default.
2. **Domain catch-all rewrite** — put an address you have *not* configured into
   `From:`, sending through a same-domain identity (#246).

(1) is what makes a shared mailbox reply from its own address, and it carries no
impersonation risk, so it becomes unconditional. `findReplyIdentityId` already
implemented exactly this and was referenced only from tests.

(2) stays behind the setting, and has to: `ownedDomains` treats **any** address
on a domain you hold an identity on as a catch-all candidate — including a
colleague's, and including one seen only in `Bcc:` — so on a multi-user domain
it can put someone else's address in your From. Enabling that for everyone
would be a regression, not a fix.

### What else is in here

- **`forward` was excluded from the resolution entirely**, so forwarding a
  message that arrived at a shared mailbox went out as the owner — though the
  comment above the gate already promised *"Reply/forward fall through to the
  recipient-based resolution below"*. Forwards take (1) but deliberately never
  (2): a reply continues a thread whose participants know the addressing, while
  a forward introduces a rewritten From to a recipient the user just typed.
- **`handleQuickReply` is narrowed to (1)** — a bare text box with no From row
  is the wrong place to apply a rewrite the user cannot see or correct — and now
  **falls back to the primary identity's signature** the way the composer does
  (`signatureIdentity`). Without that, quick-replying from a shared identity
  with no signature of its own silently dropped the user's signature.
- **`findReplyIdentityId` now scans recipients (To, then Cc, then Bcc) instead
  of scanning identities**, exact matches before `+tag`-stripped ones, and
  prefers an untagged identity over a differently-tagged sibling. Scanning
  identities let *their* order decide, and `sortIdentities` deliberately puts
  the login's own address first — so `To: team@, Cc: you@` replied as you,
  which is precisely the case this is meant to fix.
- **Automatic selection is restricted to the active account.**
  `composerClient` follows the selected identity, so in the Pro shell an
  automatic cross-account match would send a forward's inherited blobIds — and
  its autosaved draft — to a server that has never seen them. The From dropdown
  still offers every account's identities for manual selection.

### Deliberately not changed

- **New messages stay gated.** Making the `mode === 'compose'` branch
  unconditional looked tempting, but `composeFromAccountEmail` falls back to
  `AccountEntry.email`, which is written once at first login and never updated —
  so it would override a user-chosen default sender identity (#507) on every new
  message, for exactly the users who already fixed their From by hand. There is
  a test pinning that boundary.
- **The setting's label and description** now describe behaviour the toggle no
  longer solely controls. I left `locales/` untouched rather than change one
  locale's strings out of 27 — happy to send that as its own PR (all locales
  plus the hardcoded label in `app/(main)/admin/_tabs/policy.tsx`) if you want
  it, and it's worth deciding the wording first.
- `normalizeBaseEmailAddress` hardcodes `+` while `subAddressDelimiter` is
  configurable; pre-existing, shared with `resolveReplyFrom` and
  `findDraftIdentityId`, so out of scope here.
- "Forward as attachment" builds a `replyTo` with no recipients, so the forward
  fix does not reach it — it still sends as the owner.
- In plain-text mode with the signature above the quote, the embedded signature
  is chosen before the identity is resolved and the swap effect does not run for
  plain text, so the body can carry the primary's signature under an alias From.
  Pre-existing with the setting on; now reachable by default. Fixing it properly
  means teaching the swap effect about the plain-text surface.

### Testing

`npm run typecheck` clean; `npm run lint` clean (the same 9 pre-existing
warnings as `main`, 0 errors). Full suite: **3670 passing**, with only the
failures `main` produces on its own — a `zh-TW` key-drift in
`translations.test.ts`, plus suites that flake under the single-worker full run
and pass in isolation (a *different* one flakes on the `main` baseline, and none
of them import a file this PR touches).

Each behaviour was verified by reverting it and confirming exactly the intended
tests go red:

| reverted | red |
| --- | --- |
| the whole-effect setting gate | 4 — reply, forward, To-over-Cc, **and the pre-existing self-sent (#703) test** |
| `forward` admitted to the resolution | 1 — forward |
| the catch-all rewrite kept opt-in | 1 — "does not rewrite while the setting is off" |
| the rewrite never firing on a forward | 1 — "never rewrites From on a forward" |
| the compose branch's gate (made unconditional again) | 1 — the #507 boundary test |
| recipient order, back to scanning identities | 4 — To-over-Cc, Bcc-below-To, untagged preference, and the composer case |
| the untagged-sibling preference | 1 — `sales+us@` → `sales@`, not `sales+eu@` |
| the same-account restriction | 1 — "never auto-selects an identity from another account" |

Controls are deliberate: the catch-all rewrite *still* fires on a reply when the
setting is on, so the "no rewrite" tests prove the gate rather than a broken
resolver.

One fixture bug is fixed on the way: `reply-addressing.test.tsx` hard-coded
`autoSelectReplyIdentity: true` while the shipped default is `false`, so the
shipped configuration was the one nothing exercised. With the mock corrected,
the existing self-sent-reply test (#703) fails without this change — that
feature was dead in the shipped default too.
