### PR TITLE
fix: plugin sandbox locale ignores 'Automatic' language resolution

### DIFF
--- a/stores/plugin-store.ts
+++ b/stores/plugin-store.ts
@@ -8,6 +8,7 @@ import { pluginStorage } from '@/lib/plugin-storage';
 import { extractPlugin } from '@/lib/plugin-validator';
 import { loadPlugin, deactivatePlugin, setPluginStoreAccessor, setupAutoDisable, setSandboxLocale } from '@/lib/plugin-loader';
 import { useLocaleStore } from '@/stores/locale-store';
+import { getEffectiveLocale } from '@/i18n/detect-locale';
 import { removeAllPluginHooks } from '@/lib/plugin-hooks';
 import { requestConsent } from '@/lib/plugin-sandbox/consent';
 import { sha256Hex } from '@/lib/plugin-sandbox/bundle-integrity';
@@ -268,10 +269,20 @@ export const usePluginStore = create<PluginStoreState>()(
           // in the dead activateAllPlugins() path, so the sandbox locale stayed
           // 'en' forever and plugin i18n never localized). Subscribe once for
           // later language switches; those affect plugins/slots loaded after.
-          setSandboxLocale(useLocaleStore.getState().locale);
+          //
+          // Use getEffectiveLocale(), NOT the raw store value: the stored
+          // choice is '' by default and stays '' under "Automatic" (see
+          // language-switcher.tsx / settings/language-settings.tsx) - the
+          // app's own UI resolves that via document.documentElement.lang /
+          // detectBrowserLocale (see i18n/detect-locale.ts), so a plugin
+          // reading the raw store value would see an empty string (falling
+          // back to English) even when the app itself is fully localized to
+          // the visitor's browser language. Found via a plugin dev report:
+          // native UI in Hungarian, plugin's own i18n stuck on English.
+          setSandboxLocale(getEffectiveLocale());
           if (!localeSubscribed) {
             localeSubscribed = true;
-            useLocaleStore.subscribe((s) => setSandboxLocale(s.locale));
+            useLocaleStore.subscribe(() => setSandboxLocale(getEffectiveLocale()));
           }
 
           // Sync server-managed plugins before loading


### PR DESCRIPTION
## What

`setSandboxLocale()` (which drives `api.i18n.locale` for every plugin) was being fed the raw `useLocaleStore` value directly. That store defaults to `''` and **stays `''` under "Automatic" language** (the default option in the language switcher - see `components/ui/language-switcher.tsx`, `components/settings/language-settings.tsx`) - it's only ever set to a real BCP-47 tag by an *explicit* pick. `setSandboxLocale()` itself no-ops on a falsy value, so every plugin's `api.i18n.locale` stayed stuck on the loader's hardcoded `'en'` default whenever a user was on "Automatic" - **even when the app's own native UI is fully localized** via browser-language auto-detection.

The app already has the correct resolution logic for exactly this case: `i18n/detect-locale.ts`'s `getEffectiveLocale()` - checks the stored explicit choice first, then falls back to `document.documentElement.lang`, then `detectBrowserLocale()`. This is the same function `IntlProvider` uses to decide what language to actually render the app in. `setSandboxLocale()`'s two call sites (`stores/plugin-store.ts`) now use it too, instead of reading the raw store value.

## How to reproduce (before this fix) / verify (after)

1. Settings > Language = "Automatic" (the default - most users never touch this).
2. Browser/OS language set to a locale this app ships translations for and that isn't English (e.g. `hu` - Bulwark's own UI will render in Hungarian, confirming detection is working).
3. Install any plugin that declares a `manifest.json` `locales` table with a `hu` entry, e.g.:
   ```json
   { "locales": { "en": { "greeting": "Hello" }, "hu": { "greeting": "Szia" } } }
   ```
   ```js
   const api = require('@plugin-host');
   api.toast.info(`locale=${api.i18n.locale} greeting=${api.i18n.t('greeting')}`);
   ```
4. **Before this fix**: toasts `locale=en greeting=Hello`, even though the surrounding app is fully Hungarian.
5. **After this fix**: toasts `locale=hu greeting=Szia`, matching the app's real, visible language.
6. Explicitly picking a language in the switcher is unaffected either way - this only changes the "Automatic"/unset case.

Found this while building a plugin's own localization: its native UI showed Hungarian, but `api.i18n.locale` reported `en` - confirmed via the plugin's own debug logging first, then traced to this root cause rather than guessed.

## Testing

- `npm run typecheck` / `npm run lint` (0 errors, same 9 pre-existing warnings as `main`) / `npx vitest run` (3581 passed, same 4 pre-existing failures as `main`, unrelated - verified on a clean checkout).
- Manually verified against a real deployment with a plugin's `locales` table: locale reported `en` before this change and the correct app language after, with "Automatic" selected in both cases.
