### PR TITLE
fix: rsvp controls

### DIFF
--- a/components/calendar/event-detail-popover.tsx
+++ b/components/calendar/event-detail-popover.tsx
@@ -19,7 +19,7 @@ import {
   getUserStatus,
   getParticipantList,
 } from "@/lib/calendar-participants";
-import { getEventEditability } from "@/lib/calendar-editability";
+import { canUserRsvp, getEventEditability, type EditabilityContext } from "@/lib/calendar-editability";
 import { useFormatEventDate } from "@/hooks/use-format-event-date";
 
 interface EventDetailPopoverProps {
@@ -159,16 +159,27 @@ export function EventDetailPopover({
   const alertLabel = useMemo(() => getAlertLabel(event, t), [event, t]);
 
   // Gate affordances on calendar rights, not identity (see calendar-editability).
-  const editability = useMemo(() => {
+  const editabilityCtx = useMemo<EditabilityContext>(() => {
     const calendarsById = new Map(calendar ? [[calendar.id, calendar]] : []);
-    return getEventEditability(event, {
+    return {
       calendarsById,
       userCalendarAddresses: currentUserEmails,
       isSubscriptionCalendar: isSubscriptionCalendar ?? (() => false),
-    });
-  }, [event, calendar, currentUserEmails, isSubscriptionCalendar]);
+    };
+  }, [calendar, currentUserEmails, isSubscriptionCalendar]);
+
+  const editability = useMemo(
+    () => getEventEditability(event, editabilityCtx),
+    [event, editabilityCtx]
+  );
   const canEditBody = editability === "editable";
-  const rsvpMode = editability === "rsvp-only";
+
+  // Asked separately from editability: a received invite lands in the user's own
+  // calendar and resolves to 'editable', which renders no RSVP bar (#937).
+  const canRsvp = useMemo(
+    () => canUserRsvp(event, editabilityCtx),
+    [event, editabilityCtx]
+  );
 
   const userParticipantId = useMemo(
     () => getUserParticipantId(event, currentUserEmails),
@@ -537,7 +548,7 @@ export function EventDetailPopover({
       )}
 
       {/* RSVP Bar (for attendees) */}
-      {rsvpMode && onRsvp && userParticipantId && (
+      {canRsvp && onRsvp && userParticipantId && (
         <div className="px-4 py-3 border-t border-border">
           <p className="text-xs font-medium text-muted-foreground mb-2">
             {t("participants.rsvp_label")}

--- a/components/calendar/event-modal.tsx
+++ b/components/calendar/event-modal.tsx
@@ -22,7 +22,7 @@ import {
   getStatusCounts,
   buildParticipantMap,
 } from "@/lib/calendar-participants";
-import { getEventEditability, canCreateEventsIn } from "@/lib/calendar-editability";
+import { canUserRsvp, getEventEditability, canCreateEventsIn } from "@/lib/calendar-editability";
 import { PluginSlot } from "@/components/plugins/plugin-slot";
 import { useSettingsStore } from "@/stores/settings-store";
 import { generateUUID } from "@/lib/utils";
@@ -233,6 +233,17 @@ export function EventModal({
   }, [event, calendars, currentUserEmails, isSubscriptionCalendar]);
   const canEditBody = editability === "editable";
   const rsvpMode = editability === "rsvp-only";
+
+  // A received invite lands in the user's own calendar, resolves to 'editable',
+  // and so never reaches the rsvp-only view below.
+  const canRsvp = useMemo(() => {
+    if (!event) return false;
+    return canUserRsvp(event, {
+      calendarsById: new Map(calendars.map((c) => [c.id, c])),
+      userCalendarAddresses: currentUserEmails,
+      isSubscriptionCalendar: isSubscriptionCalendar ?? (() => false),
+    });
+  }, [event, calendars, currentUserEmails, isSubscriptionCalendar]);
 
   const userParticipantId = useMemo(() => {
     if (!event) return null;
@@ -786,44 +797,7 @@ export function EventModal({
         </div>
 
         <div className="px-6 py-4 border-t border-border flex-shrink-0">
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium">{t("participants.rsvp_label")}</span>
-            <div className="flex gap-2">
-              <Button
-                size="sm"
-                variant={userCurrentStatus === "accepted" ? "default" : "outline"}
-                onClick={() => handleRsvp("accepted")}
-                className={userCurrentStatus === "accepted"
-                  ? "bg-success hover:bg-success/80 text-success-foreground"
-                  : "text-success border-success/30 hover:bg-success/10"}
-              >
-                {userCurrentStatus === "accepted" && <Check className="w-4 h-4 me-1" />}
-                {t("participants.accepted")}
-              </Button>
-              <Button
-                size="sm"
-                variant={userCurrentStatus === "tentative" ? "default" : "outline"}
-                onClick={() => handleRsvp("tentative")}
-                className={userCurrentStatus === "tentative"
-                  ? "bg-warning hover:bg-warning/80 text-warning-foreground"
-                  : "border border-warning/30 text-warning hover:bg-warning/10"}
-              >
-                {userCurrentStatus === "tentative" && <Check className="w-4 h-4 me-1" />}
-                {t("participants.tentative")}
-              </Button>
-              <Button
-                size="sm"
-                variant={userCurrentStatus === "declined" ? "default" : "ghost"}
-                onClick={() => handleRsvp("declined")}
-                className={userCurrentStatus === "declined"
-                  ? "bg-destructive hover:bg-destructive/80 text-destructive-foreground"
-                  : "text-destructive hover:bg-destructive/10"}
-              >
-                {userCurrentStatus === "declined" && <Check className="w-4 h-4 me-1" />}
-                {t("participants.declined")}
-              </Button>
-            </div>
-          </div>
+          <RsvpBar status={userCurrentStatus} onRespond={handleRsvp} t={t} />
         </div>
       </div>
     );
@@ -996,6 +970,16 @@ export function EventModal({
             )}
           </div>
         </div>
+
+        {/* RSVP:
+          The viewer owes a reply but may also edit their own copy,
+          so the rsvp-only branch above does not apply to this event.
+        */}
+        {canRsvp && onRsvp && userParticipantId && (
+          <div className="px-6 py-3 border-t border-border flex-shrink-0">
+          <RsvpBar status={userCurrentStatus} onRespond={handleRsvp} t={t} />
+          </div>
+        )}
 
         {/* Action Bar */}
         <div className="px-6 py-3 border-t border-border flex-shrink-0 flex items-center justify-between">
@@ -1438,6 +1422,58 @@ export function EventModal({
           </Button>
         </div>
         )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The accept / tentative / decline row. Shared by the rsvp-only view and by the
+ * read-only view that an *editable* received invite lands in - the latter is the
+ * case that had no way to answer an invite at all (#937).
+ */
+function RsvpBar({ status, onRespond, t }: {
+  status: CalendarParticipant['participationStatus'] | null;
+  onRespond: (status: CalendarParticipant['participationStatus']) => void;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-sm font-medium">{t("participants.rsvp_label")}</span>
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          variant={status === "accepted" ? "default" : "outline"}
+          onClick={() => onRespond("accepted")}
+          className={status === "accepted"
+            ? "bg-success hover:bg-success/80 text-success-foreground"
+            : "text-success border-success/30 hover:bg-success/10"}
+        >
+          {status === "accepted" && <Check className="w-4 h-4 me-1" />}
+          {t("participants.accepted")}
+        </Button>
+        <Button
+          size="sm"
+          variant={status === "tentative" ? "default" : "outline"}
+          onClick={() => onRespond("tentative")}
+          className={status === "tentative"
+            ? "bg-warning hover:bg-warning/80 text-warning-foreground"
+            : "border border-warning/30 text-warning hover:bg-warning/10"}
+        >
+          {status === "tentative" && <Check className="w-4 h-4 me-1" />}
+          {t("participants.tentative")}
+        </Button>
+        <Button
+          size="sm"
+          variant={status === "declined" ? "default" : "ghost"}
+          onClick={() => onRespond("declined")}
+          className={status === "declined"
+            ? "bg-destructive hover:bg-destructive/80 text-destructive-foreground"
+            : "text-destructive hover:bg-destructive/10"}
+        >
+          {status === "declined" && <Check className="w-4 h-4 me-1" />}
+          {t("participants.declined")}
+        </Button>
       </div>
     </div>
   );

--- a/lib/__tests__/calendar-editability.test.ts
+++ b/lib/__tests__/calendar-editability.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type { CalendarEvent, CalendarParticipant, CalendarRights } from '@/lib/jmap/types';
 import {
   getEventEditability,
+  canUserRsvp,
   canCreateEventsIn,
   eventHasNoOwner,
   type EventEditability,
@@ -258,5 +259,89 @@ describe('getEventEditability - matrix sanity', () => {
       : makeEvent({ isOrigin: false, organizerCalendarAddress: `mailto:${OTHER}`,
           participants: { a: owner(OTHER), b: attendee(SELF) } as never });
     expect(getEventEditability(ev, ctx(rights))).toBe(expected);
+  });
+});
+
+/**
+ * Stalwart shape: participants carry only `calendarAddress` (no email/sendTo)
+ * and the organizer is additionally named by `organizerCalendarAddress`.
+ */
+function receivedInvite(attendeeAddress = SELF): CalendarEvent {
+  return makeEvent({
+    isOrigin: false,
+    organizerCalendarAddress: `mailto:${OTHER}`,
+    participants: {
+      att: {
+        '@type': 'Participant', calendarAddress: `mailto:${attendeeAddress}`,
+        participationStatus: 'needs-action', expectReply: true,
+        roles: { attendee: true, required: true },
+      },
+      org: {
+        '@type': 'Participant', calendarAddress: `mailto:${OTHER}`,
+        participationStatus: 'accepted',
+        roles: { owner: true, required: true },
+      },
+    } as never,
+  });
+}
+
+describe('canUserRsvp (issue #937)', () => {
+  it('is true for an externally organized invite in the user\'s own calendar', () => {
+    expect(canUserRsvp(receivedInvite(), ctx(ALL_RIGHTS))).toBe(true);
+  });
+
+  it('leaves the 1.9 rights-first editability of that invite untouched', () => {
+    // Must not regress 1.9 functionality
+    expect(getEventEditability(receivedInvite(), ctx(ALL_RIGHTS))).toBe('editable');
+  });
+
+  it('is true when the invited address is an account alias', () => {
+    expect(canUserRsvp(receivedInvite(ALIAS), ctx(ALL_RIGHTS, [SELF, ALIAS]))).toBe(true);
+  });
+
+  it('agrees with the rsvp-only editability state', () => {
+    const ev = receivedInvite();
+    expect(getEventEditability(ev, ctx(RSVP_ONLY))).toBe('rsvp-only');
+    expect(canUserRsvp(ev, ctx(RSVP_ONLY))).toBe(true);
+  });
+
+  it('is false for the organizer of their own event', () => {
+    const ev = makeEvent({ organizerCalendarAddress: `mailto:${SELF}`,
+      participants: { a: owner(SELF), b: attendee(OTHER) } as never });
+    expect(canUserRsvp(ev, ctx(ALL_RIGHTS))).toBe(false);
+  });
+
+  it('is false when the user is not a participant at all', () => {
+    expect(canUserRsvp(receivedInvite(OTHER), ctx(ALL_RIGHTS, ['dave@example.com']))).toBe(false);
+  });
+
+  it('is false for a plain event with no organizer or participants', () => {
+    expect(canUserRsvp(makeEvent(), ctx(ALL_RIGHTS))).toBe(false);
+  });
+
+  it('is false without mayRSVP on the calendar', () => {
+    expect(canUserRsvp(receivedInvite(), ctx(READ_ONLY))).toBe(false);
+  });
+
+  it('is false in an iCal subscription', () => {
+    expect(canUserRsvp(receivedInvite(), ctx(ALL_RIGHTS, [SELF], ['cal1']))).toBe(false);
+  });
+
+  it('is false while the calendar rights are still unloaded', () => {
+    expect(canUserRsvp(receivedInvite(), ctx(null))).toBe(false);
+  });
+
+  it('requires mayRSVP on every calendar the event belongs to', () => {
+    const ev = receivedInvite();
+    ev.calendarIds = { cal1: true, cal2: true };
+    const context: EditabilityContext = {
+      calendarsById: new Map([
+        ['cal1', { myRights: ALL_RIGHTS }],
+        ['cal2', { myRights: READ_ONLY }],
+      ]),
+      userCalendarAddresses: [SELF],
+      isSubscriptionCalendar: () => false,
+    };
+    expect(canUserRsvp(ev, context)).toBe(false);
   });
 });

--- a/lib/calendar-editability.ts
+++ b/lib/calendar-editability.ts
@@ -74,3 +74,33 @@ export function getEventEditability(
 
   return 'read-only';
 }
+
+/**
+ * Whether the viewer may RSVP to an event.
+ *
+ * Required because a received invite is delivered into the user's own calendar,
+ * which generally has mayWriteAll as `true` ([#937]).
+ */
+export function canUserRsvp(
+  event: CalendarEvent,
+  ctx: EditabilityContext,
+): boolean {
+  const calIds = Object.keys(event.calendarIds ?? {});
+
+  // Subscriptions are a one-way copy; there is no scheduling path to reply on.
+  if (calIds.some((id) => ctx.isSubscriptionCalendar(id))) return false;
+
+  const rights = calIds
+    .map((id) => ctx.calendarsById.get(id)?.myRights)
+    .filter((r): r is CalendarRights => Boolean(r));
+
+  // Rights not loaded: stay quiet rather than offer a reply that may be refused.
+  if (rights.length === 0) return false;
+  if (!rights.every((r) => r.mayRSVP)) return false;
+
+  // The organizer does not reply to their own invite, and an ownerless event carries no scheduling request at all.
+  if (isOrganizer(event, ctx.userCalendarAddresses)) return false;
+  if (eventHasNoOwner(event)) return false;
+
+  return getUserParticipantId(event, ctx.userCalendarAddresses) != null;
+}


### PR DESCRIPTION
## Summary

Introduces `canRSVP` as a concept independent of event/calendar edit-ability (since you can typically edit your own calendar). Updates existing calls to leverage `canRSVP` where appropriate while retaining existing functionality (which was a bit of a pain). Updates the rendering to leverage RSVP controls prior to edit-ability checks, and adds tests for this going forward.

## Changes

* Adds `canUserRSVP()` to `/lib/calendar-editability.ts` to determine if a user can RSVP
    * This is added separately as a received invite typically lands on a calendar where edits are permitted
* Moves RSVP controls rendering to leverage new data point
* Adds tests for RSVP controls to prevent this from happening again

## Related issues

Closes #937 


## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [x] I have added or updated documentation if needed
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [x] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

N/A

## Notes for reviewers

Existing integration tests in Docker do not check for this functionality (which is probably why it was able to happen). I did not add tests there.
