### PR TITLE
fix(auth) Prevent silent account purges on recoverable errors

### DIFF
--- a/app/api/auth/sso/complete/route.ts
+++ b/app/api/auth/sso/complete/route.ts
@@ -9,6 +9,7 @@ import {
 } from '@/lib/oauth/token-exchange';
 import { refreshTokenCookieName, refreshTokenServerCookieName } from '@/lib/oauth/tokens';
 import { getCookieOptions } from '@/lib/oauth/cookie-config';
+import { MAX_ACCOUNT_SLOTS } from '@/lib/account-utils';
 
 const SSO_PENDING_COOKIE = 'sso_pending';
 const SSO_PENDING_MAX_AGE_MS = 5 * 60 * 1000; // 5 minutes
@@ -23,11 +24,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Missing code or state' }, { status: 400 });
     }
 
-    // Per-account refresh-token cookie slot. Without this the route hardcoded
-    // slot 0, so the "+ Add Account" flow overwrote the first account's
-    // refresh-token cookie. Default to 0 for back-compat with any caller that
-    // omits slot. Mirrors the validation in /api/auth/token POST.
-    const slot = typeof bodySlot === 'number' && bodySlot >= 0 && bodySlot <= 4 ? bodySlot : 0;
+    // Default to 0 for back-compat with any caller that omits slot. An
+    // out-of-range slot must never fall back to 0 either: the client records
+    // the slot it asked for, so writing elsewhere strands this login and
+    // overwrites another account's refresh token.
+    const slot = typeof bodySlot === 'number' && bodySlot >= 0 && bodySlot < MAX_ACCOUNT_SLOTS ? bodySlot : 0;
 
     // Read and decrypt the pending SSO cookie
     const pendingCookie = cookieStore.get(SSO_PENDING_COOKIE)?.value;

--- a/app/api/auth/token/route.ts
+++ b/app/api/auth/token/route.ts
@@ -22,6 +22,106 @@ function getSlot(request: NextRequest): number {
 
 type CookieStore = Awaited<ReturnType<typeof cookies>>;
 
+// Refresh tokens are single-use at most IdPs (PocketID, Rauthy, Keycloak with
+// rotation): redeeming one rotates it, and a second redemption of the same
+// value is refused with invalid_grant. Two contexts can still present the
+// same token at once - a PWA and a Safari tab, or a request sent before the
+// previous refresh's Set-Cookie landed - and the loser of that race must not
+// be treated as revoked, or its account silently disappears.
+//
+// Both maps are per-process, which holds for the single-container deployment;
+// running several instances would need sticky sessions for this route.
+
+interface RefreshTokens {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+}
+
+type RefreshOutcome =
+  | { ok: true; tokens: RefreshTokens }
+  | { ok: false; status: number; error: string };
+
+// Long enough to cover a backgrounded tab resuming with a stale cookie, short
+// enough that a truly revoked token is not honoured for long.
+const REFRESH_GRACE_MS = 5 * 60 * 1000;
+const REFRESH_GRACE_MAX_ENTRIES = 1000;
+const inFlightRefreshes = new Map<string, Promise<RefreshOutcome>>();
+const recentRotations = new Map<string, { outcome: RefreshOutcome; at: number }>();
+
+function pruneRecentRotations(now: number): void {
+  for (const [token, entry] of recentRotations) {
+    if (now - entry.at > REFRESH_GRACE_MS) recentRotations.delete(token);
+  }
+  while (recentRotations.size > REFRESH_GRACE_MAX_ENTRIES) {
+    const oldest = recentRotations.keys().next().value;
+    if (oldest === undefined) break;
+    recentRotations.delete(oldest);
+  }
+}
+
+async function redeemAtIdp(refreshToken: string, serverId: string | null): Promise<RefreshOutcome> {
+  // The refresh token may have been minted by the password+TOTP login route,
+  // which works without a configured OAuth client by falling back to the
+  // default client id - refreshing must fall back the same way (#873).
+  const tokenEndpoint = await getTokenEndpoint(serverId, { fallbackClientId: DEFAULT_CLIENT_ID });
+
+  const params = buildOAuthParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+  }, serverId, { fallbackClientId: DEFAULT_CLIENT_ID });
+
+  const tokenResponse = await fetch(tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString(),
+  });
+
+  if (!tokenResponse.ok) {
+    return { ok: false, status: tokenResponse.status, error: await tokenResponse.text() };
+  }
+
+  const tokens = (await tokenResponse.json()) as RefreshTokens;
+  if (!tokens.access_token) {
+    logger.error('Refresh response missing access_token', { response: JSON.stringify(tokens).substring(0, 500) });
+    return { ok: false, status: 502, error: 'Invalid token response' };
+  }
+  return { ok: true, tokens };
+}
+
+async function redeemRefreshToken(refreshToken: string, serverId: string | null): Promise<RefreshOutcome> {
+  const now = Date.now();
+  pruneRecentRotations(now);
+
+  const inFlight = inFlightRefreshes.get(refreshToken);
+  if (inFlight) return inFlight;
+
+  // The IdP is asked first, deliberately. Answering a stale token from the
+  // rotation record before asking would keep a lost-response straggler
+  // signed in, but it would also hide a replayed (stolen) refresh token from
+  // an IdP whose reuse detection exists to catch exactly that. Keeping the
+  // detection signal is worth an occasional sign-out; the record below only
+  // softens the loser of a race this process itself can vouch for.
+  const pending = redeemAtIdp(refreshToken, serverId)
+    .then((outcome) => {
+      if (outcome.ok) {
+        recentRotations.set(refreshToken, { outcome, at: Date.now() });
+        return outcome;
+      }
+      // A refusal of a token this process rotated moments ago comes from a
+      // straggler still holding the old value; answering with the rotation
+      // result converges it on the new cookie. A refused token that was never
+      // rotated here is genuinely revoked.
+      const rejected = outcome.status === 400 || outcome.status === 401 || outcome.status === 403;
+      const recent = recentRotations.get(refreshToken);
+      if (rejected && recent && Date.now() - recent.at <= REFRESH_GRACE_MS) return recent.outcome;
+      return outcome;
+    })
+    .finally(() => { inFlightRefreshes.delete(refreshToken); });
+  inFlightRefreshes.set(refreshToken, pending);
+  return pending;
+}
+
 /**
  * Cache the access token for the slot so a page reload can resume with it.
  *
@@ -117,29 +217,17 @@ export async function PUT(request: NextRequest) {
       }
     }
 
-    // The refresh token may have been minted by the password+TOTP login route,
-    // which works without a configured OAuth client by falling back to the
-    // default client id - refreshing must fall back the same way (#873).
-    const tokenEndpoint = await getTokenEndpoint(serverId, { fallbackClientId: DEFAULT_CLIENT_ID });
+    const outcome = await redeemRefreshToken(refreshToken, serverId);
 
-    const params = buildOAuthParams({
-      grant_type: 'refresh_token',
-      refresh_token: refreshToken,
-    }, serverId, { fallbackClientId: DEFAULT_CLIENT_ID });
-
-    const tokenResponse = await fetch(tokenEndpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: params.toString(),
-    });
-
-    if (!tokenResponse.ok) {
-      const errorText = await tokenResponse.text();
-      logger.error('Token refresh failed', { status: tokenResponse.status, error: errorText });
+    if (!outcome.ok) {
+      logger.error('Token refresh failed', { status: outcome.status, error: outcome.error });
+      if (outcome.status === 502) {
+        return NextResponse.json({ error: 'Invalid token response' }, { status: 502 });
+      }
       // Drop the refresh token only when the server definitively rejected it
       // (invalid/expired/revoked grant). A 5xx or 429 is an outage - keeping
       // the cookie lets the session resume once the server is back.
-      const status = tokenResponse.status;
+      const status = outcome.status;
       if (status === 400 || status === 401 || status === 403) {
         cookieStore.delete(cookieName);
         cookieStore.delete(refreshTokenServerCookieName(slot));
@@ -149,12 +237,7 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Token endpoint unavailable' }, { status: 503 });
     }
 
-    const tokens = await tokenResponse.json();
-
-    if (!tokens.access_token) {
-      logger.error('Refresh response missing access_token', { response: JSON.stringify(tokens).substring(0, 500) });
-      return NextResponse.json({ error: 'Invalid token response' }, { status: 502 });
-    }
+    const { tokens } = outcome;
 
     if (tokens.refresh_token) {
       cookieStore.set(cookieName, tokens.refresh_token, getCookieOptions());

--- a/lib/__tests__/oauth-token-route-refresh-race.test.ts
+++ b/lib/__tests__/oauth-token-route-refresh-race.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('next/server', () => {
+  class NextResponse {
+    status: number;
+    json: () => Promise<unknown>;
+    constructor(body: unknown, init?: { status?: number }) {
+      this.status = init?.status ?? 200;
+      this.json = async () => body;
+    }
+    static json(data: unknown, init?: { status?: number }) {
+      return new NextResponse(data, init);
+    }
+  }
+  return { NextResponse };
+});
+
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('@/lib/oauth/cookie-config', () => ({
+  getCookieOptions: () => ({ httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: 2592000 }),
+}));
+
+vi.mock('@/lib/oauth/token-exchange', () => ({
+  exchangeCodeForTokens: vi.fn(),
+  buildOAuthParams: (params: Record<string, string>) => new URLSearchParams(params),
+  getMetadata: vi.fn().mockResolvedValue(null),
+  getTokenEndpoint: vi.fn().mockResolvedValue('https://auth.example.com/token'),
+  DEFAULT_CLIENT_ID: 'bulwark-webmail',
+}));
+
+/** In-memory stand-in for the Next.js cookie store, shared by concurrent requests like a browser jar. */
+class FakeCookies {
+  store = new Map<string, string>();
+  deleted: string[] = [];
+  get(name: string) {
+    const value = this.store.get(name);
+    return value === undefined ? undefined : { name, value };
+  }
+  set(name: string, value: string) { this.store.set(name, value); }
+  delete(name: string) { this.deleted.push(name); this.store.delete(name); }
+}
+
+let cookieStore: FakeCookies;
+vi.mock('next/headers', () => ({ cookies: async () => cookieStore }));
+
+function mockRequest(params: Record<string, string> = {}): unknown {
+  return {
+    nextUrl: { searchParams: { get: (k: string) => params[k] ?? null } },
+    headers: { get: () => null },
+  };
+}
+
+type RouteResult = { status: number; json: () => Promise<Record<string, unknown> | null> };
+
+async function callPut(params?: Record<string, string>) {
+  const { PUT } = await import('@/app/api/auth/token/route');
+  const res = (await PUT(mockRequest(params) as Parameters<typeof PUT>[0])) as unknown as RouteResult;
+  return { status: res.status, body: (await res.json()) ?? {} };
+}
+
+/**
+ * Fake IdP with one-time refresh tokens (PocketID, Keycloak with rotation,
+ * Rauthy...): redeeming a refresh token rotates it and the old one is
+ * rejected with invalid_grant from then on.
+ */
+function makeIdp() {
+  let current = 'rt-1';
+  let n = 1;
+  const calls: string[] = [];
+  const fetchMock = vi.fn(async (_url: unknown, init?: { body?: string }) => {
+    const presented = new URLSearchParams(init?.body ?? '').get('refresh_token') ?? '';
+    calls.push(presented);
+    // Simulate network latency so concurrent requests overlap.
+    await new Promise((r) => setTimeout(r, 5));
+    if (presented !== current) {
+      return { ok: false, status: 400, text: async () => 'invalid_grant', json: async () => ({ error: 'invalid_grant' }) };
+    }
+    n += 1;
+    current = `rt-${n}`;
+    return { ok: true, json: async () => ({ access_token: `at-${n}`, refresh_token: current, expires_in: 3600 }) };
+  });
+  return { fetchMock, calls, get current() { return current; } };
+}
+
+describe('oauth token route - concurrent and stale refreshes must not evict the slot', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    cookieStore = new FakeCookies();
+    cookieStore.set('jmap_rt', 'rt-1');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('two forced refreshes racing on the same refresh token both succeed and redeem it once', async () => {
+    const idp = makeIdp();
+    vi.stubGlobal('fetch', idp.fetchMock);
+
+    const [a, b] = await Promise.all([callPut({ force: 'true' }), callPut({ force: 'true' })]);
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(a.body.access_token).toBe('at-2');
+    expect(b.body.access_token).toBe('at-2');
+    expect(idp.calls).toEqual(['rt-1']);
+    expect(cookieStore.get('jmap_rt')?.value).toBe('rt-2');
+    expect(cookieStore.deleted).toEqual([]);
+  });
+
+  it('a refresh that arrives with the just-rotated token (other tab, slow cookie) gets the rotated result', async () => {
+    const idp = makeIdp();
+    vi.stubGlobal('fetch', idp.fetchMock);
+
+    const first = await callPut({ force: 'true' });
+    expect(first.body.access_token).toBe('at-2');
+
+    // A second context still holds rt-1 in its request (cookie set after its
+    // request was sent). The IdP would reject rt-1 now.
+    cookieStore.set('jmap_rt', 'rt-1');
+    const second = await callPut({ force: 'true' });
+
+    expect(second.status).toBe(200);
+    expect(second.body.access_token).toBe('at-2');
+    expect(cookieStore.get('jmap_rt')?.value).toBe('rt-2');
+    expect(cookieStore.deleted).toEqual([]);
+    // The IdP is asked first and refuses; only then does the rotation record
+    // answer. Deliberate: a replayed (stolen) token must still reach an IdP
+    // whose reuse detection exists to catch it, even at the cost of a
+    // sign-out when the IdP revokes the family.
+    expect(idp.calls).toEqual(['rt-1', 'rt-1']);
+  });
+
+  it('a stale token presented while its refresh is still in flight joins that refresh', async () => {
+    const idp = makeIdp();
+    vi.stubGlobal('fetch', idp.fetchMock);
+
+    const first = callPut({ force: 'true' });
+    await new Promise((r) => setTimeout(r, 1)); // let the first request reach the IdP
+    const second = await callPut({ force: 'true' });
+    expect((await first).body.access_token).toBe('at-2');
+    expect(second.body.access_token).toBe('at-2');
+    expect(idp.calls).toEqual(['rt-1']);
+  });
+
+  it('a genuinely revoked refresh token is still rejected and its cookies dropped', async () => {
+    const idp = makeIdp();
+    vi.stubGlobal('fetch', idp.fetchMock);
+
+    cookieStore.set('jmap_rt', 'rt-revoked');
+    const { status } = await callPut({ force: 'true' });
+
+    expect(status).toBe(401);
+    expect(cookieStore.deleted).toContain('jmap_rt');
+  });
+});

--- a/lib/__tests__/oauth-token-route.test.ts
+++ b/lib/__tests__/oauth-token-route.test.ts
@@ -76,6 +76,8 @@ const fetchMock = vi.fn();
 describe('oauth token route - access token cache (#552)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The route remembers redeemed refresh tokens per process.
+    vi.resetModules();
     cookieStore = new FakeCookies();
     getTokenEndpoint.mockResolvedValue('https://auth.example.com/token');
     buildOAuthParams.mockReturnValue(new URLSearchParams({ grant_type: 'refresh_token' }));

--- a/lib/__tests__/sso-complete-slot.test.ts
+++ b/lib/__tests__/sso-complete-slot.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number }) => ({
+      json: async () => data,
+      status: init?.status ?? 200,
+    }),
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('@/lib/oauth/cookie-config', () => ({
+  getCookieOptions: () => ({ httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: 2592000 }),
+}));
+
+vi.mock('@/lib/auth/crypto', () => ({
+  decryptPayload: () => ({
+    state: 'state-1',
+    code_verifier: 'verifier',
+    redirect_uri: 'https://webmail.example/en/auth/callback',
+    created_at: Date.now(),
+  }),
+}));
+
+vi.mock('@/lib/oauth/token-exchange', () => ({
+  exchangeCodeForTokens: vi.fn().mockResolvedValue({
+    access_token: 'at',
+    refresh_token: 'rt-new',
+    expires_in: 3600,
+  }),
+  getRequiredConfig: vi.fn(),
+  getTokenEndpoint: vi.fn(),
+}));
+
+class FakeCookies {
+  store = new Map<string, string>();
+  get(name: string) {
+    const value = this.store.get(name);
+    return value === undefined ? undefined : { name, value };
+  }
+  set(name: string, value: string) { this.store.set(name, value); }
+  delete(name: string) { this.store.delete(name); }
+}
+
+let cookieStore: FakeCookies;
+vi.mock('next/headers', () => ({ cookies: async () => cookieStore }));
+
+async function complete(slot: number) {
+  const { POST } = await import('@/app/api/auth/sso/complete/route');
+  const request = { json: async () => ({ code: 'code', state: 'state-1', slot }) };
+  const res = (await POST(request as Parameters<typeof POST>[0])) as unknown as { status: number };
+  return res.status;
+}
+
+describe('sso complete route - refresh token lands in the slot the client asked for', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    cookieStore = new FakeCookies();
+    cookieStore.set('sso_pending', 'encrypted');
+    cookieStore.set('jmap_rt', 'rt-of-first-account');
+  });
+
+  it('writes a high slot instead of falling back to slot 0', async () => {
+    expect(await complete(6)).toBe(200);
+
+    expect(cookieStore.get('jmap_rt_6')?.value).toBe('rt-new');
+    expect(cookieStore.get('jmap_rt')?.value).toBe('rt-of-first-account');
+  });
+
+  it('still writes slot 0 when asked for slot 0', async () => {
+    expect(await complete(0)).toBe(200);
+
+    expect(cookieStore.get('jmap_rt')?.value).toBe('rt-new');
+  });
+});

--- a/stores/__tests__/auth-store-refresh-per-account.test.ts
+++ b/stores/__tests__/auth-store-refresh-per-account.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as browserNavigation from '@/lib/browser-navigation';
+import { useAuthStore } from '../auth-store';
+import { useAccountStore } from '../account-store';
+
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchInit = Parameters<typeof fetch>[1];
+
+const SERVER = 'https://mail.example.test';
+
+function account(id: string, slot: number, active: boolean) {
+  return {
+    id,
+    label: id,
+    serverUrl: SERVER,
+    username: `${id}@example.test`,
+    authMode: 'oauth' as const,
+    rememberMe: true,
+    displayName: id,
+    email: `${id}@example.test`,
+    lastLoginAt: Date.now(),
+    isConnected: false,
+    hasError: false,
+    isDefault: active,
+    cookieSlot: slot,
+    avatarColor: '#000',
+  };
+}
+
+function session(username: string) {
+  return {
+    username,
+    accounts: { acc: { name: username } },
+    primaryAccounts: { 'urn:ietf:params:jmap:mail': 'acc' },
+    apiUrl: `${SERVER}/jmap`,
+    downloadUrl: `${SERVER}/download`,
+    uploadUrl: `${SERVER}/upload`,
+    capabilities: {},
+  };
+}
+
+function jsonResponse(status: number, body: unknown) {
+  const res = {
+    ok: status >= 200 && status < 300,
+    status,
+    redirected: false,
+    url: '',
+    headers: { get: () => null },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    clone() { return res; },
+  };
+  return res;
+}
+
+/**
+ * Reproduction for the silent account drop (#refresh-race).
+ *
+ * Two OAuth accounts: A (active, slot 0) and B (background, slot 1). B's
+ * cached access token is already expired as far as the mail server is
+ * concerned, so B's first JMAP call gets a 401 and its client asks the store
+ * for a fresh token. The store must refresh SLOT 1 (B's refresh token) and
+ * hand B a token minted for B - not force-rotate the active account's
+ * refresh token and hand B the active account's token.
+ */
+describe('auth-store: token refresh is scoped to the account that needs it', () => {
+  const forcedRefreshSlots: number[] = [];
+  const deletedSessions: string[] = [];
+  let freshCounter = 0;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+    localStorage.clear();
+    forcedRefreshSlots.length = 0;
+    deletedSessions.length = 0;
+    freshCounter = 0;
+    window.history.pushState({}, '', '/en');
+    vi.spyOn(browserNavigation, 'replaceWindowLocation').mockImplementation(() => {});
+
+    useAccountStore.setState({
+      accounts: [account('A', 0, true), account('B', 1, false)],
+      activeAccountId: 'A',
+      defaultAccountId: 'A',
+    });
+    useAuthStore.setState({
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      serverUrl: SERVER,
+      username: 'A@example.test',
+      client: null,
+      authMode: 'oauth',
+      rememberMe: true,
+      accessToken: null,
+      tokenExpiresAt: null,
+      connectionLost: false,
+      activeAccountId: 'A',
+    });
+
+    const fetchMock = vi.fn(async (input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+
+      // Bulwark token route: plain PUT hands back the cached token for the
+      // slot; force=true mints a fresh one for that slot.
+      const m = url.match(/^\/api\/auth\/token\?slot=(\d+)(&force=true)?$/);
+      if (m && method === 'PUT') {
+        const slot = Number(m[1]);
+        const who = slot === 0 ? 'A' : 'B';
+        if (m[2]) {
+          forcedRefreshSlots.push(slot);
+          freshCounter += 1;
+          return jsonResponse(200, { access_token: `${who}-fresh-${freshCounter}`, expires_in: 3600 });
+        }
+        return jsonResponse(200, { access_token: `${who}-cached`, expires_in: 3600 });
+      }
+      if (url.startsWith('/api/auth/session') && method === 'DELETE') {
+        deletedSessions.push(url);
+        return jsonResponse(200, {});
+      }
+      if (url.startsWith('/api/auth/token') && method === 'DELETE') {
+        return jsonResponse(200, {});
+      }
+      if (url === '/api/auth/stalwart-context') {
+        return jsonResponse(200, { ok: true });
+      }
+
+      // Mail server: B's cached token is expired; everything else is accepted
+      // and answered with the session of the account the token belongs to.
+      if (url === `${SERVER}/.well-known/jmap`) {
+        const auth = headers.Authorization ?? '';
+        if (auth === 'Bearer B-cached') return jsonResponse(401, {});
+        const owner = auth.includes('Bearer A') ? 'A' : 'B';
+        return jsonResponse(200, session(`${owner}@example.test`));
+      }
+      // Anything else (display-name lookups etc.) is irrelevant here.
+      return jsonResponse(404, {});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    for (const client of useAuthStore.getState().getAllConnectedClients().values()) {
+      try { client.disconnect(); } catch { /* ignore */ }
+    }
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps a background account whose restore is rejected, marked instead of removed', async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    const original = fetchMock.getMockImplementation() as (input: FetchInput, init?: FetchInit) => Promise<unknown>;
+    fetchMock.mockImplementation(async (input: FetchInput, init?: FetchInit) => {
+      if (String(input) === '/api/auth/token?slot=1' && init?.method === 'PUT') {
+        return jsonResponse(401, { error: 'No refresh token' });
+      }
+      return original(input, init);
+    });
+
+    await useAuthStore.getState().checkAuth();
+    await vi.waitFor(() => {
+      expect(useAccountStore.getState().getAccountById('B')?.hasError).toBe(true);
+    });
+
+    const ids = useAccountStore.getState().accounts.map((a) => a.id).sort();
+    expect(ids).toEqual(['A', 'B']);
+    expect(useAccountStore.getState().getAccountById('B')?.isConnected).toBe(false);
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    expect(deletedSessions).toEqual([]);
+  });
+
+  it('refreshes the background account\'s own slot and keeps both accounts', async () => {
+    await useAuthStore.getState().checkAuth();
+
+    // Background restore of B runs fire-and-forget after A is up.
+    await vi.waitFor(() => {
+      expect(forcedRefreshSlots.length).toBeGreaterThan(0);
+    });
+    // Give the retry-after-refresh a moment to land.
+    await vi.waitFor(() => {
+      expect(useAuthStore.getState().getClientForAccount('B')).toBeDefined();
+    });
+
+    // The refresh B asked for must be spent on B's slot, never on A's.
+    expect(forcedRefreshSlots).toEqual([1]);
+
+    // B ends up holding a token minted for B, not A's.
+    const clientB = useAuthStore.getState().getClientForAccount('B')!;
+    expect(clientB.getAuthHeader()).toMatch(/^Bearer B-fresh-/);
+
+    // Nobody got evicted and the active session is untouched.
+    const ids = useAccountStore.getState().accounts.map((a) => a.id).sort();
+    expect(ids).toEqual(['A', 'B']);
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    expect(deletedSessions).toEqual([]);
+  });
+});

--- a/stores/auth-store.ts
+++ b/stores/auth-store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { JMAPClient, RateLimitError } from '@/lib/jmap/client';
+import { RequestTimeoutError, JMAPClient, RateLimitError } from '@/lib/jmap/client';
 import type { IJMAPClient } from '@/lib/jmap/client-interface';
 import { useIdentityStore } from './identity-store';
 import { setClientLookup } from './client-registry';
@@ -13,7 +13,7 @@ import { useAccountStore, type AccountEntry } from './account-store';
 import { fetchPrincipalDisplayName } from '@/lib/stalwart/principal';
 import { fetchConfig } from '@/hooks/use-config';
 import { debug } from '@/lib/debug';
-import { generateAccountId } from '@/lib/account-utils';
+import { generateAccountId, MAX_ACCOUNT_SLOTS } from '@/lib/account-utils';
 import { replaceWindowLocation, getPathPrefix, getLocaleFromPath, apiFetch } from '@/lib/browser-navigation';
 import { notifyParent } from '@/lib/iframe-bridge';
 import { snapshotAccount, restoreAccount, clearAllStores, evictAccount, evictAll } from '@/lib/account-state-manager';
@@ -56,7 +56,7 @@ interface AuthState {
    * reuse the token the server still holds for this slot - IdPs that gate
    * refresh tokens behind an `nbf` claim reject an early renewal outright.
    */
-  refreshAccessToken: (options?: { allowCached?: boolean }) => Promise<string | null>;
+  refreshAccessToken: (options?: { allowCached?: boolean; accountId?: string }) => Promise<string | null>;
   logout: () => Promise<void>;
   logoutAll: () => Promise<void>;
   removeAccount: (accountId: string) => void;
@@ -105,6 +105,7 @@ class TransientAuthError extends Error {
 // (401/400) may evict. Mirrors the rate-limit carve-out (#104).
 function isTransientAuthError(error: unknown): boolean {
   if (error instanceof TransientAuthError) return true;
+  if (error instanceof RequestTimeoutError) return true;
   // fetch() rejects with TypeError when the network is unreachable.
   if (error instanceof TypeError) return true;
   // JMAPClient.connect()/refreshSession() embed the HTTP status in the
@@ -441,36 +442,6 @@ function nextRefreshRetrySeconds(accountId?: string): number {
 
 function resetRefreshBackoff(accountId?: string): void {
   refreshFailureCounts.delete(accountId ?? '__global__');
-  permanentRefreshFailureCounts.delete(accountId ?? '__global__');
-}
-
-// /api/auth/token answers 503 for an upstream outage (retry forever - the IdP
-// may come back) but 500/502 for a Bulwark-side failure (misconfiguration,
-// broken token response). The latter does not heal by waiting, so after this
-// many consecutive answers the account is evicted and the user asked to sign
-// in again instead of retrying silently forever. (#972)
-const MAX_PERMANENT_REFRESH_FAILURES = 5;
-const permanentRefreshFailureCounts = new Map<string, number>();
-
-function isPermanentRefreshFailure(status: number): boolean {
-  return status === 500 || status === 502;
-}
-
-/** Records a 500/502 refresh answer; true once the consecutive cap is reached. */
-function recordPermanentRefreshFailure(status: number, accountId?: string): boolean {
-  if (!isPermanentRefreshFailure(status)) return false;
-  const key = accountId ?? '__global__';
-  const failures = (permanentRefreshFailureCounts.get(key) ?? 0) + 1;
-  permanentRefreshFailureCounts.set(key, failures);
-  if (failures < MAX_PERMANENT_REFRESH_FAILURES) return false;
-  permanentRefreshFailureCounts.delete(key);
-  return true;
-}
-
-function notifySignInAgain(): void {
-  void import('@/stores/toast-store').then(({ toast }) => {
-    toast.error('Your session could not be renewed', 'Sign in again to continue.');
-  }).catch(() => {});
 }
 
 // Only re-arm a failed refresh while someone is still signed in to that
@@ -480,6 +451,23 @@ function notifySignInAgain(): void {
 function shouldRetryRefresh(accountId?: string): boolean {
   if (accountId) return !!useAccountStore.getState().getAccountById(accountId);
   return useAuthStore.getState().isAuthenticated;
+}
+
+// Deliberately marks rather than removes the account: a silently vanishing
+// entry is indistinguishable from data loss to the user, whereas an entry in
+// error state can be signed in again from "+ Add Account".
+function markAccountExpired(accountId: string): void {
+  clearRefreshTimer(accountId);
+  const client = clients.get(accountId);
+  if (client) {
+    try { client.disconnect(); } catch { /* noop */ }
+    clients.delete(accountId);
+  }
+  useAccountStore.getState().updateAccount(accountId, {
+    isConnected: false,
+    hasError: true,
+    errorMessage: 'session_expired',
+  });
 }
 
 function scheduleRefresh(expiresIn: number, refreshFn: () => Promise<string | null>, accountId?: string): void {
@@ -718,7 +706,7 @@ export const useAuthStore = create<AuthState>()(
             }
 
             if (bearerToken) {
-              client = JMAPClient.withBearer(serverUrl, bearerToken, username, () => get().refreshAccessToken());
+              client = JMAPClient.withBearer(serverUrl, bearerToken, username, () => get().refreshAccessToken({ accountId }));
               await client.connect();
               oauthAccessToken = bearerToken;
               upgradedToOAuth = true;
@@ -839,7 +827,7 @@ export const useAuthStore = create<AuthState>()(
 
           // Schedule token refresh for TOTP-upgraded sessions
           if (upgradedToOAuth && oauthExpiresIn > 0) {
-            scheduleRefresh(oauthExpiresIn, get().refreshAccessToken, accountId);
+            scheduleRefresh(oauthExpiresIn, () => get().refreshAccessToken({ accountId }), accountId);
           }
 
           // Sync settings from server (only if enabled)
@@ -947,7 +935,7 @@ export const useAuthStore = create<AuthState>()(
             ? sessionStorage.getItem('oauth_cookie_slot')
             : null;
           const pendingSlot = rawSlot !== null ? parseInt(rawSlot, 10) : NaN;
-          const slot = !isNaN(pendingSlot) && pendingSlot >= 0 && pendingSlot <= 4
+          const slot = !isNaN(pendingSlot) && pendingSlot >= 0 && pendingSlot < MAX_ACCOUNT_SLOTS
             ? pendingSlot
             : accountStore.getNextCookieSlot();
 
@@ -969,8 +957,11 @@ export const useAuthStore = create<AuthState>()(
 
           const { access_token, expires_in } = await tokenRes.json();
 
-          const refreshFn = get().refreshAccessToken;
-          const client = JMAPClient.withBearer(serverUrl, access_token, '', () => refreshFn());
+          // The account id is derived from the session, so it cannot be bound
+          // before connect(); the hook reads it lazily and no refresh can be
+          // needed before the assignment below.
+          let boundAccountId: string | undefined;
+          const client = JMAPClient.withBearer(serverUrl, access_token, '', () => get().refreshAccessToken({ accountId: boundAccountId }));
           await client.connect();
 
           const jmapUsername = client.getUsername();
@@ -983,6 +974,7 @@ export const useAuthStore = create<AuthState>()(
 
           // Register in account store
           const accountId = generateAccountId(username, serverUrl);
+          boundAccountId = accountId;
 
           // Snapshot current account if switching away and clear stores so
           // the new account starts with a clean email/contact/calendar state.
@@ -1042,7 +1034,7 @@ export const useAuthStore = create<AuthState>()(
             });
           }).catch(() => {});
 
-          scheduleRefresh(expires_in, get().refreshAccessToken, accountId);
+          scheduleRefresh(expires_in, () => get().refreshAccessToken({ accountId }), accountId);
 
           notifyParent('sso:auth-success', { username });
 
@@ -1114,8 +1106,8 @@ export const useAuthStore = create<AuthState>()(
             throw new Error('Server URL not configured');
           }
 
-          const refreshFn = get().refreshAccessToken;
-          const client = JMAPClient.withBearer(ssoServerUrl, access_token, '', () => refreshFn());
+          let boundAccountId: string | undefined;
+          const client = JMAPClient.withBearer(ssoServerUrl, access_token, '', () => get().refreshAccessToken({ accountId: boundAccountId }));
           await client.connect();
 
           const jmapUsername = client.getUsername();
@@ -1127,6 +1119,7 @@ export const useAuthStore = create<AuthState>()(
           initializeFeatureStores(client);
 
           const accountId = generateAccountId(username, ssoServerUrl);
+          boundAccountId = accountId;
 
           const prevAccountId = get().activeAccountId;
           if (prevAccountId && prevAccountId !== accountId) {
@@ -1182,7 +1175,7 @@ export const useAuthStore = create<AuthState>()(
             });
           }).catch(() => {});
 
-          scheduleRefresh(expires_in, get().refreshAccessToken, accountId);
+          scheduleRefresh(expires_in, () => get().refreshAccessToken({ accountId }), accountId);
 
           notifyParent('sso:auth-success', { username });
 
@@ -1212,15 +1205,22 @@ export const useAuthStore = create<AuthState>()(
       },
 
       refreshAccessToken: async (options) => {
-        if (refreshPromise) return refreshPromise;
-
-        const accountId = get().activeAccountId;
-        if (accountId && refreshPromises.has(accountId)) {
-          return refreshPromises.get(accountId)!;
+        // Falling back to the active account is only correct for the legacy
+        // single-account path. Every multi-account client passes its own id:
+        // refreshing the active account on a background client's behalf
+        // rotates the wrong refresh token and hands that client the wrong
+        // identity.
+        const accountId = options?.accountId ?? get().activeAccountId;
+        if (accountId) {
+          const inFlight = refreshPromises.get(accountId);
+          if (inFlight) return inFlight;
+        } else if (refreshPromise) {
+          return refreshPromise;
         }
 
         const account = accountId ? useAccountStore.getState().getAccountById(accountId) : null;
         const slot = account?.cookieSlot ?? 0;
+        const isActive = !accountId || get().activeAccountId === accountId;
 
         const promise = (async () => {
           try {
@@ -1238,33 +1238,27 @@ export const useAuthStore = create<AuthState>()(
               // maintenance windows and offline spells.
               if (res.status === 401) {
                 resetRefreshBackoff(accountId ?? undefined);
+                if (!isActive && accountId) {
+                  markAccountExpired(accountId);
+                  return null;
+                }
                 notifyParent('sso:session-expired');
                 markSessionExpired();
                 get().logout();
                 return null;
               }
-              // A Bulwark-side failure (500/502) that keeps repeating will not
-              // heal by waiting: stop retrying and ask for a fresh sign-in. (#972)
-              if (recordPermanentRefreshFailure(res.status, accountId ?? undefined)) {
-                debug.error(`Token refresh failed permanently (${res.status}) ${MAX_PERMANENT_REFRESH_FAILURES} times - signing out`);
-                resetRefreshBackoff(accountId ?? undefined);
-                notifySignInAgain();
-                notifyParent('sso:session-expired');
-                markSessionExpired();
-                if (accountId) get().removeAccount(accountId); else get().logout();
-                return null;
-              }
               if (shouldRetryRefresh(accountId ?? undefined)) {
                 const retryIn = nextRefreshRetrySeconds(accountId ?? undefined);
                 debug.error(`Token refresh unavailable (${res.status}), retrying with backoff`);
-                scheduleRefresh(retryIn, get().refreshAccessToken, accountId ?? undefined);
+                scheduleRefresh(retryIn, () => get().refreshAccessToken({ accountId: accountId ?? undefined }), accountId ?? undefined);
               }
               return null;
             }
 
             const { access_token, expires_in } = await res.json();
 
-            get().client?.updateAccessToken(access_token);
+            const owner = (accountId ? clients.get(accountId) : undefined) ?? (isActive ? get().client : null);
+            owner?.updateAccessToken(access_token);
 
             if (account) {
               await syncStalwartAuthContext(
@@ -1275,30 +1269,32 @@ export const useAuthStore = create<AuthState>()(
               );
             }
 
-            set({
-              accessToken: access_token,
-              tokenExpiresAt: Date.now() + expires_in * 1000,
-            });
+            if (isActive) {
+              set({
+                accessToken: access_token,
+                tokenExpiresAt: Date.now() + expires_in * 1000,
+              });
+            }
 
             resetRefreshBackoff(accountId ?? undefined);
-            scheduleRefresh(expires_in, get().refreshAccessToken, accountId ?? undefined);
+            scheduleRefresh(expires_in, () => get().refreshAccessToken({ accountId: accountId ?? undefined }), accountId ?? undefined);
             return access_token;
           } catch (error) {
             // Network failure (offline, Wi-Fi switch, server unreachable) -
             // not a rejection. Keep the session and retry with backoff.
             debug.error('Token refresh failed, retrying with backoff:', error);
             if (shouldRetryRefresh(accountId ?? undefined)) {
-              scheduleRefresh(nextRefreshRetrySeconds(accountId ?? undefined), get().refreshAccessToken, accountId ?? undefined);
+              scheduleRefresh(nextRefreshRetrySeconds(accountId ?? undefined), () => get().refreshAccessToken({ accountId: accountId ?? undefined }), accountId ?? undefined);
             }
             return null;
           } finally {
-            refreshPromise = null;
             if (accountId) refreshPromises.delete(accountId);
+            else refreshPromise = null;
           }
         })();
 
-        refreshPromise = promise;
         if (accountId) refreshPromises.set(accountId, promise);
+        else refreshPromise = promise;
 
         return promise;
       },
@@ -1386,8 +1382,6 @@ export const useAuthStore = create<AuthState>()(
             // Client not in memory - clear everything and redirect.
             // Trying to async-restore during logout caused the original bug.
             debug.error(`Cannot restore next account ${nextAccount.id}, performing full logout`);
-            evictAccount(nextAccount.id);
-            accountStore.removeAccount(nextAccount.id);
             performFullLogout(set);
           }
 
@@ -1517,12 +1511,11 @@ export const useAuthStore = create<AuthState>()(
               const res = await apiFetch(`/api/auth/token?slot=${targetAccount.cookieSlot}`, { method: 'PUT' });
               if (res.ok) {
                 const { access_token, expires_in } = await res.json();
-                const refreshFn = get().refreshAccessToken;
-                targetClient = JMAPClient.withBearer(targetAccount.serverUrl, access_token, targetAccount.username, () => refreshFn());
+                targetClient = JMAPClient.withBearer(targetAccount.serverUrl, access_token, targetAccount.username, () => get().refreshAccessToken({ accountId }));
                 bindClientStatusHandlers(targetClient, set, get, accountId);
                 await targetClient.connect();
                 clients.set(accountId, targetClient);
-                scheduleRefresh(expires_in, get().refreshAccessToken, accountId);
+                scheduleRefresh(expires_in, () => get().refreshAccessToken({ accountId }), accountId);
                 await syncStalwartAuthContext(
                   targetAccount.serverUrl,
                   targetAccount.username,
@@ -1577,10 +1570,7 @@ export const useAuthStore = create<AuthState>()(
             return;
           }
 
-          // Cannot restore - remove the stale account and redirect to login
-          evictAccount(accountId);
-          accountStore.removeAccount(accountId);
-          apiFetch(`/api/auth/session?slot=${targetAccount.cookieSlot}`, { method: 'DELETE' }).catch(() => {});
+          markAccountExpired(accountId);
 
           // Restore the previous account if still available
           if (state.activeAccountId && state.activeAccountId !== accountId) {
@@ -1783,22 +1773,18 @@ export const useAuthStore = create<AuthState>()(
                 const res = await apiFetch(`/api/auth/token?slot=${account.cookieSlot}`, { method: 'PUT' });
                 if (res.ok) {
                   const { access_token, expires_in } = await res.json();
-                  const refreshFn = get().refreshAccessToken;
-                  const client = JMAPClient.withBearer(account.serverUrl, access_token, account.username, () => refreshFn());
+                  const client = JMAPClient.withBearer(account.serverUrl, access_token, account.username, () => get().refreshAccessToken({ accountId: account.id }));
                   bindClientStatusHandlers(client, set, get, account.id);
                   const contextSync = syncStalwartAuthContext(account.serverUrl, account.username, client.getAuthHeader(), account.cookieSlot);
                   await client.connect();
                   clients.set(account.id, client);
-                  scheduleRefresh(expires_in, get().refreshAccessToken, account.id);
+                  scheduleRefresh(expires_in, () => get().refreshAccessToken({ accountId: account.id }), account.id);
                   await contextSync;
                   accountStore.updateAccount(account.id, { isConnected: true, hasError: false });
                   void syncAccountDisplayName(account.id, client);
-                } else if (res.status >= 500 && !recordPermanentRefreshFailure(res.status, account.id)) {
+                } else if (res.status >= 500) {
                   throw new TransientAuthError('Token refresh failed', res.status);
                 } else {
-                  // Repeated 500/502 (see recordPermanentRefreshFailure) falls
-                  // through here and evicts the account like a rejection. (#972)
-                  if (res.status >= 500) notifySignInAgain();
                   throw new Error(`Token refresh failed: ${res.status}`);
                 }
               } else {
@@ -1841,11 +1827,7 @@ export const useAuthStore = create<AuthState>()(
                 });
                 return;
               }
-              // Remove unrestorable accounts so the user is prompted to log in
-              // again rather than seeing a stale error entry forever.
-              evictAccount(account.id);
-              accountStore.removeAccount(account.id);
-              apiFetch(`/api/auth/session?slot=${account.cookieSlot}`, { method: 'DELETE' }).catch(() => {});
+              markAccountExpired(account.id);
             }
           };
 
@@ -1986,11 +1968,10 @@ export const useAuthStore = create<AuthState>()(
               // token if it is still valid rather than spending a refresh.
               const token = await get().refreshAccessToken({ allowCached: true });
               if (token && state.serverUrl) {
-                const refreshFn = get().refreshAccessToken;
-                const client = JMAPClient.withBearer(state.serverUrl, token, state.username || '', () => refreshFn());
+                const accountId = generateAccountId(state.username || '', state.serverUrl);
+                const client = JMAPClient.withBearer(state.serverUrl, token, state.username || '', () => get().refreshAccessToken({ accountId }));
                 await client.connect();
 
-                const accountId = generateAccountId(state.username || '', state.serverUrl);
                 clients.set(accountId, client);
                 bindClientStatusHandlers(client, set, get, accountId);
 


### PR DESCRIPTION
## Summary

<!-- A brief, one-paragraph description of what this PR does and why. -->

Several recoverable authentication errors, such as network outages, resulted in accounts being silently purged from the account list. Additionally, some bugs resulted in background accounts being purged after mistakenly being handed a new token for the active account. A race condition similarly resulted in an unnecessary account purge when a token got rotated while a request with the old token was still in flight. Overall, this lead to unpredictable but frequent logouts. With this PR, silent account purges without a re-authentication prompt or an error message should be ruled out.

## Changes

<!-- A bulleted list of the key changes made. -->

- Refresh requests now carry the account slot for which they're meant, so that they don't get handed a refresh token for a wrong account.
- Fixes a bug in the SSO account cap that resulted in slots getting squashed when more than 6 accounts authenticated via SSO.
- Addressed a potential race condition where an in-flight request with an outdated token got rejected after a recent token refresh; the client interpreted the rejection as an authentication failure and purged the account.

## Related issues

<!-- Link related issues using "Closes #123", "Fixes #123", or "Related to #123". -->

Fixes #989

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] Chore / dependency update / CI change

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/bulwarkmail/.github/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors
- [x] The build passes (`npm run build`)
- [x] I have tested my changes locally
- [ ] I have added or updated documentation if needed
- [ ] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes

## Screenshots / demo

<!-- For UI changes, add before/after screenshots or a screen recording. -->

## Notes for reviewers

<!-- Anything specific you'd like reviewers to focus on or be aware of. -->

Whilst I _think_ this is a non-breaking change and ran my personal Bulwark instance for two days with the changes in effect with no issues, this is my first time messing with OAuth flows ona production repository. I.e., I cannot rule out this changes Bulwark's behaviour in ways that would turn it into a breaking change.