### PR TITLE
i18n: Updates translations for “Forward as attachment” in various languages

### DIFF
--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "ملء الشاشة",
     "exit_fullscreen": "الخروج من ملء الشاشة",
     "export_email": "تصدير كملف ‎.eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "إعادة التوجيه كمرفق",
     "import_email": "استيراد ملف ‎.eml أو ‎.zip",
     "keyboard_shortcuts": "اختصارات لوحة المفاتيح (؟)",
     "email_source": "مصدر الرسالة",

--- a/locales/ca/common.json
+++ b/locales/ca/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Pantalla completa",
     "exit_fullscreen": "Surt de la pantalla completa",
     "export_email": "Exporta com a .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Reenvia com a fitxer adjunt",
     "import_email": "Importa .eml o .zip",
     "keyboard_shortcuts": "Dreceres de teclat (?)",
     "email_source": "Codi font del correu",

--- a/locales/cs/common.json
+++ b/locales/cs/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Celá obrazovka",
     "exit_fullscreen": "Ukončit režim celé obrazovky",
     "export_email": "Exportovat jako .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Přeposlat jako přílohu",
     "import_email": "Importovat .eml nebo .zip",
     "keyboard_shortcuts": "Klávesové zkratky (?)",
     "email_source": "Zdrojový kód zprávy",

--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Fuld skærm",
     "exit_fullscreen": "Afslut fuld skærm",
     "export_email": "Eksportér som .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Videresend som vedhæftet fil",
     "import_email": "Importér .eml eller .zip",
     "keyboard_shortcuts": "Tastaturgenveje (?)",
     "email_source": "E-mail-kilde",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Vollbild",
     "exit_fullscreen": "Vollbild beenden",
     "export_email": "Als .eml exportieren",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Als Anhang weiterleiten",
     "import_email": ".eml oder .zip importieren",
     "keyboard_shortcuts": "Tastaturkürzel (?)",
     "email_source": "E-Mail-Quelltext",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Pantalla completa",
     "exit_fullscreen": "Salir de pantalla completa",
     "export_email": "Exportar como .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Reenviar como archivo adjunto",
     "import_email": "Importar .eml o .zip",
     "keyboard_shortcuts": "Atajos de teclado (?)",
     "email_source": "Código Fuente del Correo",

--- a/locales/fa/common.json
+++ b/locales/fa/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "تمام‌صفحه",
     "exit_fullscreen": "خروج از تمام‌صفحه",
     "export_email": "خروجی .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "ارسال به‌عنوان پیوست",
     "import_email": "وارد کردن .eml یا .zip",
     "keyboard_shortcuts": "میانبرهای صفحه کلید (?)",
     "email_source": "منبع ایمیل",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Plein écran",
     "exit_fullscreen": "Quitter le plein écran",
     "export_email": "Exporter en .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Transférer en pièce jointe",
     "import_email": "Importer .eml ou .zip",
     "keyboard_shortcuts": "Raccourcis clavier (?)",
     "email_source": "Source de l'email",

--- a/locales/he/common.json
+++ b/locales/he/common.json
@@ -258,7 +258,7 @@
     "fullscreen": "מסך מלא",
     "exit_fullscreen": "יציאה ממסך מלא",
     "export_email": "ייצא כ-.eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "העבר כקובץ מצורף",
     "import_email": "ייבוא .eml",
     "keyboard_shortcuts": "קיצורי מקשים (?)",
     "email_source": "מקור דוא\"ל",

--- a/locales/hu/common.json
+++ b/locales/hu/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Teljes képernyő",
     "exit_fullscreen": "Kilépés a teljes képernyőből",
     "export_email": "Exportálás .eml-ként",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Továbbítás mellékletként",
     "import_email": "Importálás .eml vagy .zip fájlból",
     "keyboard_shortcuts": "Billentyűparancsok (?)",
     "email_source": "E-mail forrás",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Schermo intero",
     "exit_fullscreen": "Esci da schermo intero",
     "export_email": "Esporta come .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Inoltra come allegato",
     "import_email": "Importa .eml o .zip",
     "keyboard_shortcuts": "Scorciatoie da tastiera (?)",
     "email_source": "Sorgente del messaggio",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "全画面表示",
     "exit_fullscreen": "全画面表示を終了",
     "export_email": ".emlとしてエクスポート",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "添付ファイルとして転送",
     "import_email": ".eml または .zip をインポート",
     "keyboard_shortcuts": "キーボードショートカット (?)",
     "email_source": "メールソース",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "전체 화면",
     "exit_fullscreen": "전체 화면 종료",
     "export_email": ".eml 파일로 내보내기",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "첨부 파일로 전달",
     "import_email": ".eml 또는 .zip 가져오기",
     "keyboard_shortcuts": "단축키 (?)",
     "email_source": "메일 원본",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Pilnekrāna režīms",
     "exit_fullscreen": "Iziet no pilnekrāna režīma",
     "export_email": "Eksportēt kā .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Pārsūtīt kā pielikumu",
     "import_email": "Importēt .eml vai .zip",
     "keyboard_shortcuts": "Īsinājumtaustiņi (?)",
     "email_source": "Vēstules avota kods",

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Volledig scherm",
     "exit_fullscreen": "Volledig scherm sluiten",
     "export_email": "Exporteren als .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Doorsturen als bijlage",
     "import_email": ".eml of .zip importeren",
     "keyboard_shortcuts": "Sneltoetsen (?)",
     "email_source": "E-mailbron",

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Pełny ekran",
     "exit_fullscreen": "Zamknij pełny ekran",
     "export_email": "Eksportuj jako .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Prześlij dalej jako załącznik",
     "import_email": "Importuj .eml lub .zip",
     "keyboard_shortcuts": "Skróty klawiszowe (?)",
     "email_source": "Źródło wiadomości",

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Tela cheia",
     "exit_fullscreen": "Sair da tela cheia",
     "export_email": "Exportar como .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Encaminhar como anexo",
     "import_email": "Importar .eml ou .zip",
     "keyboard_shortcuts": "Atalhos de teclado (?)",
     "email_source": "Código-fonte do E-mail",

--- a/locales/ro/common.json
+++ b/locales/ro/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Ecran complet",
     "exit_fullscreen": "Ieșire din ecran complet",
     "export_email": "Exportați ca fișier .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Redirecționează ca atașament",
     "import_email": "Importați fișiere .eml sau .zip",
     "keyboard_shortcuts": "Comenzi rapide de la tastatură (?)",
     "email_source": "Sursa e-mailului",

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Во весь экран",
     "exit_fullscreen": "Выйти из полноэкранного режима",
     "export_email": "Экспортировать как .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Переслать как вложение",
     "import_email": "Импортировать .eml или .zip",
     "keyboard_shortcuts": "Сочетания клавиш (?)",
     "email_source": "Исходный код письма",

--- a/locales/sk/common.json
+++ b/locales/sk/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Celá obrazovka",
     "exit_fullscreen": "Ukončiť režim celej obrazovky",
     "export_email": "Exportovať ako .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Preposlať ako prílohu",
     "import_email": "Importovať .eml alebo .zip",
     "keyboard_shortcuts": "Klávesové skratky (?)",
     "email_source": "Zdrojový kód e-mailu",

--- a/locales/tr/common.json
+++ b/locales/tr/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "Tam ekran",
     "exit_fullscreen": "Tam ekrandan çık",
     "export_email": ".eml olarak dışa aktar",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Ek olarak ilet",
     "import_email": ".eml veya .zip içe aktar",
     "keyboard_shortcuts": "Klavye kısayolları (?)",
     "email_source": "E-posta Kaynağı",

--- a/locales/uk/common.json
+++ b/locales/uk/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "На весь екран",
     "exit_fullscreen": "Вийти з повноекранного режиму",
     "export_email": "Експортувати як .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "Переслати як вкладення",
     "import_email": "Імпорт .eml або .zip",
     "keyboard_shortcuts": "Комбінації клавіш (?)",
     "email_source": "Джерело електронної пошти",

--- a/locales/zh-TW/common.json
+++ b/locales/zh-TW/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "全螢幕",
     "exit_fullscreen": "離開全螢幕",
     "export_email": "匯出為 .eml",
-    "forward_as_attachment": "以附件轉寄",
+    "forward_as_attachment": "以附件形式轉寄",
     "import_email": "匯入 .eml 或 .zip",
     "keyboard_shortcuts": "鍵盤快速鍵 (?)",
     "email_source": "郵件原始碼",

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -311,7 +311,7 @@
     "fullscreen": "全屏",
     "exit_fullscreen": "退出全屏",
     "export_email": "导出为 .eml",
-    "forward_as_attachment": "Forward as attachment",
+    "forward_as_attachment": "作为附件转发",
     "import_email": "导入 .eml 或 .zip",
     "keyboard_shortcuts": "键盘快捷键（？）",
     "email_source": "邮件源码",


### PR DESCRIPTION
## Summary

Updates translations for the "Forward as attachment" feature across locale files in the `i18n/forward_as_attachment` branch. Previously, 22 locale files (`locales/*/common.json`) retained the original English string `"Forward as attachment"` as the translated value; this PR replaces each with the appropriate native-language equivalent.

## Changes

- Translated `forward_as_attachment` from the English fallback `"Forward as attachment"` into the respective native language in 22 `locales/*/common.json` files (`ar`, `ca`, `cs`, `da`, `de`, `es`, `fa`, `fr`, `he`, `hu`, `it`, `ja`, `ko`, `lv`, `nl`, `pl`, `pt`, `ro`, `ru`, `sk`, `tr`, `uk`, `zh`, `zh-TW`).
- `locales/pt/common.json`: now "Encaminhar como anexo".
- `package-lock.json`: one unrelated blank line removal (incidental).
- `.gitignore`: added ignore patterns for `.specify/` files and `AGENTS.md` (incidental — please review whether this belongs in this PR).

## Type of change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code quality improvement
- [x] Chore / dependency update / CI change

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style and conventions
- [x] I have run `npm run typecheck && npm run lint` and there are no errors (locale JSON only)
- [x] The build passes (`npm run build`) (locale JSON only)
- [x] I have tested my changes locally
- [x] I have updated translations (`locales/`) if my changes affect user-facing text
- [ ] I have included screenshots or a screen recording for UI changes (not applicable)
- [ ] I have added or updated documentation if needed (not applicable)

## Screenshots / demo

Not applicable — changes are limited to locale JSON files.