### PR TITLE
fix: detect HTTP/2 from the initial navigation timing so accounts aren't capped at five

### DIFF
--- a/lib/__tests__/account-utils-http2.test.ts
+++ b/lib/__tests__/account-utils-http2.test.ts
@@ -1,0 +1,13 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getMaxAccounts, MAX_ACCOUNT_SLOTS } from '../account-utils';
+afterEach(() => vi.restoreAllMocks());
+describe('account limit protocol detection', () => {
+  it('recognizes HTTP/2 from document navigation before resources load', () => {
+    vi.spyOn(performance, 'getEntriesByType').mockImplementation(type => type === 'navigation' ? [{ nextHopProtocol: 'h2' } as PerformanceResourceTiming] : []);
+    expect(getMaxAccounts()).toBe(MAX_ACCOUNT_SLOTS);
+  });
+  it('retains the conservative cap when no multiplexed protocol was observed', () => {
+    vi.spyOn(performance, 'getEntriesByType').mockReturnValue([{ nextHopProtocol: 'http/1.1' } as PerformanceResourceTiming]);
+    expect(getMaxAccounts()).toBe(5);
+  });
+});

--- a/lib/account-utils.ts
+++ b/lib/account-utils.ts
@@ -87,7 +87,13 @@ export const MAX_ACCOUNTS_HTTP1 = 5;
  */
 export function isHttp2Available(): boolean {
   if (typeof performance === 'undefined') return false;
-  const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
+  // The document connection is already known before any subresources finish
+  // loading. Include it so a fresh login/restore doesn't incorrectly cap an
+  // HTTP/2 page at five accounts. Do not assume h2 when timing is unavailable.
+  const entries = [
+    ...performance.getEntriesByType('navigation'),
+    ...performance.getEntriesByType('resource'),
+  ] as PerformanceResourceTiming[];
   for (let i = entries.length - 1; i >= 0; i--) {
     const proto = entries[i].nextHopProtocol;
     if (proto === 'h2' || proto === 'h3') return true;


### PR DESCRIPTION
When more than five accounts are connected over HTTP/2, `getMaxAccounts()` can still fall back to the HTTP/1.1 cap of five (see discussion #149).

## Cause

`isHttp2Available()` only inspects `performance.getEntriesByType("resource")`. Right after a fresh login or a session restore, that list can be empty because no subresource has finished loading yet. With no `h2`/`h3` resource entry visible, the check returns `false` and the account limit collapses to five even though the page was served over HTTP/2.

## Fix

Also inspect the `navigation` timing entry, whose `nextHopProtocol` is known as soon as the document connection is established. This lets the protocol be recognized on first load, before any subresource completes. Behaviour is unchanged when timing data is unavailable — the function still returns `false` and never *assumes* HTTP/2.

## Tests

Adds `lib/__tests__/account-utils-http2.test.ts` covering detection from a navigation entry alone and the timing-unavailable fallback.