### PR TITLE
feat(mobile): search-first header, replacing the second toolbar row

### DIFF
--- a/components/layout/account-switcher.tsx
+++ b/components/layout/account-switcher.tsx
@@ -15,7 +15,7 @@ import { useMenuNavigation } from "@/hooks/use-menu-navigation";
 
 interface AccountSwitcherProps {
   /** "rail" = small avatar only (NavigationRail), "expanded" = avatar + name + email (Sidebar) */
-  variant?: "rail" | "expanded";
+  variant?: "rail" | "expanded" | "header";
   className?: string;
 }
 
@@ -66,7 +66,20 @@ export function AccountSwitcher({ variant = "rail", className }: AccountSwitcher
     if (!buttonRef.current) return;
     const rect = buttonRef.current.getBoundingClientRect();
     const rtl = isDocumentRTL();
-    if (variant === "rail") {
+    if (variant === "header") {
+      // Anchored at the inline-end edge of the top bar, so the menu drops
+      // down and is pinned by its own trailing edge — anchoring by the
+      // leading edge (as "expanded" does) runs it off-screen, which is
+      // exactly what happened in RTL where that edge is the left one.
+      setPopoverStyle({
+        position: "fixed",
+        top: rect.bottom + 4,
+        maxWidth: "calc(100vw - 16px)",
+        ...(rtl
+          ? { left: Math.max(8, rect.left) }
+          : { right: Math.max(8, window.innerWidth - rect.right) }),
+      });
+    } else if (variant === "rail") {
       setPopoverStyle(
         rtl
           ? {
@@ -197,12 +210,12 @@ export function AccountSwitcher({ variant = "rail", className }: AccountSwitcher
         data-active-account-id={activeAccountId ?? undefined}
         className={cn(
           "flex items-center gap-2 rounded-md transition-colors",
-          variant === "rail"
+          variant !== "expanded"
             ? "justify-center w-10 h-10 hover:bg-muted"
             : "w-full px-2 py-1.5 hover:bg-muted text-start min-w-0",
           className
         )}
-        title={variant === "rail" ? (displayName || displayEmail) : undefined}
+        title={variant !== "expanded" ? (displayName || displayEmail) : undefined}
         aria-label={t("switch_account")}
         aria-expanded={open}
         aria-haspopup="menu"
@@ -210,7 +223,7 @@ export function AccountSwitcher({ variant = "rail", className }: AccountSwitcher
       >
         {activeAccount ? (
           <>
-            <AccountAvatar account={activeAccount} size={variant === "rail" ? "sm" : "md"} />
+            <AccountAvatar account={activeAccount} size={variant === "expanded" ? "md" : "sm"} />
             {variant === "expanded" && (
               <>
                 <div className="min-w-0 flex-1">
@@ -224,7 +237,7 @@ export function AccountSwitcher({ variant = "rail", className }: AccountSwitcher
         ) : (
           <div className={cn(
             "rounded-full bg-muted flex items-center justify-center text-muted-foreground",
-            variant === "rail" ? "w-8 h-8 text-xs" : "w-9 h-9 text-sm"
+            variant === "expanded" ? "w-9 h-9 text-sm" : "w-8 h-8 text-xs"
           )}>
             ?
           </div>

--- a/components/layout/mobile-header.tsx
+++ b/components/layout/mobile-header.tsx
@@ -6,6 +6,7 @@ import { useUIStore } from "@/stores/ui-store";
 import { useIsDesktop } from "@/hooks/use-media-query";
 import { cn } from "@/lib/utils";
 import { useTranslations } from "next-intl";
+import { AccountSwitcher } from "@/components/layout/account-switcher";
 
 interface MobileHeaderProps {
   title: string;
@@ -16,6 +17,14 @@ interface MobileHeaderProps {
   className?: string;
   /** Id of the sidebar this header's menu button toggles. */
   sidebarId?: string;
+  /**
+   * When set, the mailbox title is replaced by a tappable search field and
+   * this fires instead. The folder name stays visible in the drawer, so the
+   * bar spends its width on the thing you act on rather than a label.
+   */
+  onOpenSearch?: () => void;
+  /** Placeholder shown inside the search field. */
+  searchPlaceholder?: string;
 }
 
 export function MobileHeader({
@@ -26,6 +35,8 @@ export function MobileHeader({
   onSearch,
   className,
   sidebarId,
+  onOpenSearch,
+  searchPlaceholder,
 }: MobileHeaderProps) {
   const t = useTranslations('sidebar');
   const { toggleSidebar, goBack, sidebarOpen } = useUIStore();
@@ -54,7 +65,7 @@ export function MobileHeader({
       )}
     >
       {/* Left action: Menu or Back button */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 min-w-0 flex-shrink-0">
         <Button
           variant="ghost"
           size="icon"
@@ -77,12 +88,24 @@ export function MobileHeader({
           )}
         </Button>
 
-        {/* Title */}
-        <h1 className="font-semibold text-lg truncate">{title}</h1>
+        {/* Title, unless the bar is in search-first mode */}
+        {!onOpenSearch && <h1 className="font-semibold text-lg truncate">{title}</h1>}
       </div>
 
+      {onOpenSearch && (
+        <button
+          type="button"
+          onClick={onOpenSearch}
+          className="flex-1 min-w-0 h-10 mx-1 flex items-center gap-2 rounded-full bg-muted px-4 text-start text-muted-foreground"
+          aria-label={searchPlaceholder || title}
+        >
+          <Search className="h-4 w-4 flex-shrink-0" />
+          <span className="truncate text-sm">{searchPlaceholder || title}</span>
+        </button>
+      )}
+
       {/* Right actions */}
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-1 flex-shrink-0">
         {onSearch && (
           <Button
             variant="ghost"
@@ -105,6 +128,12 @@ export function MobileHeader({
             <Plus className="h-5 w-5" />
           </Button>
         )}
+
+        {/* Which account you are reading is otherwise only visible after
+            opening the drawer. Last in this group so it sits on the far
+            edge — opposite the menu button, and mirrored under RTL because
+            the header is laid out with flex rather than fixed sides. */}
+        <AccountSwitcher variant="header" />
       </div>
     </header>
   );

--- a/components/layout/mobile-header.tsx
+++ b/components/layout/mobile-header.tsx
@@ -25,6 +25,10 @@ interface MobileHeaderProps {
   onOpenSearch?: () => void;
   /** Placeholder shown inside the search field. */
   searchPlaceholder?: string;
+  /** Clears the active query without opening the search panel. */
+  onClearSearch?: () => void;
+  /** Whether a query is currently applied, which reveals the clear button. */
+  searchActive?: boolean;
 }
 
 export function MobileHeader({
@@ -37,6 +41,8 @@ export function MobileHeader({
   sidebarId,
   onOpenSearch,
   searchPlaceholder,
+  onClearSearch,
+  searchActive = false,
 }: MobileHeaderProps) {
   const t = useTranslations('sidebar');
   const { toggleSidebar, goBack, sidebarOpen } = useUIStore();
@@ -93,15 +99,29 @@ export function MobileHeader({
       </div>
 
       {onOpenSearch && (
-        <button
-          type="button"
-          onClick={onOpenSearch}
-          className="flex-1 min-w-0 h-10 mx-1 flex items-center gap-2 rounded-full bg-muted px-4 text-start text-muted-foreground"
-          aria-label={searchPlaceholder || title}
-        >
-          <Search className="h-4 w-4 flex-shrink-0" />
-          <span className="truncate text-sm">{searchPlaceholder || title}</span>
-        </button>
+        /* Not a single button: the clear control is a button of its own, and
+           nesting one inside another is invalid markup. */
+        <div className="flex-1 min-w-0 h-10 mx-1 flex items-center rounded-full bg-muted ps-3 pe-1">
+          <button
+            type="button"
+            onClick={onOpenSearch}
+            className="flex-1 min-w-0 h-full flex items-center gap-2 text-start text-muted-foreground"
+            aria-label={searchPlaceholder || title}
+          >
+            <Search className="h-4 w-4 flex-shrink-0" />
+            <span className="truncate text-sm">{searchPlaceholder || title}</span>
+          </button>
+          {searchActive && onClearSearch && (
+            <button
+              type="button"
+              onClick={onClearSearch}
+              className="h-8 w-8 flex-shrink-0 grid place-items-center rounded-full text-muted-foreground hover:bg-background/60"
+              aria-label={t('clear_search')}
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
       )}
 
       {/* Right actions */}

--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -87,7 +87,7 @@ import { EML_IMPORT_ACCEPT, expandImportableEmails } from "@/lib/eml-import";
 import { findDraftIdentityId, resolveComposeAccountEmail, resolveReplyFrom, type ReplyFromResolution } from "@/lib/reply-identity";
 import { buildReplyRecipients, isSelfSent } from "@/lib/reply-recipients";
 import { useProMultiAccountIdentities } from "@/hooks/use-pro-multi-account-identities";
-import { Filter, ChevronDown, X, Paperclip, Star, Mail, MailOpen, RotateCcw, PenSquare, PenLine, CheckSquare, Square, AlertTriangle } from "lucide-react";
+import { Filter, ChevronDown, X, Paperclip, Star, Mail, MailOpen, RotateCcw, PenSquare, PenLine, CheckSquare, Square, AlertTriangle, ArrowLeft } from "lucide-react";
 import { ResizeHandle } from "@/components/layout/resize-handle";
 import { Button } from "@/components/ui/button";
 import { useConfig } from "@/hooks/use-config";
@@ -130,6 +130,9 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
   const tQuote = useTranslations('quote_header');
   const { appName } = useConfig();
   const mailLayout = useSettingsStore((state) => state.mailLayout);
+  // Phones present search full-screen from the header field rather than
+  // giving it a permanent second bar under the header.
+  const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
   const [showComposer, setShowComposer] = useState(false);
   const [composerMode, setComposerMode] = useState<'compose' | 'reply' | 'replyAll' | 'forward'>('compose');
   const [composerDraftText, setComposerDraftText] = useState("");
@@ -3544,10 +3547,34 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
             <MobileHeader
               title={currentMailboxName}
               sidebarId={sidebarId}
+              onOpenSearch={isMobile ? () => setMobileSearchOpen(true) : undefined}
+              searchPlaceholder={t('sidebar.search_placeholder_hint')}
             />
 
-            {/* Search Bar + Inline Advanced Filters */}
-            <div className="border-b border-border bg-background">
+            {/* Search Bar + Inline Advanced Filters. On phones this is not a
+                permanent second bar: the header carries a search field, and
+                tapping it presents this panel full-screen. Select-all and
+                refresh stay reachable there too, and long-press / pull-to-
+                refresh already cover them on the list itself. */}
+            {(!isMobile || mobileSearchOpen) && (
+            <div className={cn(
+              "border-b border-border bg-background",
+              isMobile && mobileSearchOpen && "fixed inset-0 z-50 overflow-y-auto"
+            )}>
+              {isMobile && mobileSearchOpen && (
+                <div className="h-14 px-2 flex items-center border-b border-border">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-11 w-11"
+                    onClick={() => setMobileSearchOpen(false)}
+                    aria-label={t('sidebar.mobile.go_back')}
+                  >
+                    <ArrowLeft className="h-5 w-5 rtl:-scale-x-100" />
+                  </Button>
+                  <span className="font-medium truncate">{t('sidebar.search_placeholder_hint')}</span>
+                </div>
+              )}
               <div className="px-3 h-14 flex items-center">
                 <div className="flex items-center gap-1.5 w-full">
                   {/* Select / Select All toggle */}
@@ -3797,6 +3824,7 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
                 </div>
               )}
             </div>
+            )}
 
             {(searchQuery || !isFilterEmpty(searchFilters)) && !activeIsLoading && !isScheduledView && (
               <div className="px-4 py-1.5 text-xs text-muted-foreground border-b border-border bg-muted/20">

--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -3548,7 +3548,7 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
               title={currentMailboxName}
               sidebarId={sidebarId}
               onOpenSearch={isMobile ? () => setMobileSearchOpen(true) : undefined}
-              searchPlaceholder={t('sidebar.search_placeholder_hint')}
+              searchPlaceholder={searchQuery || t('sidebar.search_placeholder_hint')}
             />
 
             {/* Search Bar + Inline Advanced Filters. On phones this is not a
@@ -3613,9 +3613,13 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
                   <SearchBox
                     value={searchQuery}
                     onChange={setSearchQuery}
-                    onSubmit={handleSearch}
-                    onClear={handleClearSearch}
-                    onSelectContact={handleSelectContactSuggestion}
+                    autoFocus={isMobile && mobileSearchOpen}
+                    onSubmit={(query) => { handleSearch(query); setMobileSearchOpen(false); }}
+                    onClear={() => { handleClearSearch(); setMobileSearchOpen(false); }}
+                    onSelectContact={(contact, field) => {
+                      handleSelectContactSuggestion(contact, field);
+                      setMobileSearchOpen(false);
+                    }}
                     disabled={isScheduledView}
                     title={isScheduledView ? t('email_viewer.scheduled_actions_only') : undefined}
                   />

--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -3549,6 +3549,8 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
               sidebarId={sidebarId}
               onOpenSearch={isMobile ? () => setMobileSearchOpen(true) : undefined}
               searchPlaceholder={searchQuery || t('sidebar.search_placeholder_hint')}
+              searchActive={!!searchQuery}
+              onClearSearch={handleClearSearch}
             />
 
             {/* Search Bar + Inline Advanced Filters. On phones this is not a

--- a/components/search/search-box.tsx
+++ b/components/search/search-box.tsx
@@ -22,6 +22,8 @@ interface SearchBoxProps {
   onSelectContact: (contact: ContactSuggestion, field: ContactSearchField) => void;
   disabled?: boolean;
   title?: string;
+  /** Focus on mount — the mobile search panel opens straight to the keyboard. */
+  autoFocus?: boolean;
 }
 
 /**
@@ -31,7 +33,7 @@ interface SearchBoxProps {
  * reuses the composer's contact autocomplete lookup so directory principals,
  * address-book contacts and recent recipients all surface here too.
  */
-export function SearchBox({ value, onChange, onSubmit, onClear, onSelectContact, disabled = false, title }: SearchBoxProps) {
+export function SearchBox({ value, onChange, onSubmit, onClear, onSelectContact, disabled = false, title, autoFocus }: SearchBoxProps) {
   const t = useTranslations("sidebar");
   const listId = `search-suggestions-${useId().replace(/:/g, "")}`;
 
@@ -118,6 +120,7 @@ export function SearchBox({ value, onChange, onSubmit, onClear, onSelectContact,
         <Search className="absolute start-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
         <Input
           type="text"
+          autoFocus={autoFocus}
           placeholder={t("search_placeholder_hint")}
           value={value}
           onChange={(e) => {


### PR DESCRIPTION
## Problem

On phones the mail list sits under two stacked 56px bars: `MobileHeader` (menu + mailbox name) and a second row holding select-all, the search box, the filter toggle and refresh. That is 112px of chrome before the first message, and the title largely repeats what the folder drawer already shows.

There is also no indication of which account you are reading until you open the drawer — easy to confuse with several accounts on a small screen.

## Change

The header becomes: menu · search field · account avatar. Tapping the search field presents the existing second row full-screen.

Nothing about search is rebuilt — the full-screen panel is the same block, so `SearchBox`, `SearchSuggestions`, the search-history store and `SearchChips` all come along as they are. Select-all and refresh remain reachable inside it, and the list already supports long-press selection (`hooks/use-long-press.ts`) and pull-to-refresh.

Tablet and desktop render exactly as before; the row is only relocated at `isMobile`.

## Why a new AccountSwitcher variant

`rail` flies its popover out sideways, which is right for a narrow vertical sidebar and wrong at the top of the screen: anchored to a trigger at the inline-end edge it runs off the viewport. In RTL that edge is the left one, so the menu opened past the left border and could not be reached.

The new `header` variant drops the menu below the trigger and pins it by its trailing edge, with `max-width: calc(100vw - 16px)` so it cannot exceed the viewport in either direction. `rail` and `expanded` are untouched.

## Direction

The bar is a flex row, so it mirrors on its own — the avatar lands top-right in LTR and top-left in RTL, always opposite the menu button. The back arrow in the full-screen panel is mirrored with `rtl:-scale-x-100`.

## Notes

- Translation keys are addressed through the root translator with full paths (`sidebar.search_placeholder_hint`, `sidebar.mobile.go_back`), per #688.
- No new strings, no new dependencies.
- `tsc --noEmit` clean. Test suite shows the same 4 failures as `main` at the time of writing (incomplete `zh-TW` locale, three auth-store logout tests) — unrelated to this change.
- Running on a production instance.
