### PR TITLE
fix(pro): default the compose tab's From to the open mailbox

### DIFF
--- a/components/pro/__tests__/pro-compose-from-account.test.tsx
+++ b/components/pro/__tests__/pro-compose-from-account.test.tsx
@@ -1,0 +1,121 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+
+/**
+ * The Pro shell hoists every "show composer" intent - including `mailto:`
+ * links - into a compose tab, and that tab rendered `<EmailComposer />`
+ * without `composeFromAccountEmail`. Only the standard shell in
+ * `components/mail/mail-app.tsx` passed it, so in Pro `mode === 'compose'`
+ * resolved `findComposeIdentityId(identities, undefined)` to null and every
+ * new message defaulted to the account owner - even with a shared folder open.
+ */
+
+const composerProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
+
+// Stub the composer down to a prop recorder: what reaches it is the contract
+// under test.
+vi.mock('@/components/email/email-composer', () => ({
+  EmailComposer: (props: Record<string, unknown>) => {
+    composerProps.current = props;
+    return React.createElement('div', { 'data-testid': 'composer' });
+  },
+}));
+
+vi.mock('@/components/error', () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+  ComposerErrorFallback: () => null,
+}));
+
+vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }));
+vi.mock('@/lib/debug', () => ({ debug: { log: () => {}, warn: () => {}, error: () => {} } }));
+vi.mock('@/stores/toast-store', () => ({ toast: { error: () => {}, success: () => {}, warning: () => {} } }));
+
+const { emailState, authState } = vi.hoisted(() => ({
+  emailState: {
+    sendEmail: async () => ({ scheduled: false }),
+    refreshCurrentMailbox: async () => {},
+    fetchScheduledEmails: async () => {},
+    refreshScheduledMetadata: async () => {},
+    isScheduledView: false,
+    emails: [],
+    expandedThreadIds: new Set<string>(),
+    threadEmailsCache: new Map(),
+    mailboxes: [] as Array<{ id: string; isShared?: boolean; accountName?: string }>,
+    selectedMailbox: null as string | null,
+    viewingAccountId: null as string | null,
+  },
+  authState: {
+    client: { getAccountId: () => 'jmap-1' },
+    activeAccountId: 'local-1',
+    getClientForAccount: () => undefined,
+  },
+}));
+
+vi.mock('@/stores/email-store', () => {
+  const hook = (sel?: (s: typeof emailState) => unknown) =>
+    typeof sel === 'function' ? sel(emailState) : emailState;
+  hook.getState = () => emailState;
+  hook.setState = () => {};
+  return { useEmailStore: hook };
+});
+
+vi.mock('@/stores/auth-store', () => {
+  const hook = (sel?: (s: typeof authState) => unknown) =>
+    typeof sel === 'function' ? sel(authState) : authState;
+  hook.getState = () => authState;
+  return { useAuthStore: hook };
+});
+
+vi.mock('@/stores/account-store', () => {
+  const state = {
+    getAccountById: (id: string) =>
+      id === 'local-1' ? { id: 'local-1', email: 'owner@example.com' } : undefined,
+  };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  return { useAccountStore: hook };
+});
+
+vi.mock('@/stores/pro-tab-store', () => {
+  const state = { closeTab: () => {}, updateTabTitle: () => {}, updateComposeDraft: () => {} };
+  const hook = (sel?: (s: typeof state) => unknown) =>
+    typeof sel === 'function' ? sel(state) : state;
+  hook.getState = () => state;
+  return { useProTabStore: hook, registerProTabCloseInterceptor: () => () => {} };
+});
+
+import { ProComposeTabBody } from '../pro-compose-tab-body';
+
+const TAB_DATA = { sessionId: 1, mode: 'compose' as const, title: 'New message' };
+
+describe('Pro compose tab - From defaults to the open mailbox', () => {
+  beforeEach(() => {
+    composerProps.current = null;
+    emailState.mailboxes = [];
+    emailState.selectedMailbox = null;
+    emailState.viewingAccountId = null;
+  });
+
+  it('passes the shared folder owner as the compose account', () => {
+    emailState.mailboxes = [{ id: 'mb-shared', isShared: true, accountName: 'info@example.com' }];
+    emailState.selectedMailbox = 'mb-shared';
+
+    render(<ProComposeTabBody tabId="tab-1" data={TAB_DATA} />);
+
+    expect(composerProps.current?.composeFromAccountEmail).toBe('info@example.com');
+  });
+
+  // Control: on the user's own folder the prop must still resolve to the
+  // active account, so the test above is proving the shared-folder path and
+  // not just "some address gets passed".
+  it('passes the active account on an own folder', () => {
+    emailState.mailboxes = [{ id: 'mb-inbox' }];
+    emailState.selectedMailbox = 'mb-inbox';
+
+    render(<ProComposeTabBody tabId="tab-1" data={TAB_DATA} />);
+
+    expect(composerProps.current?.composeFromAccountEmail).toBe('owner@example.com');
+  });
+});

--- a/components/pro/pro-compose-tab-body.tsx
+++ b/components/pro/pro-compose-tab-body.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { EmailComposer, type ComposerDraftData } from "@/components/email/email-composer";
 import { ErrorBoundary, ComposerErrorFallback } from "@/components/error";
 import { useAuthStore } from "@/stores/auth-store";
 import { useEmailStore } from "@/stores/email-store";
+import { useAccountStore } from "@/stores/account-store";
+import { resolveComposeAccountEmail } from "@/lib/reply-identity";
 import { toast } from "@/stores/toast-store";
 import { useProTabStore, registerProTabCloseInterceptor, type ProComposeTabData } from "@/stores/pro-tab-store";
 import { debug } from "@/lib/debug";
@@ -183,6 +185,28 @@ export function ProComposeTabBody({ tabId, data }: ProComposeTabBodyProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Mirrors the standard shell (see the same prop in `components/mail/mail-app.tsx`).
+  // Without it `mode === 'compose'` resolves `findComposeIdentityId(identities,
+  // undefined)` -> null and every new message in the Pro shell defaults to the
+  // account owner, even with a shared folder open. The Pro shell hoists every
+  // "show composer" intent - including `mailto:` links - into a tab, so this
+  // omission covered the whole compose surface there.
+  //
+  // Read once, at mount: this is "the mailbox the message was started from",
+  // and the composer consumes it only while no identity has been picked yet.
+  // A tab body stays mounted (hidden) for as long as the tab is open, so
+  // subscribing to the mailbox list instead would re-render the composer - and
+  // its editor - on every counter refresh for the rest of the tab's life.
+  const [composeFromAccountEmail] = useState(() => {
+    const { mailboxes, selectedMailbox, viewingAccountId } = useEmailStore.getState();
+    const accountId = viewingAccountId ?? useAuthStore.getState().activeAccountId ?? '';
+    return resolveComposeAccountEmail(
+      mailboxes,
+      selectedMailbox,
+      useAccountStore.getState().getAccountById(accountId)?.email,
+    );
+  });
+
   return (
     <div className="flex h-full w-full flex-col bg-background">
       <ErrorBoundary fallback={ComposerErrorFallback}>
@@ -192,6 +216,7 @@ export function ProComposeTabBody({ tabId, data }: ProComposeTabBodyProps) {
           replyTo={data.replyTo}
           initialDraftText={data.initialDraftText}
           initialData={data.initialData}
+          composeFromAccountEmail={composeFromAccountEmail}
           onSend={handleSend}
           onScheduledSendCreated={handleScheduledSendCreated}
           onClose={handleClose}


### PR DESCRIPTION
`ProComposeTabBody` renders `<EmailComposer>` without `composeFromAccountEmail`.
Only the standard shell in `components/mail/mail-app.tsx` passes it, so in the
Pro/embedded shell `mode === 'compose'` resolves
`findComposeIdentityId(identities, undefined)` to null and every new message
defaults to the account owner — even with a shared folder open.

That covers the whole compose surface there rather than an edge case: the Pro
shell hoists every "show composer" intent — `mailto:` links included — into a
tab, and the inline composer never renders while it is active.

Resolved exactly as the standard shell does, so both shells share one rule. The
value is read once, at mount, rather than subscribed: a tab body stays mounted
(hidden) for as long as the tab is open, so subscribing to the mailbox list
would re-render the composer — and its editor — on every counter refresh, and
"the mailbox the message was started from" is the value the composer actually
wants.

### Testing

Two tests: the shared folder's owner is passed through, and — as a control that
the first proves the shared-folder path rather than "some address arrives" — an
own folder still resolves to the active account. Both were verified by
reverting: dropping the prop turns both red, and making the resolution ignore
the open shared folder turns exactly the first one red.

`npm run typecheck` and `npm run lint` are clean (lint: the same 9 pre-existing
warnings `main` reports, 0 errors). Full suite: 3660 passing, with only the
failures `main` produces on its own — a `zh-TW` key-drift in
`translations.test.ts` plus suites that flake under the single-worker full run
and pass in isolation, none of which import a file this PR touches.
