### PR TITLE
fix(i18n): correct zh translations and add batch forward-as-attachment

### DIFF
--- a/components/email/email-context-menu.tsx
+++ b/components/email/email-context-menu.tsx
@@ -77,6 +77,7 @@ interface EmailContextMenuProps {
   onRescheduleScheduled?: () => void;
   // Batch actions
   onBatchMarkAsRead?: (read: boolean) => void;
+  onBatchForwardAsAttachment?: () => void;
   onBatchDelete?: () => void;
   onBatchArchive?: () => void;
   onBatchMoveToMailbox?: (mailboxId: string) => void;
@@ -127,6 +128,7 @@ export function EmailContextMenu({
   onMarkAsSpam,
   onUndoSpam,
   onBatchMarkAsRead,
+  onBatchForwardAsAttachment,
   onBatchDelete,
   onBatchArchive,
   onBatchMoveToMailbox,
@@ -284,6 +286,20 @@ export function EmailContextMenu({
               })}
             />
           )}
+          <ContextMenuSeparator />
+        </>
+      )}
+
+      {/* Forward as attachment - batch variant attaches every selected
+          message as its own message/rfc822 file in one composer. */}
+      {showBatchActions && onBatchForwardAsAttachment && (
+        <>
+          <ContextMenuItem
+            icon={Paperclip}
+            label={tEmailViewer("forward_as_attachment")}
+            testId="ctx-batch-forward-as-attachment"
+            onClick={() => handleAction(onBatchForwardAsAttachment)}
+          />
           <ContextMenuSeparator />
         </>
       )}

--- a/components/email/email-list.tsx
+++ b/components/email/email-list.tsx
@@ -4,7 +4,7 @@ import { Email, ThreadGroup } from "@/lib/jmap/types";
 import { ThreadListItem } from "./thread-list-item";
 import { EmailContextMenu } from "./email-context-menu";
 import { cn } from "@/lib/utils";
-import { Trash2, Mail, MailX, MailOpen, Loader2, SearchX, AlertTriangle, CalendarClock, ShieldCheck } from "lucide-react";
+import { Trash2, Mail, MailX, MailOpen, Loader2, SearchX, AlertTriangle, CalendarClock, ShieldCheck, Paperclip } from "lucide-react";
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -35,6 +35,7 @@ interface EmailListProps {
   onReplyAll?: (email: Email) => void;
   onForward?: (email: Email) => void;
   onForwardAsAttachment?: (email: Email) => void;
+  onBatchForwardAsAttachment?: () => void;
   onMarkAsRead?: (email: Email, read: boolean) => void;
   onToggleStar?: (email: Email) => void;
   onTogglePinned?: (email: Email) => void;
@@ -65,6 +66,7 @@ export function EmailList({
   onReplyAll,
   onForward,
   onForwardAsAttachment,
+  onBatchForwardAsAttachment,
   onMarkAsRead,
   onToggleStar,
   onTogglePinned,
@@ -83,6 +85,7 @@ export function EmailList({
   const t = useTranslations('email_list');
   const tContextMenu = useTranslations('context_menu');
   const tSpam = useTranslations('email_viewer.spam');
+  const tEmailViewer = useTranslations('email_viewer');
   const { client } = useAuthStore();
   const {
     selectedEmailIds,
@@ -420,6 +423,22 @@ export function EmailList({
                 <Mail className="w-4 h-4" />
               )}
             </Button>
+            {onBatchForwardAsAttachment && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onBatchForwardAsAttachment}
+                title={tEmailViewer('forward_as_attachment')}
+                disabled={isProcessing}
+                className="hover:bg-accent transition-colors disabled:opacity-50"
+              >
+                {isProcessing ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Paperclip className="w-4 h-4" />
+                )}
+              </Button>
+            )}
             {effectiveMailboxRole === 'junk' && (
               <Button
                 variant="ghost"
@@ -644,6 +663,7 @@ export function EmailList({
           onCancelScheduledForEdit={onCancelScheduledForEdit ? () => onCancelScheduledForEdit(contextMenuEmail!) : undefined}
           onRescheduleScheduled={onRescheduleScheduled ? () => onRescheduleScheduled(contextMenuEmail!) : undefined}
           onBatchMarkAsRead={(read) => client && batchMarkAsRead(client, read)}
+          onBatchForwardAsAttachment={() => onBatchForwardAsAttachment?.()}
           onBatchDelete={() => client && batchDelete(client)}
           onBatchArchive={async () => {
             if (!client) return;

--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -101,7 +101,7 @@ import { plainTextToComposerBody, getQuoteBodies } from "@/lib/email-composer-ut
 import { appLifecycleHooks, uiHooks, routerHooks, toastHooks, emailHooks } from "@/lib/plugin-hooks";
 import { emailToReadView } from "@/lib/plugin-projection";
 import { buildQuoteHeader } from "@/lib/quote-header";
-import { buildComposeTabTitle, buildReplySubject } from "@/lib/subject-prefix";
+import { buildComposeTabTitle, buildReplySubject, buildForwardSubject } from "@/lib/subject-prefix";
 import { buildForwardAsAttachmentPayload } from "@/lib/forward-as-attachment";
 import { getEffectiveLocale } from '@/i18n/detect-locale';
 import {
@@ -2107,6 +2107,91 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
     if (isMobile) setActiveView('viewer');
   };
 
+  // Batch variant of handleForwardAsAttachment for multi-selected messages
+  // (list toolbar button + batch context-menu entry): opens ONE composer
+  // carrying every selected message as its own message/rfc822 attachment.
+  // The subject follows the first selected message, like single-message
+  // Forward. A plugin vetoing any single message (onBeforeForward.intercept)
+  // aborts the whole batch - forwarding 2 of 3 selected messages because a
+  // compliance plugin blocked the third would look like silent data loss.
+  const handleBatchForwardAsAttachment = async () => {
+    const { emails, selectedEmailIds: selection, threadEmailsCache } = useEmailStore.getState();
+    if (selection.size === 0) return;
+
+    // Selection can include messages that live only inside an expanded
+    // thread (threadEmailsCache), not as top-level rows of `emails` - the
+    // thread-header checkbox selects every message in the thread. Collect
+    // in list order so the attachments and subject match what's on screen.
+    const seen = new Set<string>();
+    const selected: Email[] = [];
+    const collect = (list: Email[]) => {
+      for (const email of list) {
+        if (selection.has(email.id) && !seen.has(email.id)) {
+          seen.add(email.id);
+          selected.push(email);
+        }
+      }
+    };
+    collect(emails);
+    for (const list of threadEmailsCache.values()) collect(list);
+    if (selected.length === 0) return;
+
+    const {
+      emailDownloadTemplate,
+      filenameSpaceReplacement,
+      filenameLowercase,
+      filenameStripDiacritics,
+      filenameCollapseSeparators,
+    } = useSettingsStore.getState();
+    const filenameOptions = {
+      template: emailDownloadTemplate,
+      spaceReplacement: filenameSpaceReplacement,
+      lowercase: filenameLowercase,
+      stripDiacritics: filenameStripDiacritics,
+      collapseSeparators: filenameCollapseSeparators,
+    };
+    const forwardPrefix = t('email_composer.prefix.forward');
+
+    const attachments: Array<{ blobId: string; name: string; type: string; size: number }> = [];
+    for (const email of selected) {
+      const transformed = await emailHooks.onBeforeComposeOpenToForwardAsAttachment.transform(email);
+      // Same per-message skip as the single flow: no blobId, nothing to attach.
+      const payload = buildForwardAsAttachmentPayload(transformed, forwardPrefix, filenameOptions);
+      if (!payload) continue;
+      const ok = await emailHooks.onBeforeForward.intercept({
+        originalEmailId: transformed.id,
+        originalEmail: emailToReadView(transformed),
+        mode: 'forward' as const,
+      });
+      if (!ok) return;
+      attachments.push(payload.attachment);
+    }
+    if (attachments.length === 0) return;
+
+    const first = selected[0];
+    startFreshComposerSession();
+    setPendingDraft({
+      to: "",
+      cc: "",
+      bcc: "",
+      subject: first.subject ? buildForwardSubject(first.subject, forwardPrefix) : "",
+      body: "",
+      showCc: false,
+      showBcc: false,
+      selectedIdentityId: null,
+      subAddressTag: "",
+      mode: "forward",
+      draftId: null,
+      replyTo: {
+        subject: first.subject,
+        attachments,
+      },
+    });
+    setComposerMode('forward');
+    setShowComposer(true);
+    if (isMobile) setActiveView('viewer');
+  };
+
   const handleDelete = async (emailToDelete: Email | null = selectedEmail) => {
     if (!client || !emailToDelete) return;
 
@@ -3932,6 +4017,7 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
                   selectEmail(email);
                   handleForwardAsAttachment(email);
                 }}
+                onBatchForwardAsAttachment={handleBatchForwardAsAttachment}
                 onMarkAsRead={async (email, read) => {
                   if (client) {
                     await markAsRead(client, email.id, read);

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -234,7 +234,7 @@
     "batch_actions": {
       "select": "选择邮件",
       "select_all": "全选",
-      "selected_messages": "已選取 {count, plural, one {1} other {#}} 封電子郵件",
+      "selected_messages": "已选取 {count, plural, one {1} other {#}} 封电子邮件",
       "mark_read": "标记为已读",
       "mark_unread": "标记为未读",
       "delete": "删除",
@@ -306,7 +306,7 @@
     "fullscreen": "全屏",
     "exit_fullscreen": "退出全屏",
     "export_email": "导出为 .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "以附件转发",
     "import_email": "导入 .eml 或 .zip",
     "keyboard_shortcuts": "键盘快捷键（？）",
     "email_source": "邮件源码",


### PR DESCRIPTION
## Fix

### zh translation corrections (`locales/zh/common.json`)
- `email_list.batch_actions.selected_messages`: Traditional-Chinese leftovers corrected to Simplified ("已選取…封電子郵件" → "已选取…封电子邮件")
- `email_viewer.forward_as_attachment`: untranslated English "Forward as attachment" → "以附件转发"

### Batch forward-as-attachment

Forward multiple selected emails as attachments (message/rfc822):

- New toolbar button (paperclip) in the batch actions bar and a batch context-menu entry (`email-context-menu.tsx`)
- `mail-app.tsx` orchestrates the flow: selected emails → one composer carrying every selected message as its own attachment; subject follows the first selected message
- Messages selected inside expanded threads are collected from `threadEmailsCache`
- A plugin veto (`onBeforeForward`) aborts the whole batch

## Testing

- `tsc --noEmit` clean
- eslint clean
- Translations test at parity with `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)