### PR TITLE
fix(mobile): open the folder drawer from the right in RTL

### DIFF
--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -3431,16 +3431,20 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
             isEmbedded
               ? (isMobile || isTablet
                   ? cn(
-                      "absolute inset-y-0 left-0 w-72 pt-[env(safe-area-inset-top)]",
+                      "absolute inset-y-0 start-0 w-72 pt-[env(safe-area-inset-top)]",
                       "transform transition-transform duration-300 ease-in-out",
-                      !sidebarOpen && "-translate-x-full"
+                      // translate-x is physical, so RTL needs the opposite
+                      // sign or the drawer slides off the wrong edge.
+                      !sidebarOpen && "-translate-x-full rtl:translate-x-full"
                     )
                   : "relative translate-x-0")
               : cn(
                   // Mobile/Tablet: fixed overlay
-                  "max-lg:fixed max-lg:inset-y-0 max-lg:left-0 max-lg:w-72 max-lg:pt-[env(safe-area-inset-top)]",
+                  // start-0 rather than left-0: in RTL the drawer belongs on
+                  // the right, matching the hamburger that opens it.
+                  "max-lg:fixed max-lg:inset-y-0 max-lg:start-0 max-lg:w-72 max-lg:pt-[env(safe-area-inset-top)]",
                   "max-lg:transform max-lg:transition-transform max-lg:duration-300 max-lg:ease-in-out",
-                  !sidebarOpen && "max-lg:-translate-x-full",
+                  !sidebarOpen && "max-lg:-translate-x-full max-lg:rtl:translate-x-full",
                   // Desktop: normal flow
                   "lg:relative lg:translate-x-0"
                 ),


### PR DESCRIPTION
## Problem

On mobile and tablet in an RTL locale, tapping the hamburger opens the folder drawer from the **left** edge — the opposite side from the button that opens it. Reported by a Hebrew user; reproduced at `dir="rtl"` on any narrow viewport.

## Cause

The sidebar container is pinned with physical direction utilities that don't respond to `dir`:

- `left-0` / `max-lg:left-0` — anchors to the physical left in both directions
- `-translate-x-full` / `max-lg:-translate-x-full` — slides off to the physical left

`<html dir>` is already set correctly from the locale; only these classes ignore it.

## Fix

- `left-0` → `start-0` (logical `inset-inline-start`), in both the embedded and the fixed-overlay branch.
- Pair the translate with an `rtl:` override. `translate-x` is physical and Tailwind has no logical equivalent, so the sign has to be flipped explicitly rather than swapped for a logical utility.

Worth noting for review: Tailwind v4 emits `rtl:` wrapped in `:where(…)`, which contributes **zero specificity**. The override therefore wins on source order alone. I verified in the built stylesheet that the RTL rule is emitted after the LTR one:

```
.max-lg\:-translate-x-full      @ 144868
.max-lg\:rtl\:translate-x-full  @ 154037   <- wins
```

The generated selector matches `:lang(he)` as well as `[dir=rtl]`, so it applies whether direction comes from the attribute or the language.

## Testing

- `tsc --noEmit` clean on this branch.
- Built and deployed to a production instance; confirmed all three rules present and correctly ordered in the served CSS.
- LTR behaviour unchanged — the negative translate and its `max-lg:` variant are untouched.

Desktop is unaffected (`lg:relative lg:translate-x-0`, normal flex flow).
