### PR TITLE
fix: added missing translation keys in contact-detail and email-composer, updated french translation

### DIFF
--- a/components/contacts/contact-detail.tsx
+++ b/components/contacts/contact-detail.tsx
@@ -234,7 +234,11 @@ export function ContactDetail({ contact, onEdit, onDelete, onAddToGroup, onDupli
           <Section title={t("detail.section_contact")}>
             <div className="space-y-3">
               {emails.map((e, i) => (
-                <FieldRow key={`em${i}`} icon={Mail} label={e.label || formatContexts(e.contexts) || t("detail.email_default_label")}>
+                <FieldRow 
+                  key={`em${i}`}
+                  icon={Mail} 
+                  label={e.label || (formatContexts(e.contexts) ? t("detail." + formatContexts(e.contexts)) : t("detail.email_default_label"))}
+                >
                   <div className="flex items-center gap-2 group">
                     <MailtoLink to={e.address} className="text-sm text-primary hover:underline break-all">
                       {e.address}
@@ -256,7 +260,7 @@ export function ContactDetail({ contact, onEdit, onDelete, onAddToGroup, onDupli
 
               {phones.map((p, i) => {
                 const features = formatPhoneFeatures(p.features);
-                const labelParts = [p.label, formatContexts(p.contexts), features].filter(Boolean) as string[];
+                const labelParts = [p.label, formatContexts(p.contexts) ? t("detail." + formatContexts(p.contexts)) : "", t("detail." + features)].filter(Boolean) as string[];
                 return (
                   <FieldRow key={`ph${i}`} icon={Phone} label={labelParts.length ? labelParts.join(" · ") : t("detail.phone_default_label")}>
                     <div className="flex items-center gap-2 group">
@@ -285,7 +289,7 @@ export function ContactDetail({ contact, onEdit, onDelete, onAddToGroup, onDupli
                   lines.push(...parts);
                 }
                 return (
-                  <FieldRow key={`ad${i}`} icon={MapPin} label={formatContexts(a.contexts) || t("detail.address_default_label")}>
+                  <FieldRow key={`ad${i}`} icon={MapPin} label={formatContexts(a.contexts) ? t("detail." + formatContexts(a.contexts)) : t("detail.address_default_label")}>
                     <div className="text-sm space-y-0.5">
                       {lines.map((line, idx) => (
                         <div key={idx}>{line}</div>

--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -2763,7 +2763,7 @@ export function EmailComposer({
                   setShowCc(true);
                 }}
               >
-                Cc
+                {t("cc")}
               </Button>
               <Button
                 variant="ghost"
@@ -2787,7 +2787,7 @@ export function EmailComposer({
                   setShowBcc(true);
                 }}
               >
-                Bcc
+                {t("bcc")}
               </Button>
             </div>
           </div>

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -2503,7 +2503,15 @@
       "related_default_label": "Related",
       "more_actions": "More actions",
       "age_years": "{count, plural, one {1 year old} other {# years old}}",
-      "years_since": "{count, plural, one {1 year} other {# years}}"
+      "years_since": "{count, plural, one {1 year} other {# years}}",
+      "private": "Private",
+      "work": "Work",
+      "cell": "Mobile",
+      "voice": "Voice",
+      "fax": "Fax",
+      "pager": "Pager",
+      "video": "Video",
+      "text": "text"
     },
     "activity": {
       "recent_emails": "Recent Emails",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -1044,16 +1044,16 @@
         "description": "Colore les icônes de dossiers et d'étiquettes par type (Boîte de réception en bleu, Indésirable en rouge, Envoyés en vert, etc.). Désactivez pour une barre latérale monochrome."
       },
       "tint_list_rows": {
-        "label": "Tint List Rows by Tag Color",
-        "description": "Shade each message row with its first tag color. Disable to keep rows plain; tag dots and chips still show the color."
+        "label": "Lignes de liste colorées selon la couleur d'étiquette",
+        "description": "Appliquez une couleur de fond à chaque ligne de message en fonction de la couleur de sa première étiquette. Désactivez cette option pour conserver des lignes unies. Les points et les pastilles d'étiquette continueront d'afficher la couleur."
       },
       "show_folder_total_count": {
         "label": "Afficher le nombre total de messages",
         "description": "Affiche le nombre total de messages à côté des dossiers et des étiquettes, en plus du nombre de messages non lus. Désactivez pour n'afficher que les messages non lus."
       },
       "favicon_unread_badge": {
-        "label": "Unread Count on Tab Icon",
-        "description": "Show the inbox unread count as a badge on the browser tab icon, so new mail is visible when the tab is not focused. Disable to keep the icon unbadged."
+        "label": "Nombre de non-lu sur l'icône de l'onglet",
+        "description": "Afficher le nombre de messages non lus de la boîte de réception sous forme de badge sur l’icône de l’onglet du navigateur, afin que les nouveaux messages restent visibles lorsque l’onglet n’est pas actif. Désactiver cette option pour ne pas afficher de badge sur l’icône."
       },
       "pro_interface": {
         "label": "Interface Pro (expérimental)",
@@ -1183,7 +1183,7 @@
         "device_status_unknown": "Inconnu de ce relais",
         "device_expires": "Expire le {date}",
         "revoke": "Révoquer",
-        "confirm_revoke_title": "Révoquer cet appareil ?",
+        "confirm_revoke_title": "Révoquer cet appareil ?",
         "confirm_revoke_message": "Il cessera immédiatement de recevoir les notifications en arrière-plan. Réactiver les notifications push sur cet appareil l’enregistrera à nouveau.",
         "confirm_revoke_message_this": "Cet appareil cessera immédiatement de recevoir les notifications en arrière-plan."
       }
@@ -1208,12 +1208,12 @@
         "preview_older": "Plus ancien :"
       },
       "date_locale": {
-        "label": "Date format region",
-        "description": "How numeric dates are ordered (day, month, year)",
-        "auto": "Automatic (match language)",
-        "iso": "ISO 8601 (YYYY-MM-DD)",
-        "dmy": "Day/Month/Year",
-        "mdy": "Month/Day/Year"
+        "label": "Format de date",
+        "description": "Comment sont ordonnées des dates (jour, mois, année)",
+        "auto": "Automatique (correspondre à la langue)",
+        "iso": "ISO 8601 (Année-Mois-Jour)",
+        "dmy": "Jour/Mois/Année",
+        "mdy": "Mois/Jour/Année"
       },
       "time_format": {
         "label": "Format d'heure",
@@ -1228,10 +1228,10 @@
         "monday": "Lundi"
       },
       "time_zone": {
-        "label": "Time zone",
-        "description": "Show email and calendar times in this time zone instead of the one reported by your browser",
-        "auto": "Automatic ({zone})",
-        "preview_now": "Now:"
+        "label": "Fuseau horaire",
+        "description": "Afficher les heures des e-mails et du calendrier dans ce fuseau horaire plutôt que dans celui indiqué par votre navigateur",
+        "auto": "Automatique ({zone})",
+        "preview_now": "Maintenant:"
       }
     },
     "email_behavior": {
@@ -1832,9 +1832,9 @@
         "button": "Voir les raccourcis"
       },
       "refresh_cache": {
-        "label": "Refresh cached data",
-        "description": "Reload contacts, calendars, and folders from the server. Keeps your accounts and sessions — fixes a stale or wrong view without signing out.",
-        "button": "Refresh"
+        "label": "Actualiser les données en cache",
+        "description": "Actualiser les contacts, calendriers et dossiers depuis le serveur. Vos comptes et sessions sont conservés. Corrige un affichage obsolète ou incorrect sans vous déconnecter.",
+        "button": "Actualiser"
       },
       "reset_settings": {
         "label": "Réinitialiser les paramètres",
@@ -2488,32 +2488,40 @@
       "cert_already_imported": "Certificat déjà importé",
       "cert_imported": "Certificat importé",
       "cert_import_failed": "Échec de l'import du certificat",
-      "section_contact": "Contact details",
-      "section_work": "Work",
-      "section_personal": "Personal",
-      "email_default_label": "Email",
-      "phone_default_label": "Phone",
-      "address_default_label": "Address",
-      "online_service_default_label": "Online",
-      "organization_label": "Organization",
-      "title_label": "Title",
-      "role_label": "Role",
+      "section_contact": "Détails du contact",
+      "section_work": "Travail",
+      "section_personal": "Personnel",
+      "email_default_label": "E-mail",
+      "phone_default_label": "Téléphone",
+      "address_default_label": "Adresse",
+      "online_service_default_label": "Connecté",
+      "organization_label": "Organisation",
+      "title_label": "Titre",
+      "role_label": "Rôle",
       "language_label": "Language",
       "related_default_label": "Related",
       "more_actions": "Plus d'actions",
       "age_years": "{count, plural, one {1 an} other {# ans}}",
-      "years_since": "{count, plural, one {il y a 1 an} other {il y a # ans}}"
+      "years_since": "{count, plural, one {il y a 1 an} other {il y a # ans}}",
+      "private": "Personnel",
+      "work": "Professionnel",
+      "cell": "Mobile",
+      "voice": "Voix",
+      "fax": "Fax",
+      "pager": "Bip",
+      "video": "Vidéo",
+      "text": "SMS"
     },
     "activity": {
-      "recent_emails": "Recent Emails",
-      "upcoming_events": "Upcoming Events",
-      "no_emails": "No recent emails",
-      "no_events": "No upcoming events",
-      "no_subject": "(No subject)",
-      "no_title": "(No title)",
-      "load_failed": "Failed to load",
+      "recent_emails": "Courriels récents",
+      "upcoming_events": "Évènements à venir",
+      "no_emails": "Aucun courriel récent",
+      "no_events": "Aucun évènement à venir",
+      "no_subject": "(Aucun objet)",
+      "no_title": "(Aucun titre)",
+      "load_failed": "Échec du chargement",
       "unknown_sender": "Unknown sender",
-      "all_day": "All day"
+      "all_day": "Toute la journée"
     },
     "form": {
       "create_title": "Nouveau contact",
@@ -2635,9 +2643,9 @@
       "no_members": "Aucun membre dans ce groupe",
       "member_count": "{count, plural, =0 {Aucun membre} one {1 membre} other {# membres}}",
       "send_email": "Send email to group",
-      "send_email_to": "To",
+      "send_email_to": "À",
       "send_email_cc": "Cc",
-      "send_email_bcc": "Bcc",
+      "send_email_bcc": "Cci",
       "no_member_emails": "This group has no members with an email address."
     },
     "import": {


### PR DESCRIPTION
## Summary

This PR add a few missing translation key that prevented translation of some Ui element in mail composer and contact detail layouts. It also add a few missing translation for french locale. 

## Changes

<!-- A bulleted list of the key changes made. -->

- Implemented translation resolution to "Cc" and and "Bcc" in mail composer
- Implemented translation resolution to email fields in contact detail view layout
- Implemented translation resolution to phone fields in contact detail view layout
- Added missing translation key for phone numbers type in contact detail
- Added a few french translation across the board

## Related issues

None

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Screenshots / demo
Before (Contact detail): 
<img width="2003" height="1296" alt="image" src="https://github.com/user-attachments/assets/bc18dbc1-fb22-4558-8a2a-2870c2efaf3d" />

After (Contact detail) :
<img width="2003" height="1296" alt="image" src="https://github.com/user-attachments/assets/95ed6228-0693-40f4-bd5e-d1826397dd45" />

Before (Mail composer) : 
<img width="2003" height="1296" alt="image" src="https://github.com/user-attachments/assets/77807abd-a3eb-4331-96ab-1a20639bda08" />

After (Mail composer) :
<img width="2003" height="1296" alt="image" src="https://github.com/user-attachments/assets/cfc1768c-6f07-408e-8d68-7598d24d0f0d" />


## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
