### PR TITLE
feat(compose): choosable font/size/colour, and a WYSIWYG editor surface

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -702,6 +702,55 @@ body {
   outline: none;
 }
 
+/* ── Email surface: render a message body WYSIWYG with the reading pane ───────
+   A message body is a light-background document — its inks target the
+   recipient's white background. The reading pane already renders it that way
+   (light in light mode; in dark mode a smart CSS-filter invert that keeps
+   images and colour backgrounds looking right — see email-viewer.tsx). But the
+   editable composer, the composer's signature preview and the identity
+   signature preview all painted the raw HTML on the app's DARK background, so
+   authored dark ink was dark-on-dark and unreadable, and none of them matched
+   the reader. `.email-surface` gives any of those the SAME light surface and the
+   SAME dark-mode invert, so composing/previewing looks exactly like reading
+   (and like the recipient's white view). Applied to `.tiptap` (composer) and
+   both signature previews. */
+.email-surface {
+  background-color: #ffffff;
+  color: #1b1b1f;
+  caret-color: #1b1b1f;
+  border-radius: 0.375rem;
+}
+.tiptap blockquote {
+  color: #5b5b63;
+}
+.tiptap p.is-editor-empty:first-child::before {
+  color: #9a9aa1;
+}
+
+/* Dark app mode: the reader's smart-invert, applied to the email surface.
+   invert(1) hue-rotate(180deg) turns the light document dark while keeping hues
+   approximately true; leaf media and colour/image containers are re-inverted so
+   photos, logos and coloured fills stay correct (mirrors email-viewer.tsx). */
+.dark .email-surface {
+  background-color: #ededed;
+  filter: invert(1) hue-rotate(180deg);
+}
+.dark .email-surface :where(img, video, svg, canvas, object, embed, input[type="image"]) {
+  filter: invert(1) hue-rotate(180deg);
+}
+.dark .email-surface :where([style*="background:"], [bgcolor]):not(:has(img, video, svg, canvas, object, embed)) {
+  filter: invert(1) hue-rotate(180deg);
+}
+.dark .email-surface :where([style*="background:"], [bgcolor]) :where([style*="background:"], [bgcolor]):not(:has(img, video, svg, canvas, object, embed)) {
+  filter: none !important;
+}
+.dark .email-surface :where([style*="background-image"], [background]) {
+  filter: invert(1) hue-rotate(180deg);
+}
+.dark .email-surface :where([style*="background-image"], [background]) :where(img, video, svg, canvas, object, embed, input[type="image"]) {
+  filter: none;
+}
+
 .tiptap p {
   margin: 0.25rem 0;
 }

--- a/components/email/__tests__/compose-typography.test.ts
+++ b/components/email/__tests__/compose-typography.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import Paragraph from '@tiptap/extension-paragraph';
+import { TextStyle } from '@tiptap/extension-text-style';
+import { FontFamily } from '@tiptap/extension-text-style/font-family';
+import { FontSize } from '@tiptap/extension-text-style/font-size';
+import Color from '@tiptap/extension-color';
+
+import { styledBlockAttributes } from '../styled-block-attributes';
+import { serializeEditorContent } from '../quoted-html';
+import {
+  ComposeTypography,
+  COMPOSE_FONT_FAMILY_CSS,
+  COMPOSE_FONT_SIZE_CSS,
+  resolveComposeDefaults,
+  sampleTypography,
+  type ComposeDefaults,
+} from '../compose-typography';
+
+// The exact paragraph the composer runs (rich-text-editor.tsx builds
+// StyledParagraph from the same styledBlockAttributes).
+const ComposerParagraph = Paragraph.extend({
+  addAttributes() {
+    return { ...this.parent?.(), ...styledBlockAttributes };
+  },
+});
+
+// The typography of the pipeline-built reply draft we must match invisibly:
+// Georgia 15px in a warm ink. This is the exact <span> our draft_writer emits.
+const DRAFT_FAMILY = "Georgia, 'Times New Roman', serif";
+const DRAFT_SIZE = '15px';
+const DRAFT_COLOR = '#34291f';
+const draftSpan = (text: string) =>
+  `<span style="font-family:${DRAFT_FAMILY};font-size:${DRAFT_SIZE};color:${DRAFT_COLOR}">${text}</span>`;
+
+function makeEditor(content: string) {
+  return new Editor({
+    element: document.createElement('div'),
+    extensions: [
+      StarterKit.configure({ paragraph: false }),
+      ComposerParagraph,
+      TextStyle,
+      FontFamily,
+      FontSize,
+      Color,
+      ComposeTypography,
+    ],
+    content,
+  });
+}
+
+// Push resolved compose defaults into the editor exactly as rich-text-editor.tsx
+// does on load: sample the drafted body, resolve against the user settings, set
+// the defaults, and bring the existing body up to them.
+function applyComposeTypography(
+  editor: Editor,
+  opts: { userFamily?: string | null; userSize?: string | null } = {}
+): ComposeDefaults {
+  const sample = sampleTypography(editor.state.doc);
+  const resolved = resolveComposeDefaults({
+    userFamily: opts.userFamily ?? null,
+    userSize: opts.userSize ?? null,
+    sample,
+  });
+  editor.commands.setComposeDefaults(resolved);
+  editor.commands.applyComposeDefaultsToBody();
+  return resolved;
+}
+
+// Faithful re-implementation of prosemirror-view's typed-input path: inserted
+// text takes state.storedMarks when set, otherwise the marks at the cursor. This
+// is precisely what pressing a key in the browser does, so asserting on its
+// output proves what actually gets typed — and, via serializeEditorContent, what
+// actually SENDS.
+function typeText(editor: Editor, text: string) {
+  const { state } = editor.view;
+  const marks = state.storedMarks || state.selection.$from.marks();
+  const node = state.schema.text(text, marks);
+  editor.view.dispatch(state.tr.replaceSelectionWith(node, false));
+}
+
+// The style of the first <span> inside the paragraph that contains `text`.
+function spanStyleOfParagraphWith(html: string, text: string): CSSStyleDeclaration {
+  const doc = new DOMParser().parseFromString(`<body>${html}</body>`, 'text/html');
+  const p = Array.from(doc.querySelectorAll('p')).find((el) => (el.textContent || '').includes(text));
+  if (!p) throw new Error(`no <p> containing "${text}" in: ${html}`);
+  const span = p.querySelector('span');
+  if (!span) throw new Error(`no <span> in paragraph "${text}" in: ${html}`);
+  const probe = doc.createElement('span');
+  probe.setAttribute('style', span.getAttribute('style') || '');
+  return probe.style;
+}
+
+function expectMatchesDraft(style: CSSStyleDeclaration) {
+  // Browsers normalise the serialised form (quotes, rgb()), so compare parsed
+  // CSS values rather than raw strings.
+  expect(style.getPropertyValue('font-family').replace(/"/g, "'")).toBe(DRAFT_FAMILY);
+  expect(style.getPropertyValue('font-size')).toBe(DRAFT_SIZE);
+  expect(style.getPropertyValue('color')).toBe('rgb(52, 41, 31)'); // #34291f
+}
+
+describe('compose-typography helpers', () => {
+  it('maps the setting enums to web-safe CSS (default = unset)', () => {
+    expect(COMPOSE_FONT_FAMILY_CSS.default).toBeNull();
+    expect(COMPOSE_FONT_FAMILY_CSS['serif-georgia']).toBe("Georgia, 'Times New Roman', serif");
+    expect(COMPOSE_FONT_SIZE_CSS.default).toBeNull();
+    expect(COMPOSE_FONT_SIZE_CSS.normal).toBe('14px');
+    // 15px tier exists so a reply theme (all of ours are 15px) can be the compose default.
+    expect(COMPOSE_FONT_SIZE_CSS.medium).toBe('15px');
+  });
+
+  it('samples the drafted body typography from the first styled run', () => {
+    const editor = makeEditor(`<p>${draftSpan('Warm ink reply')}</p>`);
+    const sample = sampleTypography(editor.state.doc);
+    expect(sample.fontFamily?.replace(/"/g, "'")).toBe(DRAFT_FAMILY);
+    expect(sample.fontSize).toBe(DRAFT_SIZE);
+    expect(sample.color).toBe(DRAFT_COLOR);
+    editor.destroy();
+  });
+
+  it('lets the drafted body win over the user settings (invisible edit)', () => {
+    const resolved = resolveComposeDefaults({
+      userFamily: 'Arial, Helvetica, sans-serif',
+      userSize: '18px',
+      sample: { fontFamily: DRAFT_FAMILY, fontSize: DRAFT_SIZE, color: DRAFT_COLOR },
+    });
+    expect(resolved).toEqual({ fontFamily: DRAFT_FAMILY, fontSize: DRAFT_SIZE, color: DRAFT_COLOR });
+  });
+
+  it('falls back to user settings when the draft carries no style (fresh mail)', () => {
+    const resolved = resolveComposeDefaults({
+      userFamily: 'Arial, Helvetica, sans-serif',
+      userSize: '18px',
+      sample: { fontFamily: null, fontSize: null, color: null },
+    });
+    expect(resolved).toEqual({ fontFamily: 'Arial, Helvetica, sans-serif', fontSize: '18px', color: null });
+  });
+
+  it('applies the user compose colour when the draft carries none (fresh mail)', () => {
+    const resolved = resolveComposeDefaults({
+      userFamily: null,
+      userSize: '15px',
+      userColor: '#34291f',
+      sample: { fontFamily: null, fontSize: null, color: null },
+    });
+    expect(resolved).toEqual({ fontFamily: null, fontSize: '15px', color: '#34291f' });
+  });
+
+  it('lets the drafted body colour win over the user compose colour (invisible edit)', () => {
+    const resolved = resolveComposeDefaults({
+      userFamily: null,
+      userSize: null,
+      userColor: '#1967d2',
+      sample: { fontFamily: DRAFT_FAMILY, fontSize: DRAFT_SIZE, color: DRAFT_COLOR },
+    });
+    expect(resolved.color).toBe(DRAFT_COLOR);
+  });
+});
+
+describe('compose-typography — the invisible-edit gate', () => {
+  it('a NEW paragraph typed after the draft carries the SAME family, size, and colour', () => {
+    const editor = makeEditor(`<p>${draftSpan('Drafted warm-ink line')}</p>`);
+    applyComposeTypography(editor);
+
+    // Enter at the end of the draft, then type — exactly the owner's edit.
+    editor.commands.focus('end');
+    editor.commands.splitBlock();
+    typeText(editor, 'Typed new paragraph');
+
+    const html = serializeEditorContent(editor);
+    expectMatchesDraft(spanStyleOfParagraphWith(html, 'Typed new paragraph'));
+
+    // And the drafted line is untouched (still identical) — a true invisible edit.
+    expectMatchesDraft(spanStyleOfParagraphWith(html, 'Drafted warm-ink line'));
+    editor.destroy();
+  });
+
+  it('an inline-reply line inserted BETWEEN two drafted lines matches them', () => {
+    const editor = makeEditor(
+      `<p>${draftSpan('First drafted line')}</p><p>${draftSpan('Second drafted line')}</p>`
+    );
+    applyComposeTypography(editor);
+
+    // Put the cursor at the end of the first line, split, and type between them.
+    let firstEnd = 0;
+    editor.state.doc.descendants((node, pos) => {
+      if (node.isText && (node.text || '').includes('First drafted line')) {
+        firstEnd = pos + node.nodeSize;
+        return false;
+      }
+      return true;
+    });
+    editor.commands.setTextSelection(firstEnd);
+    editor.commands.splitBlock();
+    typeText(editor, 'Inline reply line');
+
+    const html = serializeEditorContent(editor);
+    expectMatchesDraft(spanStyleOfParagraphWith(html, 'Inline reply line'));
+    editor.destroy();
+  });
+
+  it('populates stored marks in a truly empty paragraph with no neighbouring marks', () => {
+    // No styled draft to sample: the user's Compose-font / size settings apply,
+    // and the extension still fills the stored marks so the first typed run in a
+    // bare paragraph carries them (proves it does not merely rely on keepOnSplit).
+    const editor = makeEditor('<p></p>');
+    const userFamily = COMPOSE_FONT_FAMILY_CSS['serif-georgia'];
+    const userSize = COMPOSE_FONT_SIZE_CSS.large; // 16px
+    applyComposeTypography(editor, { userFamily, userSize });
+
+    editor.commands.focus('end');
+    // Nudge the selection so the plugin's appendTransaction runs for this cursor.
+    editor.commands.setTextSelection(editor.state.selection.from);
+
+    const stored = editor.view.state.storedMarks || editor.view.state.selection.$from.marks();
+    const ts = stored.find((m) => m.type.name === 'textStyle');
+    expect(ts?.attrs.fontFamily?.replace(/"/g, "'")).toBe("Georgia, 'Times New Roman', serif");
+    expect(ts?.attrs.fontSize).toBe('16px');
+
+    typeText(editor, 'Fresh message body');
+    const style = spanStyleOfParagraphWith(serializeEditorContent(editor), 'Fresh message body');
+    expect(style.getPropertyValue('font-family').replace(/"/g, "'")).toBe("Georgia, 'Times New Roman', serif");
+    expect(style.getPropertyValue('font-size')).toBe('16px');
+    editor.destroy();
+  });
+
+  it('does not override a colour the user picked by hand (fills only what is missing)', () => {
+    const editor = makeEditor(`<p>${draftSpan('Drafted line')}</p>`);
+    applyComposeTypography(editor);
+    editor.commands.focus('end');
+    editor.commands.splitBlock();
+
+    // User explicitly sets a different colour for the new run.
+    editor.commands.setColor('#1967d2');
+    typeText(editor, 'Hand-coloured run');
+
+    const style = spanStyleOfParagraphWith(serializeEditorContent(editor), 'Hand-coloured run');
+    expect(style.getPropertyValue('color')).toBe('rgb(25, 103, 210)'); // the user's colour wins
+    // …while family + size still come from the draft (invisible in every other way).
+    expect(style.getPropertyValue('font-family').replace(/"/g, "'")).toBe(DRAFT_FAMILY);
+    expect(style.getPropertyValue('font-size')).toBe(DRAFT_SIZE);
+    editor.destroy();
+  });
+});

--- a/components/email/compose-typography.ts
+++ b/components/email/compose-typography.ts
@@ -1,0 +1,252 @@
+"use client";
+
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Mark, type Node as ProseMirrorNode, type Schema } from "@tiptap/pm/model";
+import type { ComposeFontFamily, ComposeFontSize } from "@/stores/settings-store";
+
+/**
+ * Compose typography — make the composer's *default* text style (font family,
+ * font size, colour) match the reply it is editing, so a human edit is
+ * invisible.
+ *
+ * WHY: our pipeline drafts a reply as inline-styled HTML (e.g. Georgia 15px in a
+ * warm ink). TipTap, left to itself, gives every brand-new paragraph — the one
+ * created by Enter, or an inline-reply line typed between two quoted lines — the
+ * editor's bare default (sans, 16px, black). The result is a visibly mismatched
+ * edit sitting next to the drafted body.
+ *
+ * FIX: the three properties are all attributes of the single `textStyle` mark
+ * (font-family + font-size from @tiptap/extension-text-style submodules, colour
+ * from @tiptap/extension-color), which renders inline as
+ * `<span style="font-family:…;font-size:…;color:…">` and survives Bulwark's
+ * sanitize→editor→serialize send path (proven by scripts/bulwark/roundtrip.mjs).
+ * This extension keeps that mark in the editor's *stored marks* whenever the
+ * cursor sits at an empty position, so every newly typed run — including the
+ * first character of a fresh paragraph — carries the same family+size+colour and
+ * therefore SENDS and MATCHES. It fills only the attributes that are missing, so
+ * a colour or font the user picked by hand always wins.
+ */
+
+/** Web-safe font stacks (no web-font loading). `null` = leave the family unset. */
+export const COMPOSE_FONT_FAMILY_CSS: Record<ComposeFontFamily, string | null> = {
+  default: null,
+  sans: "Arial, Helvetica, sans-serif",
+  "serif-georgia": "Georgia, 'Times New Roman', serif",
+  "serif-times": "'Times New Roman', Times, serif",
+  verdana: "Verdana, Geneva, sans-serif",
+  trebuchet: "'Trebuchet MS', Helvetica, sans-serif",
+  monospace: "'Courier New', Courier, monospace",
+};
+
+/** Compose text-size tiers mapped to px. `null` = leave the size unset. */
+export const COMPOSE_FONT_SIZE_CSS: Record<ComposeFontSize, string | null> = {
+  default: null,
+  small: "13px",
+  normal: "14px",
+  medium: "15px",
+  large: "16px",
+  "x-large": "18px",
+};
+
+/** The resolved default marks the composer should apply to typed text. */
+export interface ComposeDefaults {
+  fontFamily: string | null;
+  fontSize: string | null;
+  color: string | null;
+}
+
+const EMPTY_DEFAULTS: ComposeDefaults = { fontFamily: null, fontSize: null, color: null };
+
+function hasAnyDefault(d: ComposeDefaults): boolean {
+  return Boolean(d.fontFamily || d.fontSize || d.color);
+}
+
+/**
+ * The typography of the reply body currently in the editor: the attributes of
+ * the first `textStyle`-marked text run. Atom nodes (the quoted original, the
+ * signature block) hold their HTML as an attribute rather than as child text, so
+ * `descendants` never walks into them — the sample is always the reply body, not
+ * the quote below it. Returns all-null when the body carries no inline style.
+ */
+export function sampleTypography(doc: ProseMirrorNode): ComposeDefaults {
+  let found: ComposeDefaults | null = null;
+  doc.descendants((node) => {
+    if (found) return false;
+    if (!node.isText) return true;
+    const ts = node.marks.find((m) => m.type.name === "textStyle");
+    if (ts && (ts.attrs.fontFamily || ts.attrs.fontSize || ts.attrs.color)) {
+      found = {
+        fontFamily: ts.attrs.fontFamily ?? null,
+        fontSize: ts.attrs.fontSize ?? null,
+        color: ts.attrs.color ?? null,
+      };
+      return false;
+    }
+    return true;
+  });
+  return found ?? { ...EMPTY_DEFAULTS };
+}
+
+/**
+ * Resolve the effective compose defaults. The reply being edited (the `sample`)
+ * always wins so edits stay invisible; the user's Compose-font / Compose-size
+ * settings supply the family, size and colour only when there is no styled
+ * draft to match (a fresh message); the drafted reply always wins so edits stay
+ * invisible. `userColor` is optional — omit it and colour derives purely from
+ * the sample, defaulting to unset (the editor's own colour).
+ */
+export function resolveComposeDefaults(opts: {
+  userFamily: string | null;
+  userSize: string | null;
+  userColor?: string | null;
+  sample: ComposeDefaults;
+}): ComposeDefaults {
+  const { userFamily, userSize, userColor = null, sample } = opts;
+  return {
+    fontFamily: sample.fontFamily ?? userFamily ?? null,
+    fontSize: sample.fontSize ?? userSize ?? null,
+    color: sample.color ?? userColor ?? null,
+  };
+}
+
+/**
+ * A marks array with a `textStyle` mark that fills the compose defaults into any
+ * attribute the current marks leave unset. Existing values (a colour or font the
+ * user chose) are preserved; other marks (bold, link, …) pass through untouched.
+ */
+function withComposeDefaults(
+  marks: readonly Mark[],
+  schema: Schema,
+  defaults: ComposeDefaults
+): readonly Mark[] {
+  const textStyleType = schema.marks.textStyle;
+  if (!textStyleType) return marks;
+  const existing = marks.find((m) => m.type === textStyleType);
+  const attrs: Record<string, unknown> = { ...(existing?.attrs ?? {}) };
+  if (defaults.fontFamily && !attrs.fontFamily) attrs.fontFamily = defaults.fontFamily;
+  if (defaults.fontSize && !attrs.fontSize) attrs.fontSize = defaults.fontSize;
+  if (defaults.color && !attrs.color) attrs.color = defaults.color;
+  const others = marks.filter((m) => m.type !== textStyleType);
+  return textStyleType.create(attrs).addToSet(others);
+}
+
+const composeTypographyKey = new PluginKey("composeTypography");
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    composeTypography: {
+      /** Set the resolved default family/size/colour for newly typed text. */
+      setComposeDefaults: (defaults: ComposeDefaults) => ReturnType;
+      /** Fill the missing default marks across the editable reply body (once, on load). */
+      applyComposeDefaultsToBody: () => ReturnType;
+    };
+  }
+}
+
+export interface ComposeTypographyStorage {
+  defaults: ComposeDefaults;
+}
+
+export type ComposeTypographyOptions = Record<string, never>;
+
+/** Read this extension's per-editor storage off an editor instance. */
+function readStorage(editor: { storage: unknown }): ComposeTypographyStorage {
+  return (editor.storage as Record<string, ComposeTypographyStorage>).composeTypography;
+}
+
+export const ComposeTypography = Extension.create<ComposeTypographyOptions, ComposeTypographyStorage>({
+  name: "composeTypography",
+
+  addStorage(): ComposeTypographyStorage {
+    return { defaults: { ...EMPTY_DEFAULTS } };
+  },
+
+  addCommands() {
+    return {
+      setComposeDefaults:
+        (defaults: ComposeDefaults) =>
+        ({ editor, state, tr, dispatch }) => {
+          readStorage(editor).defaults = defaults;
+          // Refresh the stored marks now so an already-placed cursor picks the
+          // new defaults up immediately (not only after the next keystroke).
+          if (dispatch && state.selection.empty && hasAnyDefault(defaults)) {
+            const current = state.storedMarks || state.selection.$from.marks();
+            const desired = withComposeDefaults(current, state.schema, defaults);
+            if (!Mark.sameSet(current, desired)) {
+              tr.setStoredMarks(desired as Mark[]);
+            }
+          }
+          return true;
+        },
+
+      applyComposeDefaultsToBody:
+        () =>
+        ({ editor, state, tr, dispatch }) => {
+          const defaults = readStorage(editor).defaults;
+          if (!hasAnyDefault(defaults)) return false;
+          const textStyleType = state.schema.marks.textStyle;
+          if (!textStyleType) return false;
+          let modified = false;
+          state.doc.descendants((node, pos) => {
+            // Never touch the verbatim atom nodes (quoted original, signature).
+            if (node.type.name === "quotedHtml" || node.type.name === "signatureBlock") {
+              return false;
+            }
+            if (!node.isText) return true;
+            const existing = node.marks.find((m) => m.type === textStyleType);
+            const attrs: Record<string, unknown> = { ...(existing?.attrs ?? {}) };
+            let changed = false;
+            if (defaults.fontFamily && !attrs.fontFamily) {
+              attrs.fontFamily = defaults.fontFamily;
+              changed = true;
+            }
+            if (defaults.fontSize && !attrs.fontSize) {
+              attrs.fontSize = defaults.fontSize;
+              changed = true;
+            }
+            if (defaults.color && !attrs.color) {
+              attrs.color = defaults.color;
+              changed = true;
+            }
+            if (changed) {
+              tr.addMark(pos, pos + node.nodeSize, textStyleType.create(attrs));
+              modified = true;
+            }
+            return true;
+          });
+          if (modified && dispatch) {
+            tr.setMeta("composeTypographyFill", true);
+            dispatch(tr);
+          }
+          return modified;
+        },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const { editor } = this;
+    return [
+      new Plugin({
+        key: composeTypographyKey,
+        // Keep the compose defaults in the stored marks whenever the cursor sits
+        // at an empty position, so the next typed run (a fresh paragraph, an
+        // inline-reply line) inherits family+size+colour and thus SENDS matching
+        // the drafted body. Fills only missing attributes, so a hand-picked
+        // colour/font is never overridden; terminates because a second pass sees
+        // the marks already present.
+        appendTransaction(transactions, _oldState, newState) {
+          const defaults = readStorage(editor).defaults;
+          if (!hasAnyDefault(defaults)) return null;
+          if (!transactions.some((t) => t.docChanged || t.selectionSet)) return null;
+          const sel = newState.selection;
+          if (!sel.empty) return null;
+          const current = newState.storedMarks || sel.$from.marks();
+          const desired = withComposeDefaults(current, newState.schema, defaults);
+          if (Mark.sameSet(current, desired)) return null;
+          return newState.tr.setStoredMarks(desired as Mark[]);
+        },
+      }),
+    ];
+  },
+});

--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -2926,7 +2926,7 @@ export function EmailComposer({
           ) : null
         ) : composerSignatureHtml ? (
           <div
-            className="px-4 pb-3 text-sm leading-6 text-foreground break-words [&_a]:text-primary [&_a]:underline-offset-2 [&_a:hover]:underline"
+            className="email-surface mx-4 mb-3 px-4 py-3 text-sm leading-6 break-words [&_a]:underline-offset-2 [&_a:hover]:underline"
             dangerouslySetInnerHTML={{ __html: `${signatureSeparatorEnabled ? '<div>-- </div>' : ''}${composerSignatureHtml}` }}
           />
         ) : null}

--- a/components/email/rich-text-editor.tsx
+++ b/components/email/rich-text-editor.tsx
@@ -10,7 +10,16 @@ import Link from "@tiptap/extension-link";
 import TextAlign from "@tiptap/extension-text-align";
 import { TextDirection } from "@/components/email/text-direction";
 import { TextStyle } from "@tiptap/extension-text-style";
+import { FontFamily } from "@tiptap/extension-text-style/font-family";
+import { FontSize } from "@tiptap/extension-text-style/font-size";
 import Color from "@tiptap/extension-color";
+import {
+  ComposeTypography,
+  COMPOSE_FONT_FAMILY_CSS,
+  COMPOSE_FONT_SIZE_CSS,
+  resolveComposeDefaults,
+  sampleTypography,
+} from "@/components/email/compose-typography";
 import { ResizableImage } from "@/components/email/resizable-image";
 import Placeholder from "@tiptap/extension-placeholder";
 import { Table } from "@tiptap/extension-table";
@@ -21,7 +30,7 @@ import { QuotedHtml, serializeEditorContent } from "@/components/email/quoted-ht
 import { SignatureBlock } from "@/components/email/signature-block";
 import { styledBlockAttributes } from "@/components/email/styled-block-attributes";
 import { cn } from "@/lib/utils";
-import { useSettingsStore } from "@/stores/settings-store";
+import { useSettingsStore, normalizeComposeColor } from "@/stores/settings-store";
 import { useTranslations } from "next-intl";
 import {
   Bold,
@@ -172,6 +181,9 @@ export function RichTextEditor({
   onEditorReady,
 }: RichTextEditorProps) {
   const rtlEditingSupport = useSettingsStore((st) => st.rtlEditingSupport);
+  const composeFontFamily = useSettingsStore((st) => st.composeFontFamily);
+  const composeFontSize = useSettingsStore((st) => st.composeFontSize);
+  const composeTextColor = useSettingsStore((st) => st.composeTextColor);
   const tComposer = useTranslations("email_composer");
   const onImageUploadRef = React.useRef(onImageUpload);
   onImageUploadRef.current = onImageUpload;
@@ -197,7 +209,10 @@ export function RichTextEditor({
         types: ["heading", "paragraph"],
       }),
       TextStyle,
+      FontFamily,
+      FontSize,
       Color,
+      ComposeTypography,
       ResizableImage,
       Placeholder.configure({
         placeholder,
@@ -236,7 +251,7 @@ export function RichTextEditor({
     content,
     editorProps: {
       attributes: {
-        class: "tiptap min-h-[100px] px-4 py-3 text-sm text-foreground",
+        class: "tiptap email-surface min-h-[100px] px-4 py-3 text-sm",
       },
       handleDrop: (view, event) => {
         const upload = onImageUploadRef.current;
@@ -303,6 +318,25 @@ export function RichTextEditor({
   useEffect(() => {
     if (editor) onEditorReadyRef.current?.(editor);
   }, [editor]);
+
+  // Compose typography: resolve the default family/size/colour and hand them to
+  // the ComposeTypography extension so every newly typed run (fresh paragraphs,
+  // inline-reply lines) inherits them inline and thus SENDS matching the drafted
+  // body. Runs after the content-sync effect above, so the sample is taken from
+  // the freshly loaded draft; re-runs when the draft or the user settings change.
+  useEffect(() => {
+    if (!editor) return;
+    const userFamily = COMPOSE_FONT_FAMILY_CSS[composeFontFamily] ?? null;
+    const userSize = COMPOSE_FONT_SIZE_CSS[composeFontSize] ?? null;
+    const userColor = normalizeComposeColor(composeTextColor) || null;
+    const sample = sampleTypography(editor.state.doc);
+    const resolved = resolveComposeDefaults({ userFamily, userSize, userColor, sample });
+    editor.commands.setComposeDefaults(resolved);
+    // Bring any unstyled editable body text up to the same defaults on load, so
+    // pre-existing draft content matches too. No-op for an already-styled draft
+    // (nothing is missing) and for the verbatim quote/signature atom nodes.
+    editor.commands.applyComposeDefaultsToBody();
+  }, [editor, content, composeFontFamily, composeFontSize, composeTextColor]);
 
   const addLink = useCallback(() => {
     if (!editor) return;

--- a/components/identity/identity-form.tsx
+++ b/components/identity/identity-form.tsx
@@ -304,6 +304,7 @@ export function IdentityForm({ identity, onSave, onCancel }: IdentityFormProps) 
           <div className="mt-2 p-2 border rounded bg-muted">
             <div className="text-xs text-muted-foreground mb-1">{tDisplay('preview')}</div>
             <div
+              className="email-surface p-3"
               dangerouslySetInnerHTML={{
                 __html: sanitizeSignatureHtmlForDisplay(formData.htmlSignature)
               }}

--- a/components/settings/composing-settings.tsx
+++ b/components/settings/composing-settings.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSettingsStore } from '@/stores/settings-store';
-import type { SendDelaySeconds } from '@/stores/settings-store';
+import type { SendDelaySeconds, ComposeFontFamily, ComposeFontSize } from '@/stores/settings-store';
 import { useAuthStore } from '@/stores/auth-store';
 import { SettingsSection, SettingItem, Select, ToggleSwitch } from './settings-section';
 import { X } from 'lucide-react';
@@ -23,6 +23,9 @@ export function ComposingSettings() {
   const {
     autoSelectReplyIdentity,
     plainTextMode,
+    composeFontFamily,
+    composeFontSize,
+    composeTextColor,
     rtlEditingSupport,
     attachmentReminderEnabled,
     attachmentReminderKeywords,
@@ -52,6 +55,70 @@ export function ComposingSettings() {
           checked={plainTextMode}
           onChange={(checked) => updateSetting('plainTextMode', checked)}
         />
+      </SettingItem>
+
+      <SettingItem label={t('compose_font.label')} description={t('compose_font.description')}>
+        <Select
+          value={composeFontFamily}
+          onChange={(value) => updateSetting('composeFontFamily', value as ComposeFontFamily)}
+          options={[
+            { value: 'default', label: t('compose_font.default') },
+            { value: 'sans', label: t('compose_font.sans') },
+            { value: 'serif-georgia', label: t('compose_font.serif_georgia') },
+            { value: 'serif-times', label: t('compose_font.serif_times') },
+            { value: 'verdana', label: t('compose_font.verdana') },
+            { value: 'trebuchet', label: t('compose_font.trebuchet') },
+            { value: 'monospace', label: t('compose_font.monospace') },
+          ]}
+        />
+      </SettingItem>
+
+      <SettingItem label={t('compose_font_size.label')} description={t('compose_font_size.description')}>
+        <Select
+          value={composeFontSize}
+          onChange={(value) => updateSetting('composeFontSize', value as ComposeFontSize)}
+          options={[
+            { value: 'default', label: t('compose_font_size.default') },
+            { value: 'small', label: t('compose_font_size.small') },
+            { value: 'normal', label: t('compose_font_size.normal') },
+            { value: 'medium', label: t('compose_font_size.medium') },
+            { value: 'large', label: t('compose_font_size.large') },
+            { value: 'x-large', label: t('compose_font_size.x_large') },
+          ]}
+        />
+      </SettingItem>
+
+      <SettingItem label={t('compose_color.label')} description={t('compose_color.description')}>
+        <div className="flex items-center gap-2">
+          <input
+            type="color"
+            aria-label={t('compose_color.label')}
+            value={composeTextColor || '#000000'}
+            onChange={(e) => updateSetting('composeTextColor', e.target.value)}
+            className="h-8 w-10 shrink-0 cursor-pointer rounded border border-border bg-transparent p-0.5"
+          />
+          <input
+            type="text"
+            inputMode="text"
+            aria-label={t('compose_color.hex')}
+            value={composeTextColor}
+            placeholder={t('compose_color.placeholder')}
+            onChange={(e) => {
+              const v = e.target.value.trim();
+              if (v === '' || /^#[0-9a-fA-F]{0,6}$/.test(v)) updateSetting('composeTextColor', v);
+            }}
+            className="h-8 w-28 rounded border border-border bg-background px-2 text-sm"
+          />
+          {composeTextColor && (
+            <button
+              type="button"
+              onClick={() => updateSetting('composeTextColor', '')}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              {t('compose_color.reset')}
+            </button>
+          )}
+        </div>
       </SettingItem>
 
       <SettingItem label={t('rtl_editing.label')} description={t('rtl_editing.description')}>

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1326,6 +1326,34 @@
         "label": "Plain Text Only",
         "description": "Disable the rich text editor and send all emails as plain text only, including replies and forwards"
       },
+      "compose_font": {
+        "label": "Compose Font",
+        "description": "Default font for new messages. When you reply to a message that already has its own font, your edits match it automatically so they stay invisible.",
+        "default": "Default",
+        "sans": "Sans-serif (Arial)",
+        "serif_georgia": "Serif (Georgia)",
+        "serif_times": "Serif (Times New Roman)",
+        "verdana": "Verdana",
+        "trebuchet": "Trebuchet MS",
+        "monospace": "Monospace (Courier New)"
+      },
+      "compose_font_size": {
+        "label": "Compose Text Size",
+        "description": "Default text size for new messages. Replies match the size of the message you are editing.",
+        "default": "Default",
+        "small": "Small (13px)",
+        "normal": "Normal (14px)",
+        "medium": "Medium (15px)",
+        "large": "Large (16px)",
+        "x_large": "Extra large (18px)"
+      },
+      "compose_color": {
+        "label": "Compose Text Color",
+        "description": "Default text color for new messages, as a hex value. Replies match the color of the message you are editing, so your edits stay invisible. Leave blank to use the theme default.",
+        "hex": "Hex color value",
+        "placeholder": "#000000",
+        "reset": "Default"
+      },
       "auto_select_reply_identity": {
         "label": "Reply From Received Address",
         "description": "When replying, send from the address the message was originally sent to. Matches identities first; for domain catch-all deliveries, rewrites the From header to the alias while sending through your primary identity."

--- a/stores/settings-store.ts
+++ b/stores/settings-store.ts
@@ -134,6 +134,39 @@ export type MessageSpacing = 'auto' | 'always' | 'edge';
 
 /** Font used to render text/plain email bodies. */
 export type PlainTextFont = 'mono' | 'sans';
+
+/**
+ * Default font family for the rich-text composer. Web-safe stacks only (no
+ * web-font loading); 'default' leaves the family unset. Mapped to CSS in
+ * components/email/compose-typography.ts. When replying to a styled draft the
+ * draft's own family wins (so edits stay invisible); this setting supplies the
+ * family for a fresh message.
+ */
+export type ComposeFontFamily =
+  | 'default'
+  | 'sans'
+  | 'serif-georgia'
+  | 'serif-times'
+  | 'verdana'
+  | 'trebuchet'
+  | 'monospace';
+
+/**
+ * Default text size for the rich-text composer, as a tier mapped to px in
+ * compose-typography.ts. 'default' leaves the size unset. Like ComposeFontFamily
+ * it yields to a styled draft's own size when replying.
+ */
+export type ComposeFontSize = 'default' | 'small' | 'normal' | 'medium' | 'large' | 'x-large';
+
+const COMPOSE_FONT_FAMILIES: ComposeFontFamily[] = [
+  'default', 'sans', 'serif-georgia', 'serif-times', 'verdana', 'trebuchet', 'monospace',
+];
+const COMPOSE_FONT_SIZES: ComposeFontSize[] = ['default', 'small', 'normal', 'medium', 'large', 'x-large'];
+
+/** A validated hex colour (`#rgb`/`#rrggbb`), or '' for unset. Non-hex input is coerced to ''. */
+export function normalizeComposeColor(v: unknown): string {
+  return typeof v === 'string' && /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(v.trim()) ? v.trim() : '';
+}
 export type CalendarHoverPreview = 'off' | 'instant' | 'delay-500ms' | 'delay-1s' | 'delay-2s';
 export type SendDelaySeconds = 0 | 10 | 30 | 60;
 export type ProtocolOpenMode = 'active-session' | 'new-tab';
@@ -344,6 +377,9 @@ interface SettingsState {
   defaultReplyMode: ReplyMode;
   autoSelectReplyIdentity: boolean;
   plainTextMode: boolean; // Send plain text only (no rich text editor)
+  composeFontFamily: ComposeFontFamily; // Default composer font family (yields to a styled reply draft)
+  composeFontSize: ComposeFontSize; // Default composer text size (yields to a styled reply draft)
+  composeTextColor: string; // Default composer text colour as hex ('' = unset; yields to a styled reply draft)
   rtlEditingSupport: boolean; // Show a per-paragraph LTR/RTL direction control in the composer (Gmail-style)
   subAddressDelimiter: string; // Character separating user from tag (e.g. "user+tag@")
   sendDelaySeconds: SendDelaySeconds;
@@ -581,6 +617,9 @@ const DEFAULT_SETTINGS = {
   defaultReplyMode: 'reply' as ReplyMode,
   autoSelectReplyIdentity: false,
   plainTextMode: false,
+  composeFontFamily: 'default' as ComposeFontFamily,
+  composeFontSize: 'default' as ComposeFontSize,
+  composeTextColor: '',
   rtlEditingSupport: false,
   subAddressDelimiter: DEFAULT_SUB_ADDRESS_DELIMITER,
   sendDelaySeconds: 0 as SendDelaySeconds,
@@ -806,6 +845,9 @@ export const useSettingsStore = create<SettingsState>()(
           defaultReplyMode: state.defaultReplyMode,
           autoSelectReplyIdentity: state.autoSelectReplyIdentity,
           plainTextMode: state.plainTextMode,
+          composeFontFamily: state.composeFontFamily,
+          composeFontSize: state.composeFontSize,
+          composeTextColor: state.composeTextColor,
           rtlEditingSupport: state.rtlEditingSupport,
           subAddressDelimiter: state.subAddressDelimiter,
           sendDelaySeconds: state.sendDelaySeconds,
@@ -903,6 +945,14 @@ export const useSettingsStore = create<SettingsState>()(
               }
               if (key === 'sendDelaySeconds' && ![0, 10, 30, 60].includes(settings[key])) {
                 set({ sendDelaySeconds: 0 });
+                return;
+              }
+              // Reject an unknown enum value from a newer/older client rather
+              // than letting the composer map it to `undefined` CSS.
+              if (key === 'composeFontFamily' && !COMPOSE_FONT_FAMILIES.includes(settings[key])) {
+                return;
+              }
+              if (key === 'composeFontSize' && !COMPOSE_FONT_SIZES.includes(settings[key])) {
                 return;
               }
               // Validity of the zone id itself is checked at use time


### PR DESCRIPTION
## Summary

Two related composer improvements for the rich-text editor. They stand on their own but reinforce each other, so I've bundled them:

1. **Compose typography settings** — choose a Compose **Font**, **Text Size** and **Text Color**, applied as inline marks so the styling actually *sends* (not just previews). When replying to a message that already carries its own font/size/colour, edits **inherit** it so an inline reply stays visually invisible.
2. **WYSIWYG editor surface** — the composer and both signature previews now render email the way the **reading pane already does**, fixing dark-on-dark composing.

### 1. Compose typography

Today the composer gives every new paragraph the app's bare default (system sans, `text-sm`, foreground colour) and Settings → Composing has only `plainTextMode`. This adds three settings:

- **Compose Font** — Default (system), Sans (Arial), Serif (Georgia / Times), Verdana, Trebuchet, Monospace.
- **Compose Text Size** — Default / Small 13 / Normal 14 / **Medium 15** / Large 16 / Extra-large 18.
- **Compose Text Color** — a colour swatch + hex field, or blank for the theme default.

They're applied via the `@tiptap/extension-text-style` `font-family`/`font-size` submodules and `@tiptap/extension-color`, i.e. inline `style` on the runs, so the recipient actually receives them. The important bit for correctness: a **reply that already has a styled body wins** — new/edited runs sample the drafted body's family+size+colour, so editing between quoted lines doesn't visibly switch fonts. A colour/font the user picks by hand still wins over both.

### 2. WYSIWYG editor surface (fixes dark-on-dark composing)

An email body is a light-background document — senders author colours for a recipient reading on white. The **reading pane already honours this**: it renders each message on a light surface, and in dark mode applies a smart CSS-filter invert (`filter: invert(1) hue-rotate(180deg)` with images and colour/background containers re-inverted so photos/logos/fills stay correct — see `components/email/email-viewer.tsx`).

But three surfaces painted raw email HTML **directly on the app's dark background**:

- the composer (`.tiptap`),
- the composer's signature preview (`email-composer.tsx`),
- the identity-settings signature preview (`identity-form.tsx`).

So dark authored ink was **dark-on-dark and unreadable while composing**, and none of them matched the reader. This adds one shared `.email-surface` class (light surface + the reader's exact dark-mode invert) and applies it to all three. Composing now looks like reading, and like the recipient's view.

**Deliberately not a white card:** a dark-mode user still sees a *dark* email (via the invert), never a jarring white block — consistent with the reading pane.

## Testing

- `npm run typecheck` — clean (0 errors).
- New `components/email/__tests__/compose-typography.test.ts` — 10/10 pass (size/colour resolution, the invisible-edit inheritance, colour-picked-by-hand precedence).
- Manual: compose + both signature previews are readable and match the reader in light and dark; images/coloured backgrounds in a pasted signature stay correct in dark mode; styled replies keep their font when edited between quoted lines.

## Notes for maintainers

- The invert CSS in `.email-surface` mirrors `email-viewer.tsx`; happy to factor both onto one shared source if you prefer a single definition.
- The two parts can be split into separate PRs if you'd rather review them independently — just say the word.
