### PR TITLE
fix(viewer): restore sender colours in dark mode

### DIFF
--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -2178,7 +2178,22 @@ export function EmailViewer({
     // stack another invert either - each filter toggles the inversion, so an
     // odd number of stacked filters (body + outer + inner) lands back on
     // light-on-light; the descendant rule disables filter on a color container
-    // nested inside another.
+    // nested inside another. Two things that rule has to get right:
+    //
+    // `body` is excluded from being an ancestor, because a mail whose own
+    // <body> carries a background (very common: `body style="background:#fff"`)
+    // would otherwise make every container in the message count as nested, and
+    // the whole email would stay inverted — white bodies rendering black.
+    // body is already inverted by the rule above, so it must not re-invert
+    // itself either.
+    //
+    // Colour containers are also re-inverted when they wrap media, rather than
+    // being skipped. Skipping them left the container's own colour inverted —
+    // a navy header band reading as pale blue. Re-inverting it and cancelling
+    // the per-image rule inside gives the same net result for the image while
+    // restoring the band, which is what the background-image branch below
+    // already does. That cancel rule needs a real attribute selector rather
+    // than :where() so it outweighs the bare `img` rule.
     //
     // Background-IMAGE containers are different: a real photo and whatever is
     // composited over it (headline text, logos) was designed by the sender to
@@ -2192,12 +2207,16 @@ export function EmailViewer({
       img, video, svg, canvas, object, embed, input[type="image"] {
         filter: invert(1) hue-rotate(180deg);
       }
-      [style*="background:"]:not(:has(img, video, svg, canvas, object, embed)),
-      [bgcolor]:not(:has(img, video, svg, canvas, object, embed)) {
+      [style*="background:"]:not(body),
+      [bgcolor]:not(body) {
         filter: invert(1) hue-rotate(180deg);
       }
-      :where([style*="background:"], [bgcolor])
-        :where([style*="background:"], [bgcolor]):not(:has(img, video, svg, canvas, object, embed)) {
+      [style*="background:"]:not(body) :where(img, video, svg, canvas, object, embed, input[type="image"]),
+      [bgcolor]:not(body) :where(img, video, svg, canvas, object, embed, input[type="image"]) {
+        filter: none;
+      }
+      :where([style*="background:"]:not(body), [bgcolor]:not(body))
+        :where([style*="background:"], [bgcolor]) {
         filter: none !important;
       }
       [style*="background-image"],


### PR DESCRIPTION
## Problem

In dark mode, ordinary HTML mail comes out with the sender's colours wrong: a navy header band renders pale blue, a white message body renders black. Reported against a standard transactional template.

## Cause

The dark-mode CSS inverts the body and then re-inverts colour containers so they return to what the sender designed. Two rules stopped that second step from happening.

**1. `body` was not excluded from the nested-container rule.**

```css
:where([style*="background:"], [bgcolor])
  :where([style*="background:"], [bgcolor]):not(:has(…)) { filter: none !important; }
```

A mail whose own body carries a background — `<body style="margin:0;padding:0;background:#fff;">`, which is standard in transactional templates — makes *every* colour container in the message a descendant of a colour container. All of them get `filter: none`, nothing is re-inverted, and the entire email stays inverted. That is the white-body-renders-black half.

**2. Colour containers wrapping media were skipped entirely.**

The `:not(:has(img, video, …))` guard means a header band containing a logo never gets re-inverted, so the band keeps the body's inversion. That is the navy-renders-pale-blue half.

## Change

Exclude `body` from being an ancestor in the nested rule (and from the re-invert itself — it is already inverted by the rule above, so it must not flip back).

Re-invert colour containers even when they wrap media, and cancel the per-image rule inside them — exactly what the `background-image` branch immediately below already does. The image ends up with the same net treatment as before, while the container's colour is restored.

That cancel needs a real attribute selector rather than `:where()`: `:where()` contributes no specificity, so a `:where(…) :where(img)` form loses to the bare `img { filter: … }` rule and silently does nothing.

## Verification

Reproduced the exact markup from the reported message in a browser and read computed styles, before and after:

| element | before | after |
|---|---|---|
| header band (`background:` + logo) | `none` | `invert(1) hue-rotate(180deg)` |
| body table (`background:#ffffff`) | `none` | `invert(1) hue-rotate(180deg)` |
| logo `<img>` | double transform | single, via the container |

Rendering matches: navy band, white body, both restored.

`tsc --noEmit` clean; `components/email` passes (129 tests). Running on a production instance.

## Not addressed

Colours still do not round-trip perfectly through two `invert() hue-rotate()` passes — `hue-rotate` is a linear approximation, so a saturated yellow logo comes back slightly warm. That is inherent to the technique rather than to these selectors, and this change does not make it worse: the image goes through two transforms either way.
