### PR TITLE
fix(calendar): linkify URLs in the event description

### DIFF
--- a/components/calendar/event-detail-popover.tsx
+++ b/components/calendar/event-detail-popover.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useMemo, useCallback, useLayoutEffect } fr
 import { useTranslations, useLocale } from "next-intl";
 import { createPortal } from "react-dom";
 import { Button } from "@/components/ui/button";
+import { LinkifiedText } from "@/components/ui/linkified-text";
 import {
   X, Clock, MapPin, Video, Users, Repeat, Bell, AlignLeft,
   Pencil, Trash2, Copy, Send, Check,
@@ -479,8 +480,8 @@ export function EventDetailPopover({
         {event.description && (
           <div className="flex items-start gap-2.5">
             <AlignLeft className="w-4 h-4 text-muted-foreground mt-0.5 flex-shrink-0" />
-            <p className="text-sm text-muted-foreground whitespace-pre-line line-clamp-3">
-              {event.description}
+            <p className="text-sm text-muted-foreground whitespace-pre-line line-clamp-3 break-words">
+              <LinkifiedText text={event.description} />
             </p>
           </div>
         )}

--- a/components/calendar/event-modal.tsx
+++ b/components/calendar/event-modal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { LinkifiedText } from "@/components/ui/linkified-text";
 import { X, Trash2, Check, Users, CalendarDays, Copy, Pencil, Clock, MapPin, Video, Repeat, Bell, AlignLeft, Plus } from "lucide-react";
 import { format, parseISO, addHours, addDays, isSameDay } from "date-fns";
 import type { CalendarEvent, Calendar, CalendarParticipant, CalendarEventAlert, CalendarRecurrenceRule } from "@/lib/jmap/types";
@@ -759,7 +760,9 @@ export function EventModal({
             })()}
 
             {event.description && (
-              <p className="text-sm text-muted-foreground">{event.description}</p>
+              <p className="text-sm text-muted-foreground whitespace-pre-line break-words">
+                <LinkifiedText text={event.description} />
+              </p>
             )}
 
             {locationName && (
@@ -991,7 +994,9 @@ export function EventModal({
             {event.description && (
               <div className="flex items-start gap-2.5">
                 <AlignLeft className="w-4 h-4 text-muted-foreground mt-0.5 flex-shrink-0" />
-                <p className="text-sm text-muted-foreground whitespace-pre-line">{event.description}</p>
+                <p className="text-sm text-muted-foreground whitespace-pre-line break-words">
+                  <LinkifiedText text={event.description} />
+                </p>
               </div>
             )}
           </div>

--- a/components/ui/__tests__/linkified-text.test.tsx
+++ b/components/ui/__tests__/linkified-text.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { LinkifiedText } from '../linkified-text';
+
+/**
+ * A meeting invitation puts the join URL in the event description, so that
+ * text has to render its http(s) URLs as real links - while staying plain
+ * text: the description is attacker-controlled (anyone can send an iTIP
+ * invitation), so no markup in it may ever reach the DOM.
+ */
+
+describe('LinkifiedText', () => {
+  afterEach(cleanup);
+
+  it('turns a URL in the text into a link that opens in a new tab', () => {
+    render(<LinkifiedText text="Join: https://teams.example.com/meet/319560?p=CTYa9 Meeting ID: 319 560" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://teams.example.com/meet/319560?p=CTYa9');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  it('stops the URL at the closing angle bracket of an <https://...> form', () => {
+    render(<LinkifiedText text="Need help? <https://aka.example/JoinMeeting?omkt=fr-FR> | System" />);
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://aka.example/JoinMeeting?omkt=fr-FR');
+  });
+
+  it('renders markup in the text as text, never as elements', () => {
+    const { container } = render(<LinkifiedText text={'<img src=x onerror=alert(1)> <b>bold</b>'} />);
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('b')).toBeNull();
+    expect(container.textContent).toBe('<img src=x onerror=alert(1)> <b>bold</b>');
+  });
+
+  it('does not linkify non-http schemes', () => {
+    const { container } = render(<LinkifiedText text="try javascript:alert(1) or file:///etc/passwd" />);
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  it('leaves text without a URL untouched', () => {
+    const { container } = render(<LinkifiedText text="no links here" />);
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.textContent).toBe('no links here');
+  });
+});

--- a/components/ui/linkified-text.tsx
+++ b/components/ui/linkified-text.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useMemo } from "react";
+import { plainTextToSafeHtml, sanitizePlainTextRenderedHtml } from "@/lib/email-sanitization";
+
+interface LinkifiedTextProps {
+  /** Plain text, as stored on the object (no markup is interpreted). */
+  text: string;
+  className?: string;
+}
+
+/**
+ * Plain text rendered with its http(s) URLs turned into real links.
+ *
+ * Meeting invitations carry the join URL in the event description (Teams,
+ * Meet, Zoom and the iTIP fallbacks all do), so a text-only render leaves the
+ * one actionable thing in the event un-clickable: the reader has to select the
+ * URL by hand, and it usually wraps across lines.
+ *
+ * Same pipeline as a plain-text mail body: `plainTextToSafeHtml` escapes the
+ * whole string and emits nothing but `<a href="http(s)://...">`, then
+ * `sanitizePlainTextRenderedHtml` re-checks the result. That second pass is
+ * defense in depth - unlike message bodies this renders into the main
+ * document, not the sandboxed iframe.
+ */
+export function LinkifiedText({ text, className }: LinkifiedTextProps) {
+  const html = useMemo(
+    () => sanitizePlainTextRenderedHtml(plainTextToSafeHtml(text, "text-primary hover:underline")),
+    [text],
+  );
+
+  return <span className={className} dangerouslySetInnerHTML={{ __html: html }} />;
+}


### PR DESCRIPTION
### The problem

A meeting invitation carries the join URL in the event description - Teams, Meet, Zoom and the plain iTIP fallbacks all do. The three read-only description renders (invitation RSVP view, event detail view, detail popover) print it as bare text, so the one actionable thing in the event is not clickable: you have to select the URL by hand, across the line wraps, and paste it into the address bar.

Reproduced on a real Teams invitation received over JMAP (Stalwart 0.16); the screenshots below use the dev mock server with the same shape of description.

| before | after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/lucletoffe/webmail/pr-assets/calendar-description-links/before.png" width="380"> | <img src="https://raw.githubusercontent.com/lucletoffe/webmail/pr-assets/calendar-description-links/after.png" width="380"> |

### The change

Render the description through the same pipeline the plain-text mail body already uses - `plainTextToSafeHtml` + `sanitizePlainTextRenderedHtml` - wrapped in a small `LinkifiedText` component (`components/ui/linkified-text.tsx`).

The text stays plain text. It is escaped, only `<a href="http(s)://...">` is emitted, and the result is sanitized a second time before it reaches the DOM. That second pass matters here: an event description is attacker-controlled (anyone can send an iTIP invitation) and, unlike a message body, this renders into the main document rather than the sandboxed iframe. `javascript:`/`file:` and any markup in the description stay inert text - covered by tests.

Two details along the way:
- `break-words` on the paragraphs, so a long join URL wraps instead of widening the panel;
- `whitespace-pre-line` on the invitation RSVP view, which was the only one of the three dropping the description's own line breaks (visible in the screenshots).

Left alone on purpose: the global-search preview, where the description is a preview line rather than something you act on, and the composer/editor fields.

### Checks

- `tsc --noEmit` clean, `eslint` clean on the touched files.
- `vitest run`: 3584 passed. The 4 failures on my machine (`translations.test.ts > zh-TW`, 3 in `auth-store-logout.test.ts`) also fail on an unmodified `main` checkout - unrelated to this change.
- New test file `components/ui/__tests__/linkified-text.test.tsx` (5 tests): link + `target`/`rel`, URL terminating at `>` in the `<https://...>` form, markup rendered as text, non-http schemes not linkified, plain text untouched.
