### PR TITLE
fix: set default addressbook to selected one

### DIFF
--- a/components/contacts/contacts-app.tsx
+++ b/components/contacts/contacts-app.tsx
@@ -391,6 +391,13 @@ export function ContactsApp({ linkSegments }: ContactsAppProps = {}) {
 
   const handleCreateNew = () => {
     setSelectedContact(null);
+    // When a specific address book is being viewed, create the new contact in
+    // that book instead of falling back to the account's default book.
+    if (typeof activeCategory === "object" && "addressBookId" in activeCategory) {
+      setDefaultBookIdForCreate(activeCategory.addressBookId);
+    } else {
+      setDefaultBookIdForCreate(undefined);
+    }
     setView("create");
   };
 
@@ -961,7 +968,8 @@ export function ContactsApp({ linkSegments }: ContactsAppProps = {}) {
                       } : undefined}
                       onCreateContactInBook={(book) => {
                         setDefaultBookIdForCreate(book.id);
-                        handleCreateNew();
+                        setSelectedContact(null);
+                        setView("create");
                       }}
                       onDeleteAddressBook={client ? async (book) => {
                         const ok = await confirmDialog({


### PR DESCRIPTION
## Summary

<!-- A brief, one-paragraph description of what this PR does and why. -->
Use the selected addressbook as default for the Contact creation dialog.

It's less a bug but a "user expectation issue" as the dialog provides a dropdown for addressbook selection. But as the Create button is in the contact list which shows the content of the selected addressbook, the dialog should automatically select this addressbook.

## Changes

<!-- A bulleted list of the key changes made. -->

- Use the selected addressbook as default for the Contact creation dialog.

## Related issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #940

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
