### PR TITLE
fix: normalize calendar task progress states

### DIFF
--- a/lib/__tests__/jmap-calendar-task-progress.test.ts
+++ b/lib/__tests__/jmap-calendar-task-progress.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JMAPClient } from '../jmap/client';
+
+const SESSION = {
+  capabilities: {
+    'urn:ietf:params:jmap:core': {},
+    'urn:ietf:params:jmap:calendars': {},
+  },
+  accounts: {
+    'acct-1': {
+      name: 'user@test.com',
+      isPersonal: true,
+      accountCapabilities: { 'urn:ietf:params:jmap:calendars': {} },
+    },
+  },
+  primaryAccounts: {
+    'urn:ietf:params:jmap:mail': 'acct-1',
+    'urn:ietf:params:jmap:calendars': 'acct-1',
+  },
+  apiUrl: 'https://mail.example.com/jmap/api',
+  downloadUrl: 'https://mail.example.com/jmap/download/{accountId}/{blobId}/{name}',
+  uploadUrl: 'https://mail.example.com/jmap/upload/{accountId}/',
+  eventSourceUrl: 'https://mail.example.com/jmap/eventsource',
+};
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function task(id: string, progress: unknown): Record<string, unknown> {
+  return {
+    id,
+    '@type': 'Task',
+    uid: `${id}@example.com`,
+    calendarIds: { personal: true },
+    title: id,
+    progress,
+  };
+}
+
+describe('JMAP calendar task progress compatibility', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let client: JMAPClient;
+
+  beforeEach(async () => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockResolvedValueOnce(json(SESSION));
+    client = new JMAPClient('https://mail.example.com', 'user@test.com', 'pass123');
+    await client.connect();
+    fetchSpy.mockReset();
+  });
+
+  afterEach(() => {
+    client.disconnect();
+    fetchSpy.mockRestore();
+  });
+
+  it('normalizes known CalDAV spellings returned by CalendarEvent/query and /get', async () => {
+    const returnedTasks = [
+      task('upper-cancelled', 'CANCELLED'),
+      task('single-l-canceled', 'canceled'),
+      task('underscore-needs-action', 'NEEDS_ACTION'),
+      task('underscore-in-process', 'IN_PROCESS'),
+    ];
+
+    fetchSpy
+      .mockResolvedValueOnce(json({
+        methodResponses: [['CalendarEvent/query', { ids: returnedTasks.map(({ id }) => id) }, '0']],
+      }))
+      .mockResolvedValueOnce(json({
+        methodResponses: [['CalendarEvent/get', { list: returnedTasks, notFound: [] }, '0']],
+      }));
+
+    const tasks = await client.getCalendarTasks();
+
+    expect(tasks.map(({ progress }) => progress)).toEqual([
+      'cancelled',
+      'cancelled',
+      'needs-action',
+      'in-process',
+    ]);
+  });
+
+  it('preserves unknown and non-string progress values without prototype lookups', async () => {
+    const returnedTasks = [
+      task('constructor', 'constructor'),
+      task('proto', '__proto__'),
+      task('future-value', 'blocked'),
+      task('numeric-value', 42),
+      task('null-value', null),
+    ];
+
+    fetchSpy
+      .mockResolvedValueOnce(json({
+        methodResponses: [['CalendarEvent/query', { ids: returnedTasks.map(({ id }) => id) }, '0']],
+      }))
+      .mockResolvedValueOnce(json({
+        methodResponses: [['CalendarEvent/get', { list: returnedTasks, notFound: [] }, '0']],
+      }));
+
+    const tasks = await client.getCalendarTasks();
+
+    expect(tasks.map(({ progress }) => progress as unknown)).toEqual([
+      'constructor',
+      '__proto__',
+      'blocked',
+      42,
+      null,
+    ]);
+  });
+
+  it('normalizes progress on task create refetch', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(json({
+        methodResponses: [['CalendarEvent/set', { created: { 'new-task': { id: 'created-id' } } }, '0']],
+      }))
+      .mockResolvedValueOnce(json({
+        methodResponses: [['CalendarEvent/get', {
+          list: [task('created-id', 'IN_PROCESS')],
+          notFound: [],
+        }, '0']],
+      }));
+
+    const created = await client.createCalendarTask({
+      title: 'created task',
+      calendarIds: { personal: true },
+    });
+
+    expect(created.progress).toBe('in-process');
+  });
+
+  it('preserves unknown and non-string progress on task create refetch', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(json({
+        methodResponses: [['CalendarEvent/set', { created: { 'new-task': { id: 'future-id' } } }, '0']],
+      }))
+      .mockResolvedValueOnce(json({
+        methodResponses: [['CalendarEvent/get', {
+          list: [task('future-id', 'constructor')],
+          notFound: [],
+        }, '0']],
+      }))
+      .mockResolvedValueOnce(json({
+        methodResponses: [['CalendarEvent/set', { created: { 'new-task': { id: 'numeric-id' } } }, '0']],
+      }))
+      .mockResolvedValueOnce(json({
+        methodResponses: [['CalendarEvent/get', {
+          list: [task('numeric-id', 42)],
+          notFound: [],
+        }, '0']],
+      }));
+
+    const future = await client.createCalendarTask({
+      title: 'future task',
+      calendarIds: { personal: true },
+    });
+    const numeric = await client.createCalendarTask({
+      title: 'numeric task',
+      calendarIds: { personal: true },
+    });
+
+    expect(future.progress as unknown).toBe('constructor');
+    expect(numeric.progress as unknown).toBe(42);
+  });
+});

--- a/lib/jmap/client.ts
+++ b/lib/jmap/client.ts
@@ -371,6 +371,26 @@ const CALENDAR_TASK_PROPERTIES = [
   'percentComplete',  // Task-only per RFC 8984 §5.2.4 - used in detection heuristic
 ] as const;
 
+const TASK_PROGRESS_NORMALIZATION = new Map<string, CalendarTask['progress']>([
+  ['needs-action', 'needs-action'],
+  ['needs_action', 'needs-action'],
+  ['in-process', 'in-process'],
+  ['in_process', 'in-process'],
+  ['completed', 'completed'],
+  ['cancelled', 'cancelled'],
+  ['canceled', 'cancelled'],
+]);
+
+function normalizeCalendarTask(task: CalendarTask): CalendarTask {
+  const progress = task.progress as unknown;
+  if (typeof progress !== 'string') return task;
+
+  const normalizedProgress = TASK_PROGRESS_NORMALIZATION.get(progress.toLowerCase());
+  return normalizedProgress === undefined
+    ? task
+    : { ...task, progress: normalizedProgress };
+}
+
 /**
  * IANA time zone of the user - their `timeZone` setting when set (#755),
  * otherwise the browser's - sent as the `timeZone` argument on
@@ -6901,7 +6921,7 @@ export class JMAPClient implements IJMAPClient {
 
         if (!isExplicitTask && !isCalDavTask) continue;
 
-        tasks.push({ ...obj, '@type': 'Task' as const } as CalendarTask);
+        tasks.push(normalizeCalendarTask({ ...obj, '@type': 'Task' as const } as CalendarTask));
       }
 
       debug.log('tasks', 'CalendarTask/fetch complete,', tasks.length, 'tasks of', allObjects.length, 'objects');
@@ -6968,7 +6988,7 @@ export class JMAPClient implements IJMAPClient {
       const notFound = getResponse.methodResponses[0][1].notFound || [];
       debug.log('calendar', 'CalendarTask/create get response', { found: list.length, notFound });
       if (list[0]) {
-        const created = { ...list[0], '@type': 'Task' as const } as CalendarTask;
+        const created = normalizeCalendarTask({ ...list[0], '@type': 'Task' as const } as CalendarTask);
         debug.log('tasks', 'CalendarTask/create final task object', {
           id: created.id,
           uid: created.uid,


### PR DESCRIPTION
## Summary

Normalize non-canonical calendar task `progress` values returned by JMAP so completed or cancelled tasks appear correctly in task UI.

Known spellings are converted to canonical JSCalendar values at task response boundaries. Unknown and non-string values remain unchanged. Outgoing payloads are unaffected.

Related to [stalwartlabs/calcard#20](https://github.com/stalwartlabs/calcard/issues/20). PR #980 separately handles outgoing `progressUpdated`.

## Testing

- Focused Vitest: 4 passed
- Typecheck: passed
- Lint: passed
- Build: passed
- CI-equivalent Vitest: 3,737 passed

Plain Vitest reproduces one unrelated load-sensitive resilience-test failure on both this branch and base commit.
