### PR TITLE
fix(composer): send from the address a message was delivered to

### DIFF
--- a/components/email/__tests__/recipient-chip-drag.test.tsx
+++ b/components/email/__tests__/recipient-chip-drag.test.tsx
@@ -152,6 +152,8 @@ vi.mock('@/lib/email-sanitization', () => ({
 vi.mock('@/lib/reply-identity', () => ({
   resolveReplyFrom: () => null,
   findComposeIdentityId: () => null,
+  findReplyIdentityId: () => null,
+  findDraftIdentityId: () => null,
 }));
 vi.mock('@/lib/email-threading', () => ({
   computeReplyThreadingHeaders: () => ({ inReplyTo: [], references: [] }),

--- a/components/email/__tests__/recipient-paste.test.tsx
+++ b/components/email/__tests__/recipient-paste.test.tsx
@@ -151,6 +151,8 @@ vi.mock('@/lib/email-sanitization', () => ({
 vi.mock('@/lib/reply-identity', () => ({
   resolveReplyFrom: () => null,
   findComposeIdentityId: () => null,
+  findReplyIdentityId: () => null,
+  findDraftIdentityId: () => null,
 }));
 vi.mock('@/lib/email-threading', () => ({
   computeReplyThreadingHeaders: () => ({ inReplyTo: [], references: [] }),

--- a/components/email/__tests__/reply-addressing.test.tsx
+++ b/components/email/__tests__/reply-addressing.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
 import { EmailComposer } from '../email-composer';
+import { useSettingsStore } from '@/stores/settings-store';
+import { useAuthStore } from '@/stores/auth-store';
 
 // ─── Heavy component mocks (mirrors recipient-paste.test.tsx) ─────────────────
 
@@ -17,9 +19,22 @@ vi.mock('@/components/files/file-preview-modal', () => ({ FilePreviewModal: () =
 vi.mock('@/hooks/use-focus-trap', () => ({
   useFocusTrap: () => ({ ref: { current: null } }),
 }));
+// Mutable so one test can turn the Pro cross-account identity list on; the
+// real hook namespaces every id as `<localAccountId>::<identityId>`.
+const proIdentities = vi.hoisted(() => ({
+  enabled: false,
+  groups: [] as unknown[],
+  allIdentities: [] as { id: string; email: string; name: string }[],
+}));
+
 vi.mock('@/hooks/use-pro-multi-account-identities', () => ({
-  useProMultiAccountIdentities: () => ({ enabled: false, groups: [], allIdentities: [] }),
-  stripCrossAccountIdentityPrefix: (id: string) => ({ localAccountId: null, rawId: id }),
+  useProMultiAccountIdentities: () => proIdentities,
+  stripCrossAccountIdentityPrefix: (id: string) => {
+    const at = id.indexOf('::');
+    return at === -1
+      ? { localAccountId: null, rawId: id }
+      : { localAccountId: id.slice(0, at), rawId: id.slice(at + 2) };
+  },
 }));
 
 // ─── Store mocks ──────────────────────────────────────────────────────────────
@@ -86,7 +101,7 @@ vi.mock('@/stores/settings-store', () => {
     timeFormat: '24h',
     plainTextMode: false,
     subAddressDelimiter: '+',
-    autoSelectReplyIdentity: true,
+    autoSelectReplyIdentity: false,
     attachmentReminderEnabled: false,
     attachmentReminderKeywords: [],
     sendDelaySeconds: 0,
@@ -183,6 +198,29 @@ const SELF_SENT = {
   subject: 'Re: Hello',
 };
 
+/** Delivered to an aliased/shared mailbox the user DOES hold an identity for. */
+const RECEIVED_SHARED = {
+  from: [{ email: 'bob@other.com', name: 'Bob' }],
+  to: [{ email: 'info@example.com', name: 'Info' }],
+  subject: 'Question for the team inbox',
+};
+
+/** The shared-mailbox shape: the team address in To, our own in Cc. */
+const RECEIVED_SHARED_WITH_US_IN_CC = {
+  from: [{ email: 'bob@other.com', name: 'Bob' }],
+  to: [{ email: 'info@example.com', name: 'Info' }],
+  cc: [{ email: 'me@example.com', name: 'Me' }],
+  subject: 'Question for the team inbox',
+};
+
+/** Delivered to a same-domain address that is NOT one of our identities -
+ *  the domain catch-all shape that rewrites the From header. */
+const RECEIVED_CATCH_ALL = {
+  from: [{ email: 'bob@other.com', name: 'Bob' }],
+  to: [{ email: 'colleague@example.com', name: 'A Colleague' }],
+  subject: 'Sent to a colleague on our domain',
+};
+
 /** Chip labels currently shown in a recipient row, in order. Chips are the
  *  draggable spans inside the row; next-intl is mocked to return the key, so
  *  the Cc row is found via its "cc_label" caption. */
@@ -194,8 +232,12 @@ const ccChips = () => chipsIn(screen.getByText('cc_label').parentElement as HTML
 
 const identitySelect = () => screen.getByTestId('composer-from') as HTMLSelectElement;
 
+const setAutoSelect = (on: boolean) =>
+  (useSettingsStore as unknown as { setState: (p: Record<string, unknown>) => void })
+    .setState({ autoSelectReplyIdentity: on });
+
 describe('composer reply addressing', () => {
-  beforeEach(() => { vi.clearAllMocks(); });
+  beforeEach(() => { vi.clearAllMocks(); setAutoSelect(false); });
 
   it('addresses a reply to the sender of a received message', () => {
     render(<EmailComposer mode="reply" replyTo={RECEIVED} />);
@@ -224,5 +266,101 @@ describe('composer reply addressing', () => {
   it('sends the reply to our own message from the identity that sent it', () => {
     render(<EmailComposer mode="reply" replyTo={{ ...SELF_SENT, from: [{ email: 'info@example.com', name: 'Info' }] }} />);
     expect(identitySelect().value).toBe('id-info');
+  });
+
+  // Own-identity matching is unconditional: it only chooses which of the
+  // user's OWN addresses sends, so it carries no impersonation risk. Shipping
+  // it behind an off-by-default setting meant a shared mailbox always replied
+  // as the account owner.
+  it('replies from the address that received the original', () => {
+    render(<EmailComposer mode="reply" replyTo={RECEIVED_SHARED} />);
+    expect(identitySelect().value).toBe('id-info');
+  });
+
+  it('forwards from the address that received the original', () => {
+    render(<EmailComposer mode="forward" replyTo={RECEIVED_SHARED} />);
+    expect(identitySelect().value).toBe('id-info');
+  });
+
+  // Being copied on a message addressed to the team must not make it reply as
+  // us: the identity list is ordered login-first, so resolving by identity
+  // order rather than by To/Cc/Bcc rank would pick `id-me` here.
+  it('replies from the To address even when our own identity is in Cc', () => {
+    render(<EmailComposer mode="reply" replyTo={RECEIVED_SHARED_WITH_US_IN_CC} />);
+    expect(identitySelect().value).toBe('id-info');
+  });
+
+  // Deliberate boundary: a NEW message is still resolved only when the setting
+  // is on. `composeFromAccountEmail` falls back to the account's login address,
+  // frozen at first login, so preselecting unconditionally would override a
+  // user-chosen default sender identity (#507) on every new message.
+  it('leaves a new message on the primary identity while the setting is off', () => {
+    render(<EmailComposer mode="compose" composeFromAccountEmail="info@example.com" />);
+    expect(identitySelect().value).toBe('id-me');
+  });
+
+  // The catch-all From REWRITE is a different behaviour and stays opt-in: it
+  // puts an address the user has NOT configured into From, and on a multi-user
+  // domain that address can be a colleague's.
+  it('does not rewrite From to a same-domain non-identity while the setting is off', () => {
+    render(<EmailComposer mode="reply" replyTo={RECEIVED_CATCH_ALL} />);
+    expect(screen.queryByDisplayValue('colleague@example.com')).toBeNull();
+    expect(identitySelect().value).toBe('id-me');
+  });
+
+  // A forward introduces the rewritten From to a recipient the user just
+  // typed, who has no way to tell it is not really from that person - so
+  // forwards never take the rewrite, even when it is enabled.
+  // Control: the opt-in path itself still works on a reply, so the two tests
+  // above are proving the gate, not a broken resolver.
+  it('rewrites From to the catch-all address on a reply when the setting is on', () => {
+    setAutoSelect(true);
+    try {
+      render(<EmailComposer mode="reply" replyTo={RECEIVED_CATCH_ALL} />);
+      expect(screen.getByDisplayValue('colleague@example.com')).toBeTruthy();
+    } finally {
+      setAutoSelect(false);
+    }
+  });
+
+  it('never rewrites From on a forward, even with the setting on', () => {
+    setAutoSelect(true);
+    try {
+      render(<EmailComposer mode="forward" replyTo={RECEIVED_CATCH_ALL} />);
+      expect(screen.queryByDisplayValue('colleague@example.com')).toBeNull();
+    } finally {
+      setAutoSelect(false);
+    }
+  });
+
+  // `composerClient` follows the selected identity, so auto-selecting an
+  // identity from another connected account would send this forward's inherited
+  // blobIds - and its autosaved draft - to a server that has never seen them.
+  // The From dropdown still offers that identity for manual selection.
+  it('never auto-selects an identity from another account', () => {
+    proIdentities.enabled = true;
+    proIdentities.allIdentities = [
+      { id: 'local-1::id-me', email: 'me@example.com', name: 'Me' },
+      { id: 'local-1::id-info', email: 'info@example.com', name: 'Info' },
+      { id: 'local-2::id-pers', email: 'personal@elsewhere.net', name: 'Personal' },
+    ];
+    (useAuthStore as unknown as { setState: (p: Record<string, unknown>) => void })
+      .setState({ activeAccountId: 'local-1' });
+    try {
+      render(
+        <EmailComposer
+          mode="forward"
+          replyTo={{
+            from: [{ email: 'bob@other.com', name: 'Bob' }],
+            to: [{ email: 'personal@elsewhere.net', name: 'Personal' }],
+            subject: 'Fwd',
+          }}
+        />,
+      );
+      expect(identitySelect().value).not.toBe('local-2::id-pers');
+    } finally {
+      proIdentities.enabled = false;
+      proIdentities.allIdentities = [];
+    }
   });
 });

--- a/components/email/email-composer.tsx
+++ b/components/email/email-composer.tsx
@@ -37,7 +37,7 @@ import { TemplatePicker } from "@/components/templates/template-picker";
 import { TemplateForm } from "@/components/templates/template-form";
 import type { EmailTemplate } from "@/lib/template-types";
 import { appendPlainTextSignature, getPlainTextSignature, plainTextBodyHasSignature, plainTextBodyWithoutSignature } from "@/lib/signature-utils";
-import { findComposeIdentityId, findDraftIdentityId, resolveReplyFrom } from "@/lib/reply-identity";
+import { findComposeIdentityId, findDraftIdentityId, findReplyIdentityId, resolveReplyFrom } from "@/lib/reply-identity";
 import { buildReplyRecipients, isSelfSent } from "@/lib/reply-recipients";
 import { computeReplyThreadingHeaders } from "@/lib/email-threading";
 import { RequestTimeoutError } from "@/lib/jmap/client";
@@ -180,11 +180,12 @@ interface EmailComposerProps {
   mode?: 'compose' | 'reply' | 'replyAll' | 'forward';
   /**
    * Email of the mailbox/account the user is viewing when they start a new
-   * message. When set (and `autoSelectReplyIdentity` is on), a fresh compose
-   * preselects the identity matching this address instead of the primary
-   * identity, so "New message" from info@ defaults its From to info@. Mirrors
-   * the reply-time identity match; ignored for reply/replyAll/forward (those
-   * resolve from the original recipients).
+   * message. When set, a fresh compose preselects the identity matching this
+   * address instead of the primary identity, so "New message" from info@
+   * defaults its From to info@. It matches the user's OWN identities only and
+   * is therefore not gated on `autoSelectReplyIdentity`, which gates the
+   * catch-all From rewrite. Mirrors the reply-time identity match; ignored for
+   * reply/replyAll/forward (those resolve from the original recipients).
    */
   composeFromAccountEmail?: string;
   replyTo?: {
@@ -331,6 +332,19 @@ export function EmailComposer({
     ? multiAccountIdentities.groups
     : [];
   const primaryIdentity = activeIdentities[0] ?? null;
+  const activeAccountId = useAuthStore((s) => s.activeAccountId);
+  // Automatic selection stays on the active account: `composerClient` follows
+  // the chosen identity, and a reply/forward still carries the original
+  // message's blobIds, which only its own account's server can resolve. The
+  // From dropdown keeps offering every account's identities to pick by hand.
+  const sameAccountIdentities = useMemo(
+    () => (multiAccountIdentities.enabled
+      ? identities.filter(
+          (identity) => stripCrossAccountIdentityPrefix(identity.id).localAccountId === activeAccountId,
+        )
+      : identities),
+    [multiAccountIdentities.enabled, identities, activeAccountId],
+  );
 
   const { isFeatureEnabled } = usePolicyStore();
   const templatesEnabled = isFeatureEnabled('templatesEnabled');
@@ -799,8 +813,12 @@ export function EmailComposer({
     setShowSendMenu(false);
   }, []);
 
+  // `autoSelectReplyIdentity` fused two behaviours: matching one of the user's
+  // OWN identities, which never rewrites `From:`, and the domain catch-all,
+  // which puts an address they have not configured into `From:`. Only the
+  // first is safe for everyone, so it is unconditional here; the rewrite stays
+  // behind the setting, which is what the setting's description promises.
   useEffect(() => {
-    if (!autoSelectReplyIdentity) return;
     if (selectedIdentityId || initialData?.selectedIdentityId) return;
 
     // New message started from a specific mailbox/account: default the From to
@@ -808,6 +826,11 @@ export function EmailComposer({
     // viewing info@ sends as info@. Reply/forward fall through to the
     // recipient-based resolution below.
     if (mode === 'compose') {
+      // Still gated. `composeFromAccountEmail` falls back to `AccountEntry.email`,
+      // which is written once at first login, so resolving it unconditionally
+      // would override a user-chosen default sender identity (#507) on every
+      // new message.
+      if (!autoSelectReplyIdentity) return;
       const composeIdentityId = findComposeIdentityId(identities, composeFromAccountEmail);
       if (composeIdentityId) {
         setSelectedIdentityId(composeIdentityId);
@@ -815,7 +838,10 @@ export function EmailComposer({
       return;
     }
 
-    if (mode !== 'reply' && mode !== 'replyAll') return;
+    // `forward` resolves like a reply: the address the original was delivered to
+    // is the one to send from. The comment above already promised it, and the
+    // neighbouring inline-image effect groups all three modes together.
+    if (mode !== 'reply' && mode !== 'replyAll' && mode !== 'forward') return;
 
     // Replying to our own message in a thread (#703): keep sending as the
     // identity that sent it. Resolving from the recipients here would pick the
@@ -829,20 +855,35 @@ export function EmailComposer({
       }
     }
 
-    const resolved = resolveReplyFrom(identities, {
+    const recipients = {
       to: replyTo?.to,
       cc: replyTo?.cc,
       bcc: replyTo?.bcc,
-    });
+    };
 
-    if (resolved) {
-      setSelectedIdentityId(resolved.identityId);
-      if (resolved.overrideEmail && !fromOverrideEnabled) {
-        setFromOverrideEnabled(true);
-        setFromOverrideEmail(resolved.overrideEmail);
-        if (resolved.overrideName) setFromOverrideName(resolved.overrideName);
-      }
+    // Own-identity match: unconditional, since it only ever selects one of the
+    // user's own configured addresses.
+    const ownIdentityId = findReplyIdentityId(sameAccountIdentities, recipients);
+    if (ownIdentityId) {
+      setSelectedIdentityId(ownIdentityId);
       return;
+    }
+
+    // Catch-all From rewrite: opt-in, and never on a forward. A reply continues
+    // a thread whose participants already know the addressing; a forward
+    // introduces the rewritten From to a recipient the user just typed, who has
+    // no way to tell it is not really from that person.
+    if (autoSelectReplyIdentity && mode !== 'forward') {
+      const resolved = resolveReplyFrom(identities, recipients);
+      if (resolved) {
+        setSelectedIdentityId(resolved.identityId);
+        if (resolved.overrideEmail && !fromOverrideEnabled) {
+          setFromOverrideEnabled(true);
+          setFromOverrideEmail(resolved.overrideEmail);
+          if (resolved.overrideName) setFromOverrideName(resolved.overrideName);
+        }
+        return;
+      }
     }
 
     // Fallback: match identity by the account's email when replying from unified view
@@ -863,6 +904,7 @@ export function EmailComposer({
     composeFromAccountEmail,
     fromOverrideEnabled,
     identities,
+    sameAccountIdentities,
     initialData?.selectedIdentityId,
     mode,
     replyTo?.accountId,

--- a/components/mail/mail-app.tsx
+++ b/components/mail/mail-app.tsx
@@ -85,7 +85,7 @@ import { isFilePreviewable } from "@/lib/file-preview";
 import { appendHtmlSignature, appendPlainTextSignature } from "@/lib/signature-utils";
 import { computeReplyThreadingHeaders } from "@/lib/email-threading";
 import { EML_IMPORT_ACCEPT, expandImportableEmails } from "@/lib/eml-import";
-import { findDraftIdentityId, resolveComposeAccountEmail, resolveReplyFrom, type ReplyFromResolution } from "@/lib/reply-identity";
+import { findDraftIdentityId, findReplyIdentityId, resolveComposeAccountEmail } from "@/lib/reply-identity";
 import { buildReplyRecipients, isSelfSent } from "@/lib/reply-recipients";
 import { useProMultiAccountIdentities } from "@/hooks/use-pro-multi-account-identities";
 import { Filter, ChevronDown, X, Paperclip, Star, Mail, MailOpen, RotateCcw, PenSquare, PenLine, CheckSquare, Square, AlertTriangle, ArrowLeft } from "lucide-react";
@@ -3032,36 +3032,40 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
     }
 
     const primaryIdentity = identities[0];
-    const autoSelectReplyIdentity = useSettingsStore.getState().autoSelectReplyIdentity;
 
-    // Decide the sending identity and (for domain-catch-all) an optional
-    // header From override that matches the address the message was sent to.
-    // Our own message keeps the identity it was sent from - the recipients are
-    // the other party, so resolving from them would send as their address.
-    // When the setting is off, fall through to primary-identity behavior.
+    // Send from the address the message was delivered to, so a reply out of a
+    // shared or aliased mailbox does not go out as the account owner. Our own
+    // message keeps the identity it was sent from - the recipients are the
+    // other party, so resolving from them would send as their address.
+    //
+    // Quick reply resolves the user's OWN identities only. It deliberately does
+    // NOT take the domain catch-all `From:` rewrite that the full composer
+    // offers: this surface is a bare text box with no From row, so a rewritten
+    // From would be applied with nothing on screen to show it - or to correct
+    // it. A catch-all delivery quick-replies as the matching own identity, and
+    // the user can open the full composer when they need the rewrite.
     const selfSentIdentityId = isSelfSent(replySource, ownIdentityEmails)
       ? findDraftIdentityId(identities, selectedEmail.from?.[0])
       : null;
-    const resolved: ReplyFromResolution | null = !autoSelectReplyIdentity
-      ? null
-      : selfSentIdentityId
-        ? { identityId: selfSentIdentityId }
-        : resolveReplyFrom(identities, {
-            to: selectedEmail.to,
-            cc: selectedEmail.cc,
-            bcc: selectedEmail.bcc,
-          });
-    const sendingIdentity = resolved
-      ? (identities.find((i) => i.id === resolved.identityId) || primaryIdentity)
-      : primaryIdentity;
-    const headerFromEmail = resolved?.overrideEmail || sendingIdentity?.email;
-    const headerFromName = resolved?.overrideName || sendingIdentity?.name || undefined;
-    const envelopeMailFrom = resolved?.overrideEmail ? sendingIdentity?.email : undefined;
+    const sendingIdentityId = selfSentIdentityId ?? findReplyIdentityId(identities, {
+      to: selectedEmail.to,
+      cc: selectedEmail.cc,
+      bcc: selectedEmail.bcc,
+    });
+    const sendingIdentity =
+      (sendingIdentityId ? identities.find((i) => i.id === sendingIdentityId) : undefined) || primaryIdentity;
+    const headerFromEmail = sendingIdentity?.email;
+    const headerFromName = sendingIdentity?.name || undefined;
 
-    // Append signature from the sending identity (fall back to primary
-    // when the reply-from lives on the same identity but a different alias).
+    // Alias and shared identities frequently carry no signature of their own,
+    // so fall back to the primary's - the composer does the same
+    // (`signatureIdentity`). Without it, quick-replying from a shared mailbox
+    // silently drops the user's signature.
+    const signatureIdentity = (sendingIdentity?.htmlSignature || sendingIdentity?.textSignature)
+      ? sendingIdentity
+      : primaryIdentity;
     const separator = useSettingsStore.getState().signatureSeparatorEnabled;
-    const finalBody = appendPlainTextSignature(body, sendingIdentity, { separator });
+    const finalBody = appendPlainTextSignature(body, signatureIdentity, { separator });
 
     // When the identity has an HTML signature, send a matching HTML body so the
     // signature keeps its formatting; appendPlainTextSignature would otherwise
@@ -3072,8 +3076,8 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
       .replace(/\n/g, '<br>');
-    const finalHtmlBody = sendingIdentity?.htmlSignature?.trim()
-      ? appendHtmlSignature(`<div>${escapedBody}</div>`, sendingIdentity, { separator })
+    const finalHtmlBody = signatureIdentity?.htmlSignature?.trim()
+      ? appendHtmlSignature(`<div>${escapedBody}</div>`, signatureIdentity, { separator })
       : undefined;
 
     const originalEmailId = selectedEmail.id;
@@ -3111,7 +3115,7 @@ export function MailApp({ linkSegments }: MailAppProps = {}) {
       threading?.inReplyTo,
       threading?.references,
       delayedUntil,
-      envelopeMailFrom,
+      undefined,
     );
 
     if (result.scheduled) {

--- a/lib/__tests__/reply-identity.test.ts
+++ b/lib/__tests__/reply-identity.test.ts
@@ -79,6 +79,62 @@ describe('findReplyIdentityId', () => {
 
     expect(selected).toBeNull();
   });
+
+  // The shared-mailbox shape: the team address in To, the member's own address
+  // in Cc. Scanning identities rather than recipients would answer with the
+  // member, because sortIdentities puts the login's own address first - i.e.
+  // exactly the "it replied as me again" complaint.
+  const shared: Identity[] = [
+    { id: 'owner', name: 'Owner', email: 'owner@example.com', mayDelete: false },
+    { id: 'team', name: 'Team', email: 'team@example.com', mayDelete: false },
+  ];
+
+  it('prefers a To recipient over a Cc one, whatever order the identities are in', () => {
+    const selected = findReplyIdentityId(shared, {
+      to: [{ email: 'team@example.com' }],
+      cc: [{ email: 'owner@example.com' }],
+    });
+
+    expect(selected).toBe('team');
+  });
+
+  it('ranks a Bcc identity below the address in To', () => {
+    const withArchive: Identity[] = [
+      { id: 'archive', name: 'Archive', email: 'archive@example.com', mayDelete: false },
+      { id: 'team', name: 'Team', email: 'team@example.com', mayDelete: false },
+    ];
+
+    const selected = findReplyIdentityId(withArchive, {
+      to: [{ email: 'team@example.com' }],
+      bcc: [{ email: 'archive@example.com' }],
+    });
+
+    expect(selected).toBe('team');
+  });
+
+  it('takes an exact match anywhere over a sub-address match in To', () => {
+    const selected = findReplyIdentityId(identities, {
+      to: [{ email: 'harry+news@primary.com' }],
+      cc: [{ email: 'harry@secondary.com' }],
+    });
+
+    expect(selected).toBe('secondary');
+  });
+
+  // A `+tag` identifies who the address was given to, so a delivery to an
+  // unknown tag must not answer with a sibling's tag and disclose it.
+  it('prefers the untagged identity over a differently-tagged sibling', () => {
+    const tagged: Identity[] = [
+      { id: 'eu', name: 'Sales EU', email: 'sales+eu@example.com', mayDelete: false },
+      { id: 'sales', name: 'Sales', email: 'sales@example.com', mayDelete: false },
+    ];
+
+    const selected = findReplyIdentityId(tagged, {
+      to: [{ email: 'sales+us@example.com' }],
+    });
+
+    expect(selected).toBe('sales');
+  });
 });
 
 describe('findComposeIdentityId', () => {

--- a/lib/reply-identity.ts
+++ b/lib/reply-identity.ts
@@ -35,6 +35,16 @@ function domainOf(email: string): string {
   return at > 0 ? email.slice(at + 1).toLowerCase() : '';
 }
 
+/**
+ * Pick the identity a message was delivered to, among the user's own. Never
+ * rewrites `From:` - it only chooses which configured address sends.
+ *
+ * Recipients are scanned in To, then Cc, then Bcc order, exact matches before
+ * `+tag`-stripped ones. Scanning the identities instead would let the identity
+ * list's order decide: `sortIdentities` deliberately puts the login's own
+ * address first, so `To: team@, Cc: you@` would reply as you rather than as
+ * the team - the exact case this is meant to fix.
+ */
 export function findReplyIdentityId(
   identities: Identity[],
   recipients?: ReplyRecipients,
@@ -55,16 +65,38 @@ export function findReplyIdentityId(
     return null;
   }
 
-  const exactMatches = new Set(receivedAddresses.map(normalizeEmailAddress));
-  const exactIdentity = identities.find((identity) => exactMatches.has(normalizeEmailAddress(identity.email)));
-  if (exactIdentity) {
-    return exactIdentity.id;
+  const byExact = new Map<string, string>();
+  const byBase = new Map<string, { id: string; untagged: boolean }>();
+  for (const identity of identities) {
+    const exact = normalizeEmailAddress(identity.email);
+    const base = normalizeBaseEmailAddress(identity.email);
+    if (!byExact.has(exact)) {
+      byExact.set(exact, identity.id);
+    }
+    // For a `+tag` delivery with no exact identity, the untagged identity is the
+    // answer; a differently-tagged sibling would disclose an unrelated tag.
+    const untagged = exact === base;
+    const existing = byBase.get(base);
+    if (!existing || (untagged && !existing.untagged)) {
+      byBase.set(base, { id: identity.id, untagged });
+    }
   }
 
-  const baseMatches = new Set(receivedAddresses.map(normalizeBaseEmailAddress));
-  const baseIdentity = identities.find((identity) => baseMatches.has(normalizeBaseEmailAddress(identity.email)));
+  for (const address of receivedAddresses) {
+    const exactId = byExact.get(normalizeEmailAddress(address));
+    if (exactId) {
+      return exactId;
+    }
+  }
 
-  return baseIdentity?.id ?? null;
+  for (const address of receivedAddresses) {
+    const baseMatch = byBase.get(normalizeBaseEmailAddress(address));
+    if (baseMatch) {
+      return baseMatch.id;
+    }
+  }
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
On a shared, group or aliased mailbox every reply, reply-all and forward goes
out as `identities[0]` — the account owner — whichever mailbox is open. Users
hit this as *"it keeps sending as the wrong address and I have to fix the From
by hand every time"*.

This supersedes #918, rebased onto current `main`. Two things changed since:

- The `handleStateChange` commit is **dropped** — 5805a28e8 ("resolve pushes
  with `Email/changes` and `Mailbox/changes` deltas") solved that
  independently, and better, via `emailListSync.accountId`. It was also the
  only merge conflict, so what is left applies cleanly.
- The Pro compose-tab half is now a separate, self-contained PR so it isn't
  held up by the discussion here.

### Why the setting is being split rather than flipped

The gate is deliberate — ddb636ed7 added it default-off, b0640c9ec fused the
catch-all into the same flag, and b716f95a7 (mine) then rode the same flag. I
am not asking to flip that default. The argument is that one flag is covering
two behaviours with very different risk:

1. **Own-identity match** — pick among the user's *configured* identities
   (exact, then `+tag`-stripped). Never rewrites `From:`; it only chooses which
   of your own addresses sends. This is the Thunderbird/Outlook default.
2. **Domain catch-all rewrite** — put an address you have *not* configured into
   `From:`, sending through a same-domain identity (#246).

(1) is what makes a shared mailbox reply from its own address, and it carries no
impersonation risk, so it becomes unconditional. `findReplyIdentityId` already
implemented exactly this and was referenced only from tests.

(2) stays behind the setting, and has to: `ownedDomains` treats **any** address
on a domain you hold an identity on as a catch-all candidate — including a
colleague's, and including one seen only in `Bcc:` — so on a multi-user domain
it can put someone else's address in your From. Enabling that for everyone
would be a regression, not a fix.

### What else is in here

- **`forward` was excluded from the resolution entirely**, so forwarding a
  message that arrived at a shared mailbox went out as the owner — though the
  comment above the gate already promised *"Reply/forward fall through to the
  recipient-based resolution below"*. Forwards take (1) but deliberately never
  (2): a reply continues a thread whose participants know the addressing, while
  a forward introduces a rewritten From to a recipient the user just typed.
- **`handleQuickReply` is narrowed to (1)** — a bare text box with no From row
  is the wrong place to apply a rewrite the user cannot see or correct — and now
  **falls back to the primary identity's signature** the way the composer does
  (`signatureIdentity`). Without that, quick-replying from a shared identity
  with no signature of its own silently dropped the user's signature.
- **`findReplyIdentityId` now scans recipients (To, then Cc, then Bcc) instead
  of scanning identities**, exact matches before `+tag`-stripped ones, and
  prefers an untagged identity over a differently-tagged sibling. Scanning
  identities let *their* order decide, and `sortIdentities` deliberately puts
  the login's own address first — so `To: team@, Cc: you@` replied as you,
  which is precisely the case this is meant to fix.
- **Automatic selection is restricted to the active account.**
  `composerClient` follows the selected identity, so in the Pro shell an
  automatic cross-account match would send a forward's inherited blobIds — and
  its autosaved draft — to a server that has never seen them. The From dropdown
  still offers every account's identities for manual selection.

### Deliberately not changed

- **New messages stay gated.** Making the `mode === 'compose'` branch
  unconditional looked tempting, but `composeFromAccountEmail` falls back to
  `AccountEntry.email`, which is written once at first login and never updated —
  so it would override a user-chosen default sender identity (#507) on every new
  message, for exactly the users who already fixed their From by hand. There is
  a test pinning that boundary.
- **The setting's label and description** now describe behaviour the toggle no
  longer solely controls. I left `locales/` untouched rather than change one
  locale's strings out of 27 — happy to send that as its own PR (all locales
  plus the hardcoded label in `app/(main)/admin/_tabs/policy.tsx`) if you want
  it, and it's worth deciding the wording first.
- `normalizeBaseEmailAddress` hardcodes `+` while `subAddressDelimiter` is
  configurable; pre-existing, shared with `resolveReplyFrom` and
  `findDraftIdentityId`, so out of scope here.
- "Forward as attachment" builds a `replyTo` with no recipients, so the forward
  fix does not reach it — it still sends as the owner.
- In plain-text mode with the signature above the quote, the embedded signature
  is chosen before the identity is resolved and the swap effect does not run for
  plain text, so the body can carry the primary's signature under an alias From.
  Pre-existing with the setting on; now reachable by default. Fixing it properly
  means teaching the swap effect about the plain-text surface.

### Testing

`npm run typecheck` clean; `npm run lint` clean (the same 9 pre-existing
warnings as `main`, 0 errors). Full suite: **3670 passing**, with only the
failures `main` produces on its own — a `zh-TW` key-drift in
`translations.test.ts`, plus suites that flake under the single-worker full run
and pass in isolation (a *different* one flakes on the `main` baseline, and none
of them import a file this PR touches).

Each behaviour was verified by reverting it and confirming exactly the intended
tests go red:

| reverted | red |
| --- | --- |
| the whole-effect setting gate | 4 — reply, forward, To-over-Cc, **and the pre-existing self-sent (#703) test** |
| `forward` admitted to the resolution | 1 — forward |
| the catch-all rewrite kept opt-in | 1 — "does not rewrite while the setting is off" |
| the rewrite never firing on a forward | 1 — "never rewrites From on a forward" |
| the compose branch's gate (made unconditional again) | 1 — the #507 boundary test |
| recipient order, back to scanning identities | 4 — To-over-Cc, Bcc-below-To, untagged preference, and the composer case |
| the untagged-sibling preference | 1 — `sales+us@` → `sales@`, not `sales+eu@` |
| the same-account restriction | 1 — "never auto-selects an identity from another account" |

Controls are deliberate: the catch-all rewrite *still* fires on a reply when the
setting is on, so the "no rewrite" tests prove the gate rather than a broken
resolver.

One fixture bug is fixed on the way: `reply-addressing.test.tsx` hard-coded
`autoSelectReplyIdentity: true` while the shipped default is `false`, so the
shipped configuration was the one nothing exercised. With the mock corrected,
the existing self-sent-reply test (#703) fails without this change — that
feature was dead in the shipped default too.
