### PR TITLE
feat(plugins): let a plugin display its own result set in the message list

### DIFF
--- a/lib/plugin-sandbox/host-api.ts
+++ b/lib/plugin-sandbox/host-api.ts
@@ -144,6 +144,10 @@ const PERM_PER_METHOD: Record<string, Permission | null> = {
   'keywords.discover': 'email:read',
   'keywords.getCounts': 'email:read',
   'keywords.refreshCounts': 'email:read',
+  // Show an explicit set of message ids in the list. Read-only and session-scoped: the host fetches
+  // with the user's own JMAP client, so a plugin cannot surface a message the user could not
+  // already open. Strictly weaker than tabs.categorize below, which writes keywords.
+  'search.showMessages': 'ui:message-list',
   // message-list category tabs
   'tabs.set': 'ui:message-list-tabs',
   'tabs.clear': 'ui:message-list-tabs',
@@ -997,6 +1001,9 @@ function requireClient() {
 
 // ─── Native keyword definitions ──────────────────────────────
 
+// A plugin's result set is a list a human reads, not a bulk export. The cap keeps one call from
+// pulling a whole mailbox through Email/get, which the client would chunk but nobody would scroll.
+const MAX_SHOW_MESSAGES = 200;
 const MAX_PLUGIN_KEYWORD_DEFINITIONS = 500;
 const MAX_PLUGIN_KEYWORD_LABEL_LENGTH = 255;
 const VALID_VISIBILITIES = new Set<KeywordVisibility>(['show', 'hide', 'unread']);
@@ -1512,6 +1519,25 @@ export async function dispatchApiCall(
     case 'keywords.getCounts': return doKeywordsGetCounts(args[0]);
     case 'keywords.refreshCounts': return doKeywordsRefreshCounts();
 
+    case 'search.showMessages': {
+      // For plugins that do their own retrieval -- semantic search, an external index, a memory
+      // system -- and want the result in the list the user already knows rather than in a panel of
+      // their own.
+      const ids = args[0];
+      if (!Array.isArray(ids) || ids.length === 0 || ids.some((id) => typeof id !== 'string' || !id)) {
+        throw new Error('search.showMessages: ids must be a non-empty array of strings');
+      }
+      if (ids.length > MAX_SHOW_MESSAGES) {
+        throw new Error(`search.showMessages: at most ${MAX_SHOW_MESSAGES} ids`);
+      }
+      const showLabel = typeof args[1] === 'string' && args[1].trim()
+        ? String(args[1]).slice(0, 120)
+        : plugin.name;
+      const { client: showClient } = useAuthStore.getState();
+      if (!showClient) throw new Error('search.showMessages: no active session');
+      await useEmailStore.getState().showMessages(showClient, ids as string[], showLabel);
+      return undefined;
+    }
     case 'tabs.set': {
       // validateTabsConfig (inside registerTabs) throws a developer-readable
       // error that surfaces as the api.tabs.set rejection in the sandbox.

--- a/lib/plugin-sandbox/protocol.ts
+++ b/lib/plugin-sandbox/protocol.ts
@@ -255,6 +255,8 @@ export const API_METHODS = [
   'email.setKeyword', 'email.removeKeyword',
   // Native tag definitions, discovery, and sidebar counts.
   'keywords.list', 'keywords.add', 'keywords.reorder', 'keywords.discover', 'keywords.getCounts', 'keywords.refreshCounts',
+  // Show a plugin's own result set in the message list.
+  'search.showMessages',
   // Message-list category tabs (Gmail-style inbox tabs).
   'tabs.set', 'tabs.clear', 'tabs.getState', 'tabs.categorize', 'tabs.refreshCounts',
   // Sieve integration for delivery-time classification plugins.

--- a/lib/plugin-sandbox/runtime.tsx
+++ b/lib/plugin-sandbox/runtime.tsx
@@ -370,6 +370,20 @@ function buildPluginApi(manifest: PluginManifest) {
     // ANDs the active tab's JMAP search filter (`query`) or keyword into the
     // mailbox Email/query - see MessageListTabsConfig in plugin-types. Tabs
     // are cleared automatically when the plugin unloads.
+    search: {
+      /**
+       * Show these message ids in the list, as a search result would appear.
+       *
+       * For plugins that do their own retrieval and want the answer in the list the user already
+       * knows rather than in a panel of their own. The host fetches with the user's own session,
+       * so this can only surface mail that user could already open.
+       *
+       * `label` appears in the search box; the existing Clear control is the way back, so no new
+       * affordance is introduced. Defaults to the plugin's name.
+       */
+      showMessages: (ids: string[], label?: string) =>
+        callApi('search.showMessages', [ids, label]) as Promise<void>,
+    },
     tabs: {
       /** Register (or replace) this plugin's tab set. */
       set: (config: unknown) => callApi('tabs.set', [config]) as Promise<void>,

--- a/lib/plugin-types.ts
+++ b/lib/plugin-types.ts
@@ -1044,6 +1044,7 @@ export const ALL_PERMISSIONS = [
   'ui:download-file',
   // Register native message-list category tabs (Gmail-style inbox tabs).
   'ui:message-list-tabs',
+  'ui:message-list',
   'ui:composer-toolbar', 'ui:composer-sidebar',
   'ui:sidebar-widget', 'ui:settings-section',
   'ui:context-menu', 'ui:navigation-rail', 'ui:keyboard',

--- a/stores/__tests__/email-store-show-messages.test.ts
+++ b/stores/__tests__/email-store-show-messages.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEmailStore } from '../email-store';
+import { useAuthStore } from '../auth-store';
+import { useSettingsStore } from '@/stores/settings-store';
+import { DEFAULT_SEARCH_FILTERS } from '@/lib/jmap/search-utils';
+import type { Email } from '@/lib/jmap/types';
+import type { IJMAPClient } from '@/lib/jmap/client-interface';
+
+// Coverage for `showMessages`, the store action behind `api.search.showMessages`.
+//
+// A plugin that does its own retrieval (semantic search, an external index, a memory system)
+// computes which messages are relevant and hands back ids. The host fetches them with the user's
+// own client, so a plugin can only surface mail that user could already open, and renders them in
+// the message list rather than in a panel of its own.
+//
+// The `label` lands in `searchQuery` deliberately: the existing Clear control is then the way back
+// to the folder listing, so no new affordance is introduced for the user to learn.
+
+function makeEmail(id: string): Email {
+  return {
+    id,
+    subject: `Subject ${id}`,
+    from: [{ email: 'sender@example.com' }],
+    to: [{ email: 'recipient@example.com' }],
+    receivedAt: '2026-01-01T00:00:00Z',
+    keywords: {},
+    hasAttachment: false,
+    preview: '',
+    size: 0,
+    mailboxIds: { inbox: true },
+    threadId: `thread-${id}`,
+  } as unknown as Email;
+}
+
+function makeClient(known: string[] = []) {
+  return {
+    // The real client returns only the ids the session can read; an id belonging to another
+    // account simply does not come back.
+    getSomeEmails: vi.fn(async (ids: string[]) => ids.filter(id => known.includes(id)).map(makeEmail)),
+  } as unknown as IJMAPClient;
+}
+
+describe('showMessages', () => {
+  let client: IJMAPClient;
+
+  beforeEach(() => {
+    client = makeClient(['m1', 'm2', 'm3']);
+
+    useAuthStore.setState({
+      activeAccountId: 'account-a',
+      getClientForAccount: (id: string) => (id === 'account-a' ? client : undefined) as never,
+    } as never);
+
+    useSettingsStore.setState({ emailsPerPage: 50 } as never);
+
+    useEmailStore.setState({
+      isUnifiedView: false,
+      unifiedRole: null,
+      crossView: null,
+      viewingAccountId: null,
+      selectedMailbox: 'inbox',
+      searchMailboxId: '',
+      searchQuery: '',
+      searchFilters: { ...DEFAULT_SEARCH_FILTERS },
+      searchAbortController: null,
+      emails: [],
+      mailboxes: [],
+      accountMailboxes: {},
+      scheduledSubmissionByEmailId: new Map(),
+      selectedEmail: null,
+    } as never);
+  });
+
+  it('shows exactly the requested messages', async () => {
+    await useEmailStore.getState().showMessages(client, ['m1', 'm3'], 'plugin: rate case');
+
+    const state = useEmailStore.getState();
+    expect(state.emails.map(e => e.id)).toEqual(['m1', 'm3']);
+    expect(state.totalEmails).toBe(2);
+    expect(state.isLoading).toBe(false);
+  });
+
+  it('puts the label in the search box, so Clear is the way back', async () => {
+    await useEmailStore.getState().showMessages(client, ['m1'], 'plugin: rate case');
+
+    expect(useEmailStore.getState().searchQuery).toBe('plugin: rate case');
+  });
+
+  it('is not folder-scoped: a plugin result set may span folders', async () => {
+    useEmailStore.setState({ selectedMailbox: 'sent' } as never);
+    await useEmailStore.getState().showMessages(client, ['m1', 'm2'], 'across folders');
+
+    // getSomeEmails is called with the ids alone -- no mailbox filter narrows them.
+    expect(client.getSomeEmails).toHaveBeenCalledWith(['m1', 'm2']);
+    expect(useEmailStore.getState().emails).toHaveLength(2);
+  });
+
+  it('cannot surface a message the session cannot read', async () => {
+    // The security property, and it is structural rather than enforced here: the fetch runs on the
+    // user's own client, so an id from another account returns nothing.
+    await useEmailStore.getState().showMessages(client, ['m1', 'not-mine'], 'mixed');
+
+    expect(useEmailStore.getState().emails.map(e => e.id)).toEqual(['m1']);
+  });
+
+  it('opens a single result, because there is no choice left to make', async () => {
+    await useEmailStore.getState().showMessages(client, ['m2'], 'one message');
+
+    expect(useEmailStore.getState().selectedEmail?.id).toBe('m2');
+  });
+
+  it('leaves several results closed, because choosing is the reader\'s job', async () => {
+    await useEmailStore.getState().showMessages(client, ['m1', 'm2'], 'two messages');
+
+    expect(useEmailStore.getState().selectedEmail).toBeNull();
+  });
+
+  it('ignores an empty id list rather than blanking the list', async () => {
+    useEmailStore.setState({ emails: [makeEmail('existing')] } as never);
+    await useEmailStore.getState().showMessages(client, [], 'nothing');
+
+    expect(useEmailStore.getState().emails.map(e => e.id)).toEqual(['existing']);
+    expect(client.getSomeEmails).not.toHaveBeenCalled();
+  });
+
+  it('reports a fetch failure instead of leaving a spinner', async () => {
+    const failing = {
+      getSomeEmails: vi.fn().mockRejectedValue(new Error('JMAP down')),
+    } as unknown as IJMAPClient;
+    useAuthStore.setState({
+      activeAccountId: 'account-a',
+      getClientForAccount: () => failing as never,
+    } as never);
+
+    await useEmailStore.getState().showMessages(failing, ['m1'], 'will fail');
+
+    const state = useEmailStore.getState();
+    expect(state.error).toBe('JMAP down');
+    expect(state.isLoading).toBe(false);
+    expect(state.emails).toEqual([]);
+  });
+
+  it('leaves the folder listing intact when the user clicks a mailbox instead of Clear', async () => {
+    // The label lives in `searchQuery` so the Clear control works. Selecting a folder is the
+    // other way out, and it used to leave the label set -- so the next load searched for the
+    // label text rather than listing the folder, and the mailbox came back empty.
+    await useEmailStore.getState().showMessages(client, ['m1', 'm2'], 'plugin: rate case');
+    expect(useEmailStore.getState().searchQuery).toBe('plugin: rate case');
+    expect(useEmailStore.getState().isPluginList).toBe(true);
+
+    useEmailStore.getState().selectMailbox('archive');
+
+    expect(useEmailStore.getState().searchQuery).toBe('');
+    expect(useEmailStore.getState().isPluginList).toBe(false);
+    expect(useEmailStore.getState().selectedMailbox).toBe('archive');
+  });
+
+  it("does not clear a user's own search when they change folder", async () => {
+    // Upstream keeps a search alive across folders on purpose; this patch must not change it.
+    useEmailStore.setState({ searchQuery: 'invoice', isPluginList: false } as never);
+
+    useEmailStore.getState().selectMailbox('archive');
+
+    expect(useEmailStore.getState().searchQuery).toBe('invoice');
+  });
+});

--- a/stores/email-store.ts
+++ b/stores/email-store.ts
@@ -65,6 +65,10 @@ interface EmailStore {
   isLoadingMore: boolean; // Track when loading more emails (pagination)
   error: string | null;
   searchQuery: string;
+  // True while the list holds a plugin's result set rather than a user's search.
+  // `searchQuery` carries the plugin's label so the existing Clear control works, but a
+  // label is not a search term: leaving it set makes the next folder load search for it.
+  isPluginList: boolean;
   quota: { used: number; total: number } | null;
   processingReadStatus: Set<string>; // Track emails being marked as read/unread
   selectedEmailIds: Set<string>; // Track selected emails for batch operations
@@ -232,6 +236,18 @@ interface EmailStore {
     sourceJmapAccountId?: string,
   ) => Promise<void>;
   searchEmails: (client: IJMAPClient, query: string) => Promise<void>;
+  /**
+   * Display an explicit set of message ids in the list, as a search result would be.
+   *
+   * For plugins that do their own retrieval -- semantic search, an external index, a memory
+   * system: the plugin decides which messages are relevant and hands back ids. The host fetches
+   * them with the user's own session, so a plugin can only surface mail that user could already
+   * open.
+   *
+   * `label` is shown in the search box, which is what gives the user a way out: the existing
+   * Clear control returns to the folder listing, so no new affordance is introduced.
+   */
+  showMessages: (client: IJMAPClient, ids: string[], label: string) => Promise<void>;
   advancedSearch: (client: IJMAPClient) => Promise<void>;
   setSearchFilters: (filters: Partial<SearchFilters>) => void;
   setSearchMailboxId: (mailboxId: string) => void;
@@ -1075,6 +1091,7 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
   isLoadingMore: false,
   error: null,
   searchQuery: "",
+  isPluginList: false,
   quota: null,
   processingReadStatus: new Set(),
   selectedEmailIds: new Set(),
@@ -1203,7 +1220,10 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
       console.error('Failed to fetch tag counts:', error);
     }
   }),
-  selectMailbox: (mailboxId) => set({
+  selectMailbox: (mailboxId) => set((state) => ({
+    // A plugin's label is cleared here; a user's search is not, because upstream keeps a
+    // search alive across folders on purpose and `searchMailboxId` pins its scope.
+    ...(state.isPluginList ? { searchQuery: "", isPluginList: false } : {}),
     selectedMailbox: mailboxId,
     selectedEmail: null,
     selectedEmailIds: new Set(),
@@ -1212,11 +1232,12 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
     threadEmailsCache: new Map(),
     threadEmailCounts: new Map(),
     isLoadingThread: null,
-  }),
+  })),
   setLoading: (loading) => set({ isLoading: loading }),
   setLoadingEmail: (loading) => set({ isLoadingEmail: loading }),
   setError: (error) => set({ error }),
-  setSearchQuery: (query) => set({ searchQuery: query }),
+  // Typing a search replaces a plugin's list, so the flag stops applying.
+  setSearchQuery: (query) => set({ searchQuery: query, isPluginList: false }),
   setQuota: (quota) => set({ quota }),
 
   toggleEmailSelection: (emailId) => {
@@ -2407,6 +2428,44 @@ export const useEmailStore = create<EmailStore>((set, get) => ({
     } catch (error) {
       set({
         error: error instanceof Error ? error.message : "Failed to search emails",
+        isLoading: false,
+        emails: [],
+        externalSearchResults: [],
+        hasMoreEmails: false,
+        totalEmails: 0
+      });
+    }
+  },
+
+  showMessages: async (client, ids, label) => {
+    if (!ids || ids.length === 0) {
+      return;
+    }
+    set({ isLoading: true, error: null, searchQuery: label, isPluginList: true, emails: [], hasMoreEmails: false, totalEmails: 0 });
+    try {
+      // Deliberately not folder-scoped: a plugin's result set may span folders, and the ids are
+      // already the answer, so there is nothing left to narrow.
+      const emails = await resolveActionClient(client).getSomeEmails(ids);
+      // The same transform the folder and search paths run, so plugins that decorate a list still
+      // see these messages.
+      const decorated = await emailHooks.onEmailsFetched.transform(emails);
+      set({
+        emails: annotateScheduledEmails(decorated, get().scheduledSubmissionByEmailId),
+        externalSearchResults: [],
+        hasMoreEmails: false,
+        totalEmails: decorated.length,
+        isLoading: false
+      });
+      // A single result is an unambiguous destination, so open it: asking for one message and then
+      // clicking the only row is a step with no decision in it. Several results stay closed,
+      // because choosing between them is the reader's job. Routed through selectEmail so
+      // onEmailOpen fires and plugins observing the open message behave normally.
+      if (decorated.length === 1) {
+        get().selectEmail(decorated[0]);
+      }
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : "Failed to show messages",
         isLoading: false,
         emails: [],
         externalSearchResults: [],


### PR DESCRIPTION
Implements `api.search.showMessages(ids, label)` as described in #954: a plugin that does its own
retrieval can hand the host a set of email ids and a label, and the host renders exactly those
messages in the message list.

### What it does

```ts
await api.search.showMessages(ids, "5 messages about the tariff decision");
```

The list shows those messages and the label appears where a search term normally would, so the
user can see why the list looks that way and clear it like any other search.

### Clearing rules

Both are covered by tests, and the second one is the non-obvious one:

- **Typing a search replaces a plugin's list.** A user's own search always wins.
- **Changing folder clears a plugin's list but NOT a user's search.** A search is deliberately kept
  across folders and scoped by `searchMailboxId`. A plugin-supplied set has no equivalent scope, so
  carrying it into another folder would silently reinterpret it — it is dropped instead.

### Scope and safety

- **`ui:message-list` permission**, declared alongside the existing capabilities.
- **Read-only and session-scoped.** The host fetches with the user's own JMAP client, so a plugin
  cannot surface a message the user could not already open. Strictly weaker than `tabs.categorize`,
  which writes keywords.
- **Capped at 200 ids** per call. A result set is a list a human reads, not a bulk export; the cap
  keeps one call from pulling a whole mailbox through `Email/get`.

### Tests

`stores/__tests__/email-store-show-messages.test.ts` — 10 tests covering the `isPluginList`
lifecycle and both clearing rules. Passing against this branch:

```
✓ stores/__tests__/email-store-show-messages.test.ts (10 tests) 7ms
  Test Files  1 passed (1)
       Tests  10 passed (10)
```

`eslint` reports no new problems; the warnings it emits on this tree are pre-existing.

### Notes

Based on `1.9.2`. Happy to change the name, the signature, or the clearing semantics — the shape
here is what fell out of using it rather than a strong opinion, and I'd rather match your
preference than land it as-is.
