### PR TITLE
fix(list): stop the batch toolbar hiding the message you just selected

### DIFF
--- a/components/email/email-list.tsx
+++ b/components/email/email-list.tsx
@@ -156,6 +156,11 @@ export function EmailList({
   // open it shrinks the list and would shove every row downwards. Feed each
   // height change back into scrollTop so the rows stay put on screen (and
   // slide back when the toolbar collapses again).
+  //
+  // Except at the very top: there are no rows above to hold steady, so the
+  // compensation just scrolls the first message underneath the toolbar and
+  // reads as the toolbar covering the message you selected. Let the list
+  // move down there instead.
   useEffect(() => {
     const toolbar = batchToolbarRef.current;
     if (!toolbar || typeof ResizeObserver === 'undefined') return;
@@ -166,7 +171,8 @@ export function EmailList({
       lastHeight = height;
       const list = parentRef.current;
       if (!list || delta === 0) return;
-      list.scrollTop += delta;
+      if (delta > 0 && list.scrollTop <= 0) return;
+      list.scrollTop = Math.max(0, list.scrollTop + delta);
     });
     observer.observe(toolbar);
     return () => observer.disconnect();


### PR DESCRIPTION
## Problem

Select the **top** message in the list and the batch toolbar opens directly over it — the message you just acted on disappears behind the bar acting on it. Most obvious on mobile, where the list starts at the top of the screen, but it reproduces anywhere the list is scrolled to zero.

## Cause

3ea64b2f feeds the toolbar's height back into `scrollTop` so rows keep their position as it animates open:

```js
list.scrollTop += delta;
```

That is right in the middle of a list. At the very top it is not: there are no rows above to hold steady, so the scroll simply slides the first rows underneath the toolbar. From `scrollTop: 0`, "keep the rows where they are" and "the toolbar now occupies 64px above them" cannot both hold — something has to move, and it should be the content.

## Change

Skip the compensation when the list is already at the top, and let the content move down there. Mid-list behaviour is untouched, so the original fix still does its job everywhere it was aimed at.

The scroll is also clamped at zero, so collapsing the toolbar can no longer drive `scrollTop` negative.

## Testing

- `tsc --noEmit` clean; `components/email` passes (129 tests).
- Reasoned through three cases: at the top (compensation now skipped), mid-list (unchanged), and collapsing (clamped at zero). The reporter hit this on mobile in an RTL locale.
- Running on a production instance.
