### PR TITLE
fix(mail): unified mailbox missed accounts that had not connected yet

### DIFF
--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -29,6 +29,7 @@ import { ThreadGroup, Email, Mailbox, isUnifiedMailboxId, UNIFIED_ROLE_BY_ID, CR
 import { useAccountStore } from "@/stores/account-store";
 import { usePolicyStore } from "@/stores/policy-store";
 import type { UnifiedAccountClient } from "@/lib/unified-mailbox";
+import { connectedAccountsGrew } from "@/lib/unified-mailbox";
 import { KeyboardShortcutsModal } from "@/components/keyboard-shortcuts-modal";
 import { useEmailStore, buildUnifiedAccountClients } from "@/stores/email-store";
 import { toast } from "@/stores/toast-store";
@@ -1279,6 +1280,35 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
       refreshUnifiedCounts(built);
     });
   }, [enableUnifiedMailbox, includeGroupInUnified, unifiedCrossAccount, activeAccountId, isEmbedded, isAuthenticated, client, mailboxes, connectedAccountsSignature, buildPopulatedUnifiedAccounts, refreshUnifiedCounts, refreshCrossCounts, showCrossUnread, showCrossStarred, showCrossAll]);
+
+  // Refetch the open unified/cross list whenever an account joins the connected
+  // set. Only growth matters - a shrink (sign-out, disconnect) is already
+  // handled by the flows that cause it, and refetching there would fight them.
+  const previousConnectedAccountsRef = useRef<string | null>(null);
+  useEffect(() => {
+    const previous = previousConnectedAccountsRef.current;
+    previousConnectedAccountsRef.current = connectedAccountsSignature;
+    if (!connectedAccountsGrew(previous, connectedAccountsSignature)) return;
+    if (!isAuthenticated || !client) return;
+
+    // Read the view at fire time: this effect is keyed on the account set, not
+    // on the view, so the deps stay free of fast-changing state.
+    const state = useEmailStore.getState();
+    if (!state.isUnifiedView) return;
+    const { unifiedRole, crossView } = state;
+    if (!unifiedRole && !crossView) return;
+    // An active search owns the list; re-running a browse fetch under it would
+    // replace the user's results with the folder contents.
+    if (state.searchQuery || !isFilterEmpty(state.searchFilters)) return;
+
+    void buildPopulatedUnifiedAccounts()
+      .then((populated) => (
+        unifiedRole
+          ? fetchUnifiedEmailsAction(populated, unifiedRole)
+          : fetchCrossViewAction(populated, crossView!)
+      ))
+      .catch(() => { /* per-account failures surface through unifiedErrors */ });
+  }, [connectedAccountsSignature, isAuthenticated, client, buildPopulatedUnifiedAccounts, fetchUnifiedEmailsAction, fetchCrossViewAction]);
 
   // Deep links (#733). Applies `/mail/folder|message|thread/<id>` - and the
   // legacy `?email=<id>` the push service worker used to emit - once the JMAP

--- a/lib/__tests__/unified-accounts-grew.test.ts
+++ b/lib/__tests__/unified-accounts-grew.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { connectedAccountsGrew } from '../unified-mailbox';
+
+/**
+ * Guards the trigger for the unified list refetch (#950). The unified view can
+ * be fetched while background accounts are still connecting; when one lands we
+ * refetch, but only on growth - a shrink is already driven by the flow that
+ * caused it, and mount must not count or the initial fetch is duplicated.
+ */
+describe('connectedAccountsGrew (#950)', () => {
+  it('detects an account joining the set', () => {
+    expect(connectedAccountsGrew('alice', 'alice,bob')).toBe(true);
+  });
+
+  it('detects growth when several accounts land at once', () => {
+    expect(connectedAccountsGrew('alice', 'alice,bob,carol')).toBe(true);
+  });
+
+  it('treats the first render as no growth, so the initial fetch is not duplicated', () => {
+    expect(connectedAccountsGrew(null, 'alice,bob')).toBe(false);
+  });
+
+  it('ignores an unchanged set', () => {
+    expect(connectedAccountsGrew('alice,bob', 'alice,bob')).toBe(false);
+  });
+
+  it('ignores a shrink (sign-out / disconnect owns that flow)', () => {
+    expect(connectedAccountsGrew('alice,bob', 'alice')).toBe(false);
+  });
+
+  it('ignores everything disconnecting', () => {
+    expect(connectedAccountsGrew('alice,bob', '')).toBe(false);
+  });
+
+  // The realistic #950 sequence: reload starts with nothing connected (the
+  // rehydrate reset), the active account lands, then the background ones.
+  it('fires for the first account after an empty start', () => {
+    expect(connectedAccountsGrew('', 'alice')).toBe(true);
+  });
+
+  it('fires again as each background account lands', () => {
+    expect(connectedAccountsGrew('alice', 'alice,bob')).toBe(true);
+    expect(connectedAccountsGrew('alice,bob', 'alice,bob,carol')).toBe(true);
+  });
+
+  // A swap keeps the count identical, so a length comparison would miss it -
+  // the check must be membership-based.
+  it('detects a replacement even though the size is unchanged', () => {
+    expect(connectedAccountsGrew('alice,bob', 'alice,carol')).toBe(true);
+  });
+
+  it('does not treat the empty-string baseline as a member', () => {
+    // ''.split(',') === [''] - a naive Set would contain '' and mis-compare.
+    expect(connectedAccountsGrew('', '')).toBe(false);
+  });
+});

--- a/lib/unified-mailbox.ts
+++ b/lib/unified-mailbox.ts
@@ -511,3 +511,13 @@ export function getUnifiedRoles(
 
   return roles;
 }
+
+/**
+ * Only growth is interesting. A shrink (sign-out, disconnect) is already driven
+ * by the flow that caused it, so refetching there would race it. See #950.
+ */
+export function connectedAccountsGrew(previous: string | null, current: string): boolean {
+  if (previous === null || previous === current) return false;
+  const before = new Set(previous ? previous.split(',').filter(Boolean) : []);
+  return current.split(',').some((id) => id !== '' && !before.has(id));
+}

--- a/stores/__tests__/account-store-rehydrate.test.ts
+++ b/stores/__tests__/account-store-rehydrate.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useAccountStore } from '../account-store';
+
+/**
+ * `isConnected` / `hasError` describe a live JMAP client, which cannot survive a
+ * page load - but the whole account entry is persisted, so a fresh tab used to
+ * rehydrate them as still-connected. The unified mailbox filters on
+ * `isConnected` and silently drops accounts whose client is not in the map yet,
+ * and the effects keyed on the connected-accounts signature never re-fired
+ * because the signature already looked complete at mount. See #950.
+ */
+function seedStorage(accounts: Array<Record<string, unknown>>) {
+  localStorage.setItem(
+    'account-registry',
+    JSON.stringify({
+      state: { accounts, activeAccountId: accounts[0]?.id ?? null, defaultAccountId: null },
+      version: 0,
+    }),
+  );
+}
+
+function entry(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    cookieSlot: 0,
+    username: `${id}@example.org`,
+    serverUrl: 'https://mail.example.org',
+    displayName: id,
+    email: `${id}@example.org`,
+    avatarColor: '#123456',
+    lastLoginAt: 1_700_000_000_000,
+    isConnected: true,
+    hasError: false,
+    isDefault: false,
+    ...overrides,
+  };
+}
+
+describe('account-store rehydrate (#950)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('clears persisted isConnected so it reflects this session, not the last one', async () => {
+    seedStorage([entry('alice'), entry('bob')]);
+
+    await useAccountStore.persist.rehydrate();
+
+    const { accounts } = useAccountStore.getState();
+    expect(accounts).toHaveLength(2);
+    // Neither client has connected in this session yet.
+    expect(accounts.every((a) => a.isConnected === false)).toBe(true);
+  });
+
+  it('clears a persisted error state so a stale failure does not stick', async () => {
+    seedStorage([
+      entry('alice', { isConnected: false, hasError: true, errorMessage: 'Temporarily rate limited by server' }),
+    ]);
+
+    await useAccountStore.persist.rehydrate();
+
+    const alice = useAccountStore.getState().accounts[0];
+    expect(alice.hasError).toBe(false);
+    expect(alice.errorMessage).toBeUndefined();
+  });
+
+  it('preserves every other field of the entry', async () => {
+    seedStorage([entry('alice', { displayName: 'Alice A', cookieSlot: 3, isDefault: true })]);
+
+    await useAccountStore.persist.rehydrate();
+
+    const alice = useAccountStore.getState().accounts[0];
+    expect(alice.id).toBe('alice');
+    expect(alice.displayName).toBe('Alice A');
+    expect(alice.cookieSlot).toBe(3);
+    expect(alice.isDefault).toBe(true);
+    expect(alice.email).toBe('alice@example.org');
+    expect(alice.serverUrl).toBe('https://mail.example.org');
+    expect(alice.lastLoginAt).toBe(1_700_000_000_000);
+  });
+
+  it('leaves the active/default account selection alone', async () => {
+    seedStorage([entry('alice'), entry('bob')]);
+
+    await useAccountStore.persist.rehydrate();
+
+    expect(useAccountStore.getState().activeAccountId).toBe('alice');
+  });
+
+  it('is a no-op for an empty registry', async () => {
+    seedStorage([]);
+
+    await useAccountStore.persist.rehydrate();
+
+    expect(useAccountStore.getState().accounts).toEqual([]);
+  });
+});

--- a/stores/account-store.ts
+++ b/stores/account-store.ts
@@ -223,6 +223,24 @@ export const useAccountStore = create<AccountState>()(
         activeAccountId: state.activeAccountId,
         defaultAccountId: state.defaultAccountId,
       }),
+      // `isConnected` / `hasError` describe a *live* JMAP client, which never
+      // survives a reload - yet the whole entry is persisted, so a fresh tab
+      // rehydrated them as still-connected. Consumers then treated an account
+      // whose client had not been restored yet as ready: the unified mailbox
+      // filters on `isConnected` and silently dropped such accounts when their
+      // client was missing from the map, and the effects keyed on the
+      // "connected accounts" signature never re-fired because the signature was
+      // already complete at mount. Clearing them here makes both reflect this
+      // session, so the signature genuinely changes as each account connects
+      // (#950).
+      onRehydrateStorage: () => (state) => {
+        if (!state) return;
+        state.accounts = state.accounts.map((a) => (
+          a.isConnected || a.hasError
+            ? { ...a, isConnected: false, hasError: false, errorMessage: undefined }
+            : a
+        ));
+      },
     }
   )
 );


### PR DESCRIPTION
After a reload the unified mailbox showed messages only from the active
account; other accounts appeared only once the user had visited them. Reported
as intermittent — a tester saw it fail roughly 1 in 14 runs. There is no
timeout involved (nothing on the unified/mailbox path uses setTimeout,
AbortSignal or Promise.race); it is a race between the UI's first unified fetch
and the background restore of the secondary accounts, plus the absence of any
self-heal afterwards.

Full analysis in ANALYSIS-950-unified-mailbox-race.md (untracked).

## Root cause

Three things had to line up:

1. `checkAuth` (`stores/auth-store.ts:1814-1826`) awaits only the *active*
   account, kicks off `restoreRemaining()` for the rest as a fire-and-forget
   sequential loop, and immediately flips `isAuthenticated`. Inside
   `restoreAccount`, `clients.set(...)` happens only *after* `await
   client.connect()` — so there is a window where a secondary account has no
   client.
2. `buildUnifiedAccountClients` (`stores/email-store.ts:825`) does
   `if (!c) continue` — an account with no live client is silently dropped from
   the unified set. Not queued, not retried, not surfaced.
3. `isConnected` was **persisted** (`stores/account-store.ts`, `partialize`
   includes the whole `accounts` array) and rehydrated as still-true from the
   previous session. So the account passed the `isConnected` filter while
   failing the client lookup — landing exactly in (2). It also meant
   `connectedAccountsSignature` (`components/mail/mail-app.tsx:471-474`) was
   already "complete" at mount and never changed when a client actually
   arrived, so nothing re-fired. And the effects keyed on it only recompute
   *counts* — never the message list.

Result: whichever accounts had not connected by the time the unified view first
fetched were missing, and stayed missing until manual navigation. The UI
normally wins the race (it must do mailbox fetch + first mail page + effects
before the deep-link handler runs), which is why it usually works; it loses when
a secondary connect is slow or the active account's boot is cache-warm.

## Changes

- `stores/account-store.ts`: added `onRehydrateStorage` clearing `isConnected`,
  `hasError` and `errorMessage` on load. These describe a live JMAP client and
  cannot survive a reload. This is the key change: it makes both the
  `isConnected` filter and `connectedAccountsSignature` reflect *this* session,
  so the signature genuinely changes as each account connects.
  Verified this cannot prevent reconnection: `checkAuth` reads the full account
  list and never filters on `isConnected` (`auth-store.ts:1664`, `:1813`), and
  the orphan-cookie adoption path already adds accounts with
  `isConnected: false`, confirming "false until connected" is the intended
  semantic. Every other consumer is a reactive React read of the store, so they
  update as accounts connect.
- `components/mail/mail-app.tsx`: new effect that refetches the *open* unified
  or cross-view list when an account joins the connected set. Guards:
  only on growth (a shrink is already driven by the flow that caused it);
  skips the first render (the initial fetch is owned by the deep-link /
  mailbox-select path, so counting mount would double-fetch); skips when a
  search is active (a browse refetch would replace the user's results); reads
  the current view from the store at fire time so the deps stay off
  fast-changing state.
- `lib/unified-mailbox.ts`: extracted `connectedAccountsGrew(previous, current)`
  — the subtle part of the above (membership-based, not length-based, so a
  same-size swap still counts; empty-string baseline handled). Pulled out so it
  is unit-testable without rendering the 4300-line MailApp.
- `stores/__tests__/account-store-rehydrate.test.ts` (new, 5 tests): the flags
  are cleared, a stale error does not stick, every other field is preserved, the
  active/default selection is untouched, empty registry is a no-op. Verified the
  two behavioural tests fail without the fix.
- `lib/__tests__/unified-accounts-grew.test.ts` (new, 10 tests): growth, the
  multi-account-at-once case, first-render, unchanged, shrink, full disconnect,
  the realistic post-reload sequence, and the same-size swap.

## What this does and does not fix

Fixes the timing race (mode A) and makes the view self-heal if any account
connects late for any reason. It also incidentally clears a stale persisted
`hasError`, so an account left in an error state by the previous session gets a
fresh attempt.

Does **not** add a retry for an account whose restore fails *in this session*
(rate-limit / transient at `auth-store.ts:1777-1798` sets `isConnected: false`
and returns; `checkAuth` runs once per mount). That path still needs a manual
visit and is worth a follow-up — it is the other way to reach the same symptom.


## Related issues

Fixes #950

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [X] My code follows the project's code style and conventions
- [X] I have run `npm run typecheck && npm run lint` and there are no errors
- [X] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->
