### PR TITLE
fix(list): centre the sender avatar against the row

### DIFF
--- a/components/email/thread-list-item.tsx
+++ b/components/email/thread-list-item.tsx
@@ -331,7 +331,7 @@ const SingleEmailItem = React.forwardRef<HTMLDivElement, SingleEmailItemProps>(
               name={sender?.name}
               email={sender?.email}
               size={isFocusedMailLayout ? "sm" : "md"}
-              className="flex-shrink-0 shadow-sm"
+              className="flex-shrink-0 self-center shadow-sm"
               disableImages={hideJunkAvatarImages}
               checked={isChecked}
               onToggle={handleCheckboxClick}
@@ -773,7 +773,7 @@ export const ThreadListItem = React.forwardRef<HTMLDivElement, ThreadListItemPro
             )}
 
             {density !== 'extra-compact' && (
-              <div className="relative flex-shrink-0">
+              <div className="relative flex-shrink-0 self-center">
                 <SelectableAvatar
                   name={avatarPerson?.name}
                   email={avatarPerson?.email}


### PR DESCRIPTION
## Problem

The sender avatar sits high in each list row rather than centred against it — level with the sender line, with the subject and preview extending below it. Most obvious at default density, where a row is three lines tall.

## Cause

The row lays out with `items-start`:

```jsx
isFocusedMailLayout ? 'flex items-center' : 'flex items-start'
```

That is correct for the row as a whole: the sender line, subject and preview stack, and the body should govern the row height. But the avatar is a sibling of that body and inherits the same alignment, so it pins to the top.

## Change

Give the avatar `self-center` in both the single-message row and the thread row. The row keeps `items-start`, so nothing else moves.

Deliberately not switching the container to `items-center`: at `extra-compact` density the avatar is not rendered and a selection checkbox takes its place, carrying its own `!isFocusedMailLayout && 'mt-2'` offset that is tuned for `items-start`. The two are mutually exclusive, so centring only the avatar leaves that path untouched.

## Testing

`tsc --noEmit` clean; `components/email` passes (129 tests). Running on a production instance.
