### PR TITLE
feat(auth): Send prompt=select_account to IdM when adding additional accounts

### DIFF
--- a/app/(main)/[locale]/login/page.tsx
+++ b/app/(main)/[locale]/login/page.tsx
@@ -620,6 +620,9 @@ export default function LoginPage() {
     authUrl.searchParams.set("state", state);
     authUrl.searchParams.set("code_challenge", challenge);
     authUrl.searchParams.set("code_challenge_method", "S256");
+    if (isAddAccountMode) {
+      authUrl.searchParams.set("prompt", "select_account");
+    }
 
     window.location.href = authUrl.toString();
   };


### PR DESCRIPTION
## Summary

<!-- A brief, one-paragraph description of what this PR does and why. -->

When adding additional accounts, the URL param `prompt=select_account` gets sent to the IdM so that PocketID and others present an account picker to the user.

## Changes

<!-- A bulleted list of the key changes made. -->

Just three lines, adding an `if` check for it being an additional account auth flow, setting the `prompt` URL parameter to `select_account_ if that's the case. 

## Related issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Closes #978


## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->

Could potentially break auth flows for IdM providers which don't support `prompt=select_account`, though that's a standard prompt, so all IdM providers should support it.