### PR TITLE
feat: api.ui.openDialog + plugin-dialog slot for large, clickable custom UI

### DIFF
--- a/components/email/__tests__/composer-plugin-attachment-source.test.tsx
+++ b/components/email/__tests__/composer-plugin-attachment-source.test.tsx
@@ -1,0 +1,255 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { EmailComposer } from '../email-composer';
+import { useAuthStore } from '@/stores/auth-store';
+
+// ─── Heavy component mocks (mirrors composer-draft-attachments.test.tsx) ─────
+
+vi.mock('@/components/email/rich-text-editor', () => ({
+  RichTextEditor: () => React.createElement('div', { 'data-testid': 'rich-text-editor' }),
+}));
+
+// A stand-in "cloud storage" plugin: renders a single button for the
+// composer-attachment-source slot which, on click, calls the `onAttach`
+// callback the host passed through extraProps - exactly what a real plugin
+// does after it has uploaded a picked file to JMAP itself (api.jmap.uploadBlob).
+// Every other slot renders nothing, matching the rest of the test suite.
+vi.mock('@/components/plugins/plugin-slot', () => ({
+  PluginSlot: ({ name, extraProps }: { name: string; extraProps?: Record<string, unknown> }) => {
+    if (name !== 'composer-attachment-source') return null;
+    const onAttach = extraProps?.onAttach as
+      | ((f: { blobId: string; name: string; type: string; size: number }) => void)
+      | undefined;
+    return React.createElement(
+      'button',
+      {
+        type: 'button',
+        'data-testid': 'fake-cloud-storage-plugin',
+        onClick: () =>
+          onAttach?.({ blobId: 'cloud-blob-1', name: 'vacation.jpg', type: 'image/jpeg', size: 42_000 }),
+      },
+      'Attach from cloud storage',
+    );
+  },
+}));
+
+vi.mock('@/components/identity/sub-address-helper', () => ({ SubAddressHelper: () => null }));
+vi.mock('@/components/templates/template-picker', () => ({ TemplatePicker: () => null }));
+vi.mock('@/components/templates/template-form', () => ({ TemplateForm: () => null }));
+vi.mock('@/components/files/file-preview-modal', () => ({ FilePreviewModal: () => null }));
+vi.mock('@/hooks/use-focus-trap', () => ({
+  useFocusTrap: () => ({ current: null }),
+}));
+vi.mock('@/hooks/use-pro-multi-account-identities', () => ({
+  useProMultiAccountIdentities: () => ({ enabled: false, groups: [], allIdentities: [] }),
+  stripCrossAccountIdentityPrefix: (id: string) => ({ localAccountId: null, rawId: id }),
+}));
+
+// ─── Store mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('@/stores/auth-store', () => {
+  const state = {
+    client: null,
+    identities: [],
+    primaryIdentity: null,
+    isAuthenticated: false,
+    isDemoMode: false,
+    activeAccountId: null,
+    connectionLost: false,
+    getClientForAccount: () => undefined,
+    getAllConnectedClients: () => new Map(),
+    syncIdentities: () => {},
+    refreshIdentities: async () => {},
+  };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  hook.setState = (p: Partial<typeof state>) => Object.assign(state, p);
+  return { useAuthStore: hook };
+});
+
+vi.mock('@/stores/identity-store', () => {
+  const state = {
+    identities: [{ id: 'id-me', email: 'me@example.com', name: 'Me' }],
+    defaultIdentityId: 'id-me',
+  };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  hook.setState = (p: Partial<typeof state>) => Object.assign(state, p);
+  return { useIdentityStore: hook };
+});
+
+vi.mock('@/stores/account-store', () => {
+  const state = { accounts: [], getAccountById: () => undefined };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  hook.setState = (p: Partial<typeof state>) => Object.assign(state, p);
+  return { useAccountStore: hook };
+});
+
+vi.mock('@/stores/email-store', () => {
+  const state = {
+    draftSaveEnabled: false,
+    sendRawEmail: async () => ({ sent: true }),
+  };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  hook.setState = (p: Partial<typeof state>) => Object.assign(state, p);
+  return { useEmailStore: hook };
+});
+
+vi.mock('@/stores/settings-store', () => {
+  const state = {
+    timeFormat: '24h',
+    plainTextMode: false,
+    subAddressDelimiter: '+',
+    autoSelectReplyIdentity: true,
+    attachmentReminderEnabled: false,
+    attachmentReminderKeywords: [],
+    emptySubjectWarningEnabled: true,
+    sendDelaySeconds: 0,
+    signaturePosition: 'above_quote',
+    signatureSeparatorEnabled: false,
+    requestReadReceiptDefault: false,
+    addTrustedSender: () => {},
+    trustedSendersAddressBook: null,
+    updateSetting: () => {},
+  };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  hook.setState = (p: Partial<typeof state>) => Object.assign(state, p);
+  return { useSettingsStore: hook };
+});
+
+vi.mock('@/stores/contact-store', () => {
+  const state = {
+    contacts: [],
+    getAutocomplete: async () => [],
+    addToTrustedSendersBook: async () => {},
+  };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  hook.setState = (p: Partial<typeof state>) => Object.assign(state, p);
+  return { useContactStore: hook };
+});
+
+vi.mock('@/stores/template-store', () => {
+  const state = { templates: [], addTemplate: async () => {} };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  hook.setState = (p: Partial<typeof state>) => Object.assign(state, p);
+  return { useTemplateStore: hook };
+});
+
+// ─── Misc dependency mocks ────────────────────────────────────────────────────
+
+vi.mock('@/stores/toast-store', () => ({
+  toast: { info: () => {}, error: () => {}, success: () => {} },
+}));
+
+vi.mock('@/lib/plugin-hooks', () => ({
+  emailHooks: {
+    onComposerOpen: { call: async () => [] },
+    onRecipientChange: { call: async () => [] },
+    getRecipientSuggestions: { call: async () => [] },
+    onRecipientChipsChange: { transform: async (chips: unknown) => chips },
+    onDraftChange: { emit: () => {} },
+    onBeforeDraftAutoSave: { transform: async (draft: unknown) => draft },
+    onBeforeEmailSend: { intercept: async () => true },
+    onComposeSend: { intercept: async () => true },
+    onTransformOutgoingEmail: { transform: async (email: unknown) => email },
+  },
+  contactHooks: {
+    search: { call: async () => [] },
+    onProvideRecipientSuggestions: { transform: async (initial: unknown) => initial },
+  },
+}));
+
+vi.mock('@/lib/email-sanitization', () => ({
+  sanitizeSignatureHtml: (v: string) => v,
+  sanitizeEmailHtml: (v: string) => v,
+  parseHtmlSafely: (html: string) => new DOMParser().parseFromString(html, 'text/html'),
+}));
+
+vi.mock('@/lib/email-threading', () => ({
+  computeReplyThreadingHeaders: () => ({ inReplyTo: [], references: [] }),
+}));
+vi.mock('@/lib/signature-utils', () => ({
+  appendPlainTextSignature: (body: string) => body,
+  getPlainTextSignature: () => '',
+  plainTextBodyHasSignature: () => false,
+  plainTextBodyWithoutSignature: (body: string) => body,
+}));
+vi.mock('@/lib/sub-addressing', () => ({ generateSubAddress: () => '' }));
+vi.mock('@/lib/debug', () => ({ debug: { log: () => {}, warn: () => {}, error: () => {} } }));
+vi.mock('@/components/email/quoted-html', () => ({
+  buildQuotedHtmlBlock: () => '',
+  serializeEditorContent: () => '',
+}));
+vi.mock('@/lib/template-utils', () => ({ substitutePlaceholders: (s: string) => s }));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+/**
+ * A plugin rendered into the composer-attachment-source slot (e.g. a WebDAV /
+ * cloud-storage file browser) uploads the file it picked to JMAP itself, then
+ * calls the `onAttach` callback the host handed it via extraProps to have the
+ * result added to the draft - without ever touching the local file picker or
+ * drag-drop path.
+ */
+describe('composer-attachment-source plugin slot', () => {
+  afterEach(() => {
+    useAuthStore.setState({ client: null });
+    vi.clearAllMocks();
+  });
+
+  it('adds a plugin-supplied blob as an attachment chip when onAttach is called', async () => {
+    render(<EmailComposer onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId('fake-cloud-storage-plugin'));
+
+    expect(await screen.findByText('vacation.jpg')).toBeInTheDocument();
+  });
+
+  it('includes the plugin-supplied attachment (by blobId, no local File) in the next save', async () => {
+    const createDraft = vi.fn().mockResolvedValueOnce('draft-1');
+    useAuthStore.setState({
+      client: {
+        createDraft,
+        getEmail: vi.fn(),
+        hasDelayedSend: () => false,
+        getMaxDelayedSend: () => 0,
+      } as never,
+    });
+
+    render(<EmailComposer onClose={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('fake-cloud-storage-plugin'));
+    expect(screen.getByText('vacation.jpg')).toBeInTheDocument();
+
+    // Fake timers only from here on - the autosave debounce below needs
+    // vi.advanceTimersByTimeAsync, but findBy*'s own internal polling (not
+    // used above, kept in mind for future edits to this test) would hang
+    // forever under fake time with nothing driving it forward.
+    vi.useFakeTimers();
+
+    // Any edit marks the draft dirty and arms the autosave debounce.
+    fireEvent.change(screen.getByPlaceholderText(/subject/i), {
+      target: { value: 'Photos from the trip' },
+    });
+    await act(async () => { await vi.advanceTimersByTimeAsync(2500); });
+
+    expect(createDraft).toHaveBeenCalledTimes(1);
+    expect(createDraft.mock.calls[0][8]).toEqual([
+      expect.objectContaining({ blobId: 'cloud-blob-1', name: 'vacation.jpg', size: 42_000 }),
+    ]);
+
+    vi.useRealTimers();
+  });
+});

--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -19,7 +19,7 @@ import { buildQuotedHtmlBlock, serializeEditorContent } from "@/components/email
 import { buildSignatureBlock, containsEmbeddedSignature, SIGNATURE_RANGE_MARKER } from "@/components/email/signature-block";
 import { emailHooks, contactHooks, isExternalAttachmentResult } from "@/lib/plugin-hooks";
 import { onUploadProgress } from "@/lib/upload-progress";
-import type { AlmostSavedDraft, OutgoingEmail, RecipientSuggestion } from "@/lib/plugin-types";
+import type { AlmostSavedDraft, OutgoingEmail, PluginAttachmentUpload, RecipientSuggestion } from "@/lib/plugin-types";
 import { useAuthStore } from "@/stores/auth-store";
 import { useIdentityStore } from "@/stores/identity-store";
 import { useProMultiAccountIdentities, stripCrossAccountIdentityPrefix } from "@/hooks/use-pro-multi-account-identities";
@@ -1616,6 +1616,24 @@ export function EmailComposer({
     setAttachments(prev => prev.filter((_, i) => i !== index));
   };
 
+  // Lets a plugin attach a file it has already uploaded to the JMAP server
+  // (via api.jmap.uploadBlob) without going through the local file-picker /
+  // drag-drop path - e.g. a plugin that browses an external WebDAV store and
+  // offers "attach from there". No `file` is set, matching the existing
+  // draft-part hydration path above (a blobId-only attachment is already a
+  // supported shape, just never previously reachable from a plugin).
+  const handlePluginAttachmentAdd = useCallback((upload: PluginAttachmentUpload) => {
+    setAttachments(prev => [
+      ...prev,
+      {
+        name: upload.name,
+        type: upload.type,
+        size: upload.size,
+        blobId: upload.blobId,
+      },
+    ]);
+  }, []);
+
   // Inline preview for composer attachments, reusing the message viewer's
   // FilePreviewModal (so previewability and the open-in-new-tab safety gate are
   // handled there). Prefer the local File - no network - and fall back to the
@@ -3107,6 +3125,15 @@ export function EmailComposer({
               </Button>
             )}
             <PluginSlot name="composer-toolbar" />
+            {/* Lets a plugin offer an alternative attachment source (an
+                external file browser, cloud storage picker, etc). The plugin
+                calls `onAttach` once it has uploaded the chosen file to JMAP
+                itself (api.jmap.uploadBlob) and just wants it added to this
+                draft. */}
+            <PluginSlot
+              name="composer-attachment-source"
+              extraProps={{ onAttach: handlePluginAttachmentAdd }}
+            />
           </div>
 
           {/* Right side - Discard + Send (desktop) */}

--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -4030,6 +4030,19 @@ export function EmailViewer({
                               <Eye className="w-3.5 h-3.5 text-foreground" />
                             </button>
                           )}
+                          <PluginSlot
+                            name="attachment-actions"
+                            className="contents"
+                            extraProps={{
+                              attachment: {
+                                name: attachment.name || '',
+                                type: attachment.type,
+                                size: attachment.size,
+                                blobId: attachment.blobId,
+                                emailId: email?.id,
+                              } satisfies AttachmentInfo,
+                            }}
+                          />
                         </div>
                       </div>
                         )}
@@ -4090,6 +4103,19 @@ export function EmailViewer({
                                     <Eye className="w-3.5 h-3.5 text-foreground" />
                                   </button>
                                 )}
+                                <PluginSlot
+                                  name="attachment-actions"
+                                  className="contents"
+                                  extraProps={{
+                                    attachment: {
+                                      name: attachment.name || '',
+                                      type: attachment.type,
+                                      size: attachment.size,
+                                      blobId: attachment.blobId,
+                                      emailId: email?.id,
+                                    } satisfies AttachmentInfo,
+                                  }}
+                                />
                               </div>
                             </div>
                               )}
@@ -4821,6 +4847,19 @@ export function EmailViewer({
                         <Eye className="w-4 h-4 text-foreground" />
                       </button>
                     )}
+                    <PluginSlot
+                      name="attachment-actions"
+                      className="contents"
+                      extraProps={{
+                        attachment: {
+                          name: attachment.name || '',
+                          type: attachment.type,
+                          size: attachment.size,
+                          blobId: attachment.blobId,
+                          emailId: email?.id,
+                        } satisfies AttachmentInfo,
+                      }}
+                    />
                   </div>
                 </div>
                   )}
@@ -4881,6 +4920,19 @@ export function EmailViewer({
                               <Eye className="w-4 h-4 text-foreground" />
                             </button>
                           )}
+                          <PluginSlot
+                            name="attachment-actions"
+                            className="contents"
+                            extraProps={{
+                              attachment: {
+                                name: attachment.name || '',
+                                type: attachment.type,
+                                size: attachment.size,
+                                blobId: attachment.blobId,
+                                emailId: email?.id,
+                              } satisfies AttachmentInfo,
+                            }}
+                          />
                         </div>
                       </div>
                         )}
@@ -4962,6 +5014,19 @@ export function EmailViewer({
                           <Eye className="w-4 h-4 text-foreground" />
                         </button>
                       )}
+                      <PluginSlot
+                        name="attachment-actions"
+                        className="contents"
+                        extraProps={{
+                          attachment: {
+                            name: attachment.name || '',
+                            type: attachment.type,
+                            size: attachment.size,
+                            blobId: attachment.blobId,
+                            emailId: email?.id,
+                          } satisfies AttachmentInfo,
+                        }}
+                      />
                     </div>
                   </div>
                     )}
@@ -5021,6 +5086,19 @@ export function EmailViewer({
                                 <Eye className="w-3.5 h-3.5 text-foreground" />
                               </button>
                             )}
+                            <PluginSlot
+                              name="attachment-actions"
+                              className="contents"
+                              extraProps={{
+                                attachment: {
+                                  name: attachment.name || '',
+                                  type: attachment.type,
+                                  size: attachment.size,
+                                  blobId: attachment.blobId,
+                                  emailId: email?.id,
+                                } satisfies AttachmentInfo,
+                              }}
+                            />
                           </div>
                         </div>
                           )}

--- a/components/plugins/plugin-dialog-host.tsx
+++ b/components/plugins/plugin-dialog-host.tsx
@@ -8,6 +8,8 @@
 
 import React, { useEffect, useMemo, useState, useSyncExternalStore } from 'react';
 import { head, resolveHead, subscribe } from '@/lib/plugin-sandbox/host-dialog';
+import { PluginIframeSlot } from './plugin-iframe-slot';
+import type { SlotName } from '@/lib/plugin-types';
 
 // Lightweight **bold** support in plugin dialog messages. Everything else is
 // rendered literally (newlines come from the parent's white-space: pre-wrap).
@@ -39,7 +41,7 @@ export function PluginDialogHost(): React.JSX.Element | null {
 
   const canSubmit = fields.every((f) => !f.required || (values[f.name] ?? '').length > 0);
 
-  const cancel = () => resolveHead(current?.kind === 'prompt' ? null : false);
+  const cancel = () => resolveHead(current?.kind === 'prompt' || current?.kind === 'custom' ? null : false);
   const submitPrompt = () => { if (canSubmit) resolveHead(values); };
 
   useEffect(() => {
@@ -48,9 +50,11 @@ export function PluginDialogHost(): React.JSX.Element | null {
       if (e.key === 'Escape') {
         e.preventDefault();
         cancel();
-      } else if (e.key === 'Enter' && !isPrompt) {
+      } else if (e.key === 'Enter' && (current?.kind === 'confirm' || current?.kind === 'alert')) {
         // For prompts, Enter is handled by the form (so it respects required
-        // validation and works from within an input); non-prompt dialogs accept.
+        // validation and works from within an input); confirm/alert accept.
+        // Custom dialogs resolve only via their own onResult callback or the
+        // host's X/Escape - an Enter press has no defined meaning for them.
         e.preventDefault();
         resolveHead(true);
       }
@@ -58,7 +62,7 @@ export function PluginDialogHost(): React.JSX.Element | null {
     document.addEventListener('keydown', onKey, true);
     return () => document.removeEventListener('keydown', onKey, true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [current, isPrompt, canSubmit, values]);
+  }, [current, canSubmit, values]);
 
   if (!current) return null;
 
@@ -94,20 +98,40 @@ export function PluginDialogHost(): React.JSX.Element | null {
           border: '1px solid var(--color-border, #e2e8f0)',
           borderRadius: 12,
           padding: 20,
-          maxWidth: 480,
+          maxWidth: current.kind === 'custom' ? (current.width ?? 560) : 480,
+          maxHeight: current.kind === 'custom' ? '85vh' : undefined,
+          overflowY: current.kind === 'custom' ? 'auto' : undefined,
           width: '92%',
           boxShadow: '0 16px 48px rgba(0,0,0,0.35)',
         }}
       >
-        <h2 id="plugin-dialog-title" style={{ fontSize: 16, fontWeight: 600, margin: '0 0 10px 0' }}>
-          {current.title}
-        </h2>
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+          <h2 id="plugin-dialog-title" style={{ fontSize: 16, fontWeight: 600, margin: '0 0 10px 0' }}>
+            {current.title}
+          </h2>
+          {current.kind === 'custom' && (
+            <button
+              type="button"
+              onClick={cancel}
+              aria-label="Close"
+              style={{ border: 'none', background: 'transparent', cursor: 'pointer', fontSize: 18, lineHeight: 1, padding: 0, color: 'inherit' }}
+            >
+              ✕
+            </button>
+          )}
+        </div>
         {current.message && (
           <p style={{ fontSize: 13, lineHeight: 1.5, margin: '0 0 16px 0', color: 'var(--color-muted-foreground, #64748b)', whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}>
             {renderMessage(current.message)}
           </p>
         )}
-        {isPrompt ? (
+        {current.kind === 'custom' ? (
+          <PluginIframeSlot
+            pluginId={current.pluginId}
+            slot={(current.slot ?? 'plugin-dialog') as SlotName}
+            extraProps={{ ...(current.extraProps ?? {}), onResult: (value: unknown) => resolveHead(value) }}
+          />
+        ) : isPrompt ? (
           <form onSubmit={(e) => { e.preventDefault(); submitPrompt(); }}>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginBottom: 16 }}>
               {fields.map((f, i) => (

--- a/lib/plugin-sandbox/host-api.ts
+++ b/lib/plugin-sandbox/host-api.ts
@@ -24,7 +24,7 @@ import { DEFAULT_KEYWORD_SCAN_LIMIT } from '../jmap/client';
 import { suggestKeywordColor } from '../keyword-discovery';
 import { MAX_KEYWORD_LENGTH } from '../keyword-nesting';
 import { KEYWORD_PREFIX } from '../thread-utils';
-import { awaitDialog, awaitPrompt, type PromptField } from './host-dialog';
+import { awaitDialog, awaitPrompt, awaitCustomDialog, type PromptField } from './host-dialog';
 import { fileStorage } from '../plugin-storage';
 import { generateUUID } from '../utils';
 import { AddressBook, ContactCard, Identity } from '../jmap/types';
@@ -131,6 +131,7 @@ const PERM_PER_METHOD: Record<string, Permission | null> = {
   'ui.confirm': null,
   'ui.alert': null,
   'ui.prompt': null,
+  'ui.openDialog': null,
   'ui.rerenderEmail': null,
   'ui.rerenderFetchedEmails': null,
   'ui.openExternalUrl': null,
@@ -1504,6 +1505,24 @@ export async function dispatchApiCall(
         confirmLabel: typeof opts.confirmLabel === 'string' ? opts.confirmLabel : undefined,
         cancelLabel: typeof opts.cancelLabel === 'string' ? opts.cancelLabel : undefined,
         fields,
+      });
+    }
+    case 'ui.openDialog': {
+      // Renders one of THIS plugin's own slots inside PluginDialogHost's
+      // real app-root overlay, instead of a fixed confirm/prompt form - see
+      // the 'plugin-dialog' SlotName / host-dialog.ts comments for why this
+      // exists (a small toolbar/row slot can't show a large custom UI).
+      const opts = (args[0] ?? {}) as { title?: string; slot?: string; extraProps?: Record<string, unknown>; width?: number };
+      if (!opts.slot || typeof opts.slot !== 'string') {
+        throw new Error('ui.openDialog requires a "slot" name');
+      }
+      return awaitCustomDialog({
+        pluginId: plugin.id,
+        title: String(opts.title ?? plugin.name ?? ''),
+        message: '',
+        slot: opts.slot,
+        extraProps: (opts.extraProps && typeof opts.extraProps === 'object') ? opts.extraProps : {},
+        width: typeof opts.width === 'number' ? opts.width : undefined,
       });
     }
     case 'ui.rerenderEmail': {

--- a/lib/plugin-sandbox/host-dialog.ts
+++ b/lib/plugin-sandbox/host-dialog.ts
@@ -5,7 +5,7 @@
 // at a time. Prompts collect one or more (optionally masked) text fields so a
 // plugin never has to fall back to the sandbox-blocked `window.prompt`.
 
-export type DialogKind = 'confirm' | 'alert' | 'prompt';
+export type DialogKind = 'confirm' | 'alert' | 'prompt' | 'custom';
 
 export interface PromptField {
   /** Key the field's value is returned under. */
@@ -36,8 +36,22 @@ export interface DialogRequest {
   danger?: boolean;
   /** Fields to collect, for `kind === 'prompt'`. */
   fields?: PromptField[];
+  /**
+   * For `kind === 'custom'`: the plugin's own slot name to render in place of
+   * the confirm/prompt body, and the props to pass it. Unlike every other
+   * slot mount, this one renders inside `PluginDialogHost`'s real
+   * `position: fixed; inset: 0` container at the app root - not a small,
+   * CSS-constrained row - so it's the only way a plugin can show a large,
+   * fully custom, genuinely clickable UI (see PR discussion / the
+   * webdav-storage plugin's folder browser for why this exists at all: a
+   * prompt-loop UI works but nobody wants to type folder numbers).
+   */
+  slot?: string;
+  extraProps?: Record<string, unknown>;
+  /** Optional width override in px for the dialog box (custom kind only). */
+  width?: number;
   /** Called when the dialog closes with its typed result (see DialogResult). */
-  resolve: (result: DialogResult) => void;
+  resolve: (result: unknown) => void;
 }
 
 const queue: DialogRequest[] = [];
@@ -64,16 +78,16 @@ export function head(): DialogRequest | null {
   return queue[0] ?? null;
 }
 
-export function resolveHead(result: DialogResult): void {
+export function resolveHead(result: unknown): void {
   const entry = queue.shift();
   if (!entry) return;
   try { entry.resolve(result); } catch { /* ignore */ }
   notify();
 }
 
-/** The "cancelled" result for a given dialog kind (null for prompt, else false). */
-function cancelledResult(kind: DialogKind): DialogResult {
-  return kind === 'prompt' ? null : false;
+/** The "cancelled" result for a given dialog kind (null for prompt/custom, else false). */
+function cancelledResult(kind: DialogKind): unknown {
+  return kind === 'prompt' || kind === 'custom' ? null : false;
 }
 
 /** Cancel every pending dialog for a plugin (called on unload). */
@@ -111,6 +125,20 @@ export function awaitDialog(req: Omit<DialogRequest, 'id' | 'resolve'>): Promise
  */
 export function awaitPrompt(req: Omit<DialogRequest, 'id' | 'resolve'>): Promise<Record<string, string> | null> {
   return new Promise((resolve) => {
-    enqueueDialog({ ...req, resolve: (r) => resolve(r && typeof r === 'object' ? r : null) });
+    enqueueDialog({ ...req, resolve: (r) => resolve(r && typeof r === 'object' ? (r as Record<string, string>) : null) });
+  });
+}
+
+/**
+ * Custom variant: renders the given plugin slot inside PluginDialogHost's
+ * real full-screen container instead of a confirm/prompt form. Resolves to
+ * whatever value the slot component passes to its `onResult` prop (an
+ * ordinary callback, marshalled across the iframe boundary the same way
+ * `composer-attachment-source`'s `onAttach` is), or `null` if the user
+ * closes the dialog (X button / Escape) without calling it.
+ */
+export function awaitCustomDialog(req: Omit<DialogRequest, 'id' | 'resolve' | 'kind'>): Promise<unknown> {
+  return new Promise((resolve) => {
+    enqueueDialog({ ...req, kind: 'custom', resolve });
   });
 }

--- a/lib/plugin-sandbox/runtime.tsx
+++ b/lib/plugin-sandbox/runtime.tsx
@@ -327,6 +327,17 @@ function buildPluginApi(manifest: PluginManifest) {
         cancelLabel?: string;
         fields?: Array<{ name: string; label: string; type?: 'text' | 'password'; placeholder?: string; required?: boolean }>;
       }) => callApi('ui.prompt', [opts], 0) as Promise<Record<string, string> | null>,
+      /** Opens one of this plugin's OWN slots (see the 'plugin-dialog'
+       *  SlotName) inside a real, app-root, full-size dialog - unlike every
+       *  other slot, which renders wherever it's placed in the page and is
+       *  constrained by that spot's own layout. Use this for anything that
+       *  needs to be a large, genuinely clickable custom UI (a file browser,
+       *  a multi-step form, etc.) rather than a toolbar/row-sized control.
+       *  Resolves to whatever value the slot component passes to its
+       *  `onResult` prop, or null if the user closes the dialog without
+       *  calling it. No timeout - it waits for the user. */
+      openDialog: (opts: { title?: string; slot: string; extraProps?: Record<string, unknown>; width?: number }) =>
+        callApi('ui.openDialog', [opts], 0) as Promise<unknown>,
       /** Re-runs the onRenderEmailBody hook for the open message (e.g. after a
        *  crypto plugin unlocks a key) so its body re-renders without a reload. */
       rerenderEmail: () => callApi('ui.rerenderEmail', []) as Promise<void>,

--- a/lib/plugin-types.ts
+++ b/lib/plugin-types.ts
@@ -288,7 +288,9 @@ export type SlotName =
   | 'navigation-rail-bottom'
   | 'calendar-event-actions'
   | 'admin-plugin-page'
-  | 'contact-cryptokeys';
+  | 'contact-cryptokeys'
+  | 'attachment-actions'
+  | 'composer-attachment-source';
 
 export interface SlotRegistration {
   pluginId: string;
@@ -872,6 +874,20 @@ export interface AttachmentInfo {
   blobId?: string;
   /** The email this attachment belongs to (download / preview) */
   emailId?: string;
+}
+
+/**
+ * A file a plugin has already uploaded to the JMAP server (via
+ * `api.jmap.uploadBlob`) and wants attached to the email the user is
+ * currently composing. Passed to the `onAttach` callback a plugin receives
+ * through the `composer-attachment-source` slot's extraProps.
+ */
+export interface PluginAttachmentUpload {
+  /** JMAP blob id of the already-uploaded content. */
+  blobId: string;
+  name: string;
+  type: string;
+  size: number;
 }
 
 /**

--- a/lib/plugin-types.ts
+++ b/lib/plugin-types.ts
@@ -290,7 +290,13 @@ export type SlotName =
   | 'admin-plugin-page'
   | 'contact-cryptokeys'
   | 'attachment-actions'
-  | 'composer-attachment-source';
+  | 'composer-attachment-source'
+  // Rendered inside a plugin-requested host dialog (see `ui.openDialog` /
+  // PluginDialogHost), NOT in-page like every other slot above - this is
+  // the only slot that renders inside the app-root fixed overlay instead of
+  // wherever the slot is placed in the page, so it's the one to use for a
+  // large, genuinely clickable custom UI a small toolbar/row slot can't fit.
+  | 'plugin-dialog';
 
 export interface SlotRegistration {
   pluginId: string;


### PR DESCRIPTION
## What

A new `api.ui.openDialog({ title, slot, extraProps, width })` method plus a new `plugin-dialog` `SlotName`. A plugin calls it and awaits the returned `Promise<unknown>`, which resolves to whatever value the named slot's own component passes to its `onResult` prop, or `null` if the user closes the dialog (X button / Escape / backdrop click) without doing so.

Implementation reuses the existing confirm/alert/prompt dialog queue (`lib/plugin-sandbox/host-dialog.ts`) with a new `'custom'` `DialogKind`, and `PluginDialogHost` renders the requested slot via the existing `PluginIframeSlot` mechanism, but inside the dialog's real app-root `position: fixed; inset: 0` overlay instead of the confirm/prompt form.

## Why

Depends on #974 (builds on top of it - `plugin-types.ts`'s `SlotName` union already has the two slots from that PR).

Every existing plugin slot renders wherever it's placed in the page - a toolbar row, an attachment's hover-action bar, a settings page - and its iframe is auto-sized to fit whatever height the slot's own content occupies (see `runtime.tsx`'s `ResizeObserver` + `host-bridge.ts`'s `iframe.style.height`). That's fine for small controls, but there was no way for a plugin to show something *large* - a graphical file browser, a multi-step form - triggered from a small toolbar/row button. I ran into this concretely: a `position: fixed` overlay rendered from inside an `attachment-actions` slot is clipped to that row's own tiny, CSS-constrained layout (confirmed live - the "modal" rendered, just squeezed into an invisible sliver), and even a correctly-sized in-flow panel is *still* clipped by the surrounding row's own fixed height, which no plugin-side layout choice can escape.

`api.ui.confirm/alert/prompt` already solve this for simple text dialogs by rendering at the app root via `PluginDialogHost` - `ui.openDialog` generalizes that same mechanism to a plugin's own arbitrary custom UI instead of a fixed confirm/prompt form.

## How to test it yourself

Drop this in a `PLUGIN_DEV_DIR` folder (needs `manifest.json` from any working example plugin, entrypoint below):

```js
const { createElement: h } = require('react');
const api = require('@plugin-host');

function DialogContent({ onResult }) {
  return h('div', null,
    h('p', null, 'Pick one:'),
    ['Apple', 'Banana', 'Cherry'].map((f) =>
      h('button', { key: f, style: { display: 'block', margin: 4 }, onClick: () => onResult(f) }, f),
    ),
  );
}

function OpenButton() {
  const onClick = async () => {
    const picked = await api.ui.openDialog({ title: 'Pick a fruit', slot: 'plugin-dialog', width: 320 });
    api.toast.success(picked ? `You picked ${picked}` : 'Cancelled');
  };
  return h('button', { onClick }, 'Open big dialog');
}

exports.slots = {
  'toolbar-actions': { component: OpenButton, order: 999 },
  'plugin-dialog': { component: DialogContent, order: 1 },
};
```

1. Click the toolbar button - a real, full-size, click-to-pick dialog appears (rendered by `PluginDialogHost` at the app root), not squeezed into the toolbar's own row.
2. Click a fruit - the toast confirms the resolved value.
3. Open it again and press Escape, or click the backdrop - toast says "Cancelled".
4. Compare with `api.ui.prompt`, which only offers plain text fields - this is for anything that needs to be genuinely clickable/graphical.

I used this to build a WebDAV/Nextcloud storage plugin's folder browser (a real, multi-level, clickable file tree with a "new folder" action) - happy to share that code as a second real-world example if useful.

## Testing

- `npm run typecheck` / `npm run lint` (0 errors, same 9 pre-existing warnings as `main`) / `npx vitest run` (3581 passed, same 4 pre-existing failures as `main`, unrelated to this change - verified on a clean checkout).
- Manually verified end-to-end against a real deployment (not just `PLUGIN_DEV_DIR`): a plugin's `plugin-dialog` slot renders a multi-level clickable folder browser inside the dialog, resolves correctly on selection, and resolves to `null` on Escape/backdrop-click/the dialog's own close button.
