### PR TITLE
fix(calendar): show in-flight state on Save, and surface the silent length-guard rejection

### DIFF
--- a/components/calendar/event-modal.tsx
+++ b/components/calendar/event-modal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useTranslations, useLocale } from "next-intl";
+import { toast } from "@/stores/toast-store";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { X, Trash2, Check, Users, CalendarDays, Copy, Pencil, Clock, MapPin, Video, Repeat, Bell, AlignLeft, Plus } from "lucide-react";
@@ -462,7 +463,13 @@ export function EventModal({
   const handleSave = useCallback(async () => {
     const trimmedTitle = title.trim();
     if (!trimmedTitle || isSaving) return;
-    if (trimmedTitle.length > 500 || description.trim().length > 10000 || location.trim().length > 500) return;
+    if (trimmedTitle.length > 500 || description.trim().length > 10000 || location.trim().length > 500) {
+      // This guard returned silently, so a rejected save was indistinguishable from a dead
+      // button. The fields also enforce their limits via maxLength, so this is a backstop —
+      // but if it ever fires, say so.
+      toast.error(t("notifications.event_error"));
+      return;
+    }
 
     const pendingAttendee = participantInputRef.current?.flush() ?? null;
     const effectiveAttendees = pendingAttendee ? [...attendees, pendingAttendee] : attendees;
@@ -1415,7 +1422,9 @@ export function EventModal({
             disabled={!title.trim() || isSaving}
             className="w-full"
           >
-            {t("form.save")}
+            {/* While a save is in flight the button was disabled with no visible change, so a
+                slow request (mobile, VPN) looked like a dead button for the whole timeout. */}
+            {isSaving ? t("form.saving") : t("form.save")}
           </Button>
         </div>
         )}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -2780,6 +2780,7 @@
       "all_day_event": "All-day event",
       "calendar_select": "Calendar",
       "save": "Save",
+      "saving": "Saving…",
       "cancel": "Cancel",
       "delete_confirm": "Are you sure you want to delete this event?",
       "color": "Color"


### PR DESCRIPTION
Follow-up to #888 / #887. That PR fixed the *crash* in the calendar Save path (`crypto.randomUUID`
on insecure origins); this one fixes the two places where the same dialog gives the user **no
feedback at all**, which is what made the crash present as "the Save button is dead".

Both are still reproducible on `main` today.

## 1. Save has no in-flight state
`handleSave` is `async`, and the button is disabled while `isSaving` — but nothing on screen
changes. On a slow link (mobile, VPN, a self-hosted server over a tunnel) the button simply stops
responding for the full duration of the request, which reads as a dead button and invites repeat
clicks. `disabled` prevents the double-submit, so this is a feedback bug rather than a data bug —
but "nothing happened" is the reason users click again.

Fix: `{isSaving ? t("form.saving") : t("form.save")}`, plus the missing `calendar.form.saving`
key. (`calendar.form` had no `saving`; the `saving` key that exists elsewhere in `common.json` is
in a different namespace.)

## 2. The length guard returns silently
```ts
if (trimmedTitle.length > 500 || description.trim().length > 10000 || location.trim().length > 500) return;
```
A save rejected here produces no toast, no field error, no dialog change — indistinguishable from
case 1. The inputs also enforce these limits via `maxLength`, so this is a backstop that should
rarely fire; when it does, it should say so. Fix: `toast.error(t("notifications.event_error"))`
before the return, using the key that already exists.

## Notes
- Two files, +12/-2, no refactor, no dependency change.
- `notifications.event_error` already exists; only `calendar.form.saving` is added, English only —
  happy to leave it for translators or add other locales if you prefer.
- Found while running Bulwark against a self-hosted Stalwart over a plain-http LAN origin, which is
  also how #887 surfaced. Happy to adjust the wording or drop the code comments if you'd rather
  keep the file comment-free.
