### PR TITLE
fix: add translations for plugin fetched from marketplace

### DIFF
--- a/app/api/admin/marketplace/route.ts
+++ b/app/api/admin/marketplace/route.ts
@@ -365,6 +365,10 @@ export async function POST(request: NextRequest) {
         ...(declaredApiPostPaths.length > 0
           ? { apiPostPaths: declaredApiPostPaths }
           : {}),
+        ...(manifest.locales && typeof manifest.locales === 'object'
+          ? { locales: manifest.locales as ServerPlugin['locales'] }
+          : {}),
+
       };
 
       await savePlugin(plugin, code);


### PR DESCRIPTION
## Summary
Fix https://github.com/paulhenry46/pgp-plugin/issues/28 . Indeed, when plugins are imported from marketplace, ServerPlugin object is not populated with locales. As a result, the plugin use the translation key as fallback.

## Changes
- Populate ServerPlugin object with locales from manifest

## Related issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
